### PR TITLE
fix: Collider::reverse_indices default now false

### DIFF
--- a/crates/build/src/pipelines/models/mod.rs
+++ b/crates/build/src/pipelines/models/mod.rs
@@ -137,7 +137,7 @@ pub enum Collider {
     FromModel {
         #[serde(default)]
         flip_normals: bool,
-        #[serde(default = "true_value")]
+        #[serde(default)]
         reverse_indices: bool,
     },
     Character {


### PR DESCRIPTION
I don't believe indices need reversed at all. In my testing this has detrimental effects to every object tested; so I'm changing the default to false.

@FredrikNoren I think flip_normals ends up having the same effect as this, and in addition to that, both are probably not needed from my testing so we may want to drop them (it seems our winding order matches PhysX; your original issue with more details on this issue is long gone so I'm basing this on my observations with ~12 different objects).