### PR TITLE
Bumping wgpu from 0.14.2 to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
  "thread-priority",
  "tokio",
  "tracing",
- "wgpu 0.14.2",
+ "wgpu",
  "winit",
 ]
 
@@ -359,7 +359,7 @@ dependencies = [
  "profiling 1.0.7 (git+https://github.com/philpax/profiling.git)",
  "serde",
  "tokio",
- "wgpu 0.14.2",
+ "wgpu",
  "winit",
  "yaml-rust-davvid",
 ]
@@ -390,7 +390,7 @@ dependencies = [
  "ambient_ui",
  "glam 0.22.0",
  "log",
- "wgpu 0.14.2",
+ "wgpu",
  "winit",
 ]
 
@@ -517,7 +517,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "wgpu 0.14.2",
+ "wgpu",
  "which",
  "winit",
 ]
@@ -587,7 +587,7 @@ dependencies = [
  "once_cell",
  "profiling 1.0.7 (git+https://github.com/philpax/profiling.git)",
  "serde",
- "wgpu 0.14.2",
+ "wgpu",
 ]
 
 [[package]]
@@ -610,8 +610,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "wgpu 0.14.2",
- "wgpu 0.15.1",
+ "wgpu",
  "winit",
 ]
 
@@ -682,7 +681,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wgpu 0.14.2",
+ "wgpu",
 ]
 
 [[package]]
@@ -754,7 +753,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "wgpu 0.14.2",
+ "wgpu",
 ]
 
 [[package]]
@@ -793,7 +792,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "wgpu 0.14.2",
+ "wgpu",
  "winit",
 ]
 
@@ -909,7 +908,7 @@ dependencies = [
  "profiling 1.0.7 (git+https://github.com/philpax/profiling.git)",
  "serde",
  "smallvec",
- "wgpu 0.14.2",
+ "wgpu",
  "winit",
 ]
 
@@ -955,7 +954,7 @@ dependencies = [
  "ordered-float",
  "tokio",
  "tracing",
- "wgpu 0.14.2",
+ "wgpu",
 ]
 
 [[package]]
@@ -995,7 +994,7 @@ dependencies = [
  "toml 0.7.2",
  "tracing",
  "url",
- "wgpu 0.14.2",
+ "wgpu",
  "yaml-rust-davvid",
 ]
 
@@ -1061,7 +1060,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "wgpu 0.14.2",
+ "wgpu",
 ]
 
 [[package]]
@@ -1101,7 +1100,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "wgpu 0.14.2",
+ "wgpu",
  "winit",
 ]
 
@@ -1160,7 +1159,7 @@ dependencies = [
  "ambient_renderer",
  "ambient_std",
  "glam 0.22.0",
- "wgpu 0.14.2",
+ "wgpu",
 ]
 
 [[package]]
@@ -1178,7 +1177,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu 0.14.2",
+ "wgpu",
 ]
 
 [[package]]
@@ -2292,17 +2291,6 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827914e1f53b1e0e025ecd3d967a7836b7bcb54520f90e21ef8df7b4d88a2759"
-dependencies = [
- "bitflags",
- "libloading",
- "winapi",
-]
-
-[[package]]
-name = "d3d12"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
@@ -3160,18 +3148,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "glow"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bd5877156a19b8ac83a29b2306fe20537429d318f3ff0a1a2119f8d9c61919"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
  "web-sys",
 ]
 
@@ -4157,26 +4133,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "naga"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262d2840e72dbe250e8cf2f522d080988dfca624c4112c096238a4845f591707"
-dependencies = [
- "bit-set",
- "bitflags",
- "codespan-reporting",
- "hexf-parse",
- "indexmap",
- "log",
- "num-traits",
- "rustc-hash",
- "spirv",
- "termcolor",
- "thiserror",
- "unicode-xid",
 ]
 
 [[package]]
@@ -7192,28 +7148,6 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "wgpu"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f643110d228fd62a60c5ed2ab56c4d5b3704520bd50561174ec4ec74932937"
-dependencies = [
- "arrayvec",
- "js-sys",
- "log",
- "naga 0.10.0",
- "parking_lot",
- "raw-window-handle",
- "smallvec",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core 0.14.2",
- "wgpu-hal 0.14.1",
- "wgpu-types 0.14.1",
-]
-
-[[package]]
-name = "wgpu"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d745a1b6d91d85c33defbb29f0eee0450e1d2614d987e14bf6baf26009d132d7"
@@ -7222,7 +7156,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "log",
- "naga 0.11.0",
+ "naga",
  "parking_lot",
  "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-window-handle",
@@ -7231,33 +7165,9 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core 0.15.1",
- "wgpu-hal 0.15.2",
- "wgpu-types 0.15.1",
-]
-
-[[package]]
-name = "wgpu-core"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6000d1284ef8eec6076fd5544a73125fd7eb9b635f18dceeb829d826f41724ca"
-dependencies = [
- "arrayvec",
- "bit-vec",
- "bitflags",
- "cfg_aliases",
- "codespan-reporting",
- "fxhash",
- "log",
- "naga 0.10.0",
- "parking_lot",
- "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "raw-window-handle",
- "smallvec",
- "thiserror",
- "web-sys",
- "wgpu-hal 0.14.1",
- "wgpu-types 0.14.1",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -7272,54 +7182,15 @@ dependencies = [
  "codespan-reporting",
  "fxhash",
  "log",
- "naga 0.11.0",
+ "naga",
  "parking_lot",
  "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-window-handle",
  "smallvec",
  "thiserror",
  "web-sys",
- "wgpu-hal 0.15.2",
- "wgpu-types 0.15.1",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc320a61acb26be4f549c9b1b53405c10a223fbfea363ec39474c32c348d12f"
-dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash",
- "bit-set",
- "bitflags",
- "block",
- "core-graphics-types",
- "d3d12 0.5.0",
- "foreign-types",
- "fxhash",
- "glow 0.11.2",
- "gpu-alloc",
- "gpu-descriptor",
- "js-sys",
- "khronos-egl",
- "libloading",
- "log",
- "metal",
- "naga 0.10.0",
- "objc",
- "parking_lot",
- "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "range-alloc",
- "raw-window-handle",
- "renderdoc-sys",
- "smallvec",
- "thiserror",
- "wasm-bindgen",
- "web-sys",
- "wgpu-types 0.14.1",
- "winapi",
+ "wgpu-hal",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -7335,10 +7206,10 @@ dependencies = [
  "bitflags",
  "block",
  "core-graphics-types",
- "d3d12 0.6.0",
+ "d3d12",
  "foreign-types",
  "fxhash",
- "glow 0.12.1",
+ "glow",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
@@ -7349,7 +7220,7 @@ dependencies = [
  "libloading",
  "log",
  "metal",
- "naga 0.11.0",
+ "naga",
  "objc",
  "parking_lot",
  "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7360,17 +7231,8 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types 0.15.1",
+ "wgpu-types",
  "winapi",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6b28ef22cac17b9109b25b3bf8c9a103eeb293d7c5f78653979b09140375f6"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ profiling = { git = "https://github.com/philpax/profiling.git", features = [
     "profile-with-puffin",
 ] }
 tracing = "0.1.35"
-wgpu = "0.14.2"
+wgpu = "0.15.1"
 winit = { version = "0.28.1", features = ["serde"] }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 tokio = { version = "1.20", features = ["parking_lot"] }

--- a/crates/app/src/renderers.rs
+++ b/crates/app/src/renderers.rs
@@ -214,6 +214,7 @@ impl UIRender {
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Rgba8Snorm,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[wgpu::TextureFormat::Rgba8Snorm],
             },
         ));
 
@@ -243,6 +244,7 @@ impl UIRender {
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Depth32Float,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_SRC,
+                view_formats: &[wgpu::TextureFormat::Depth32Float],
             },
         )
     }

--- a/crates/gizmos/src/gizmos.wgsl
+++ b/crates/gizmos/src/gizmos.wgsl
@@ -30,12 +30,12 @@ struct VertexOutput {
 @vertex
 fn vs_main(@builtin(instance_index) instance_index: u32,
 @builtin(vertex_index) vertex_index: u32) -> VertexOutput {
-  let pos = get_raw_mesh_position(vertex_index);
+  let mesh_pos = get_raw_mesh_position(vertex_index);
   let uv = get_raw_mesh_uv(vertex_index);
 
   let gizmo = gizmo_buffer.gizmos[instance_index];
 
-  let pos = gizmo.model_matrix * vec4<f32>(pos, 1.);
+  let pos = gizmo.model_matrix * vec4<f32>(mesh_pos, 1.);
   let clip_pos = (global_params.projection_view * pos);
 
   let ndc = clip_pos.xyz / clip_pos.w;
@@ -54,15 +54,15 @@ fn corner(radius: f32, uv: vec2<f32>, stretch: vec2<f32>, scale: vec2<f32>) -> b
   // let max_len = min(stretch.x, stretch.y);
   let aspect = (stretch.y / stretch.x);
   let short_side = max(stretch.x, stretch.y);
-  let radius = radius / short_side;
-  let anchor = corner - vec2<f32>(sign(mid.x), sign(mid.y)) * radius ;
+  let radius_scaled = radius / short_side;
+  let anchor = corner - vec2<f32>(sign(mid.x), sign(mid.y)) * radius_scaled;
 
   let rel = mid - anchor;
   let to_corner = corner - mid;
-  let ang = dot(normalize((mid - anchor)), normalize(corner));
-  let ang = dot(normalize(mid - anchor), normalize(corner - anchor));
+  var ang = dot(normalize((mid - anchor)), normalize(corner));
+  ang = dot(normalize(mid - anchor), normalize(corner - anchor));
 
-  return length(mid - anchor) > radius &&
+  return length(mid - anchor) > radius_scaled &&
     (ang > 0.707 || abs(unstretched_mid.x) > 1.0 || abs(unstretched_mid.y) > 1.0);
 }
 

--- a/crates/gpu/src/texture.rs
+++ b/crates/gpu/src/texture.rs
@@ -123,6 +123,7 @@ impl Texture {
                 format,
                 usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::RENDER_ATTACHMENT,
                 label,
+                view_formats: &[format],
             },
         );
         texture.write(image.as_raw());
@@ -145,6 +146,7 @@ impl Texture {
                 format,
                 usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                 label,
+                view_formats: &[format],
             },
             &img.into_vec(),
         )
@@ -175,6 +177,7 @@ impl Texture {
                 format,
                 usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::RENDER_ATTACHMENT,
                 label,
+                view_formats: &[format],
             },
         );
         for (layer, img) in data.into_iter().enumerate() {
@@ -222,6 +225,7 @@ impl Texture {
                 format: wgpu::TextureFormat::R32Float,
                 usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                 label: Some("texture"),
+                view_formats: &[wgpu::TextureFormat::R32Float],
             },
             bytemuck::cast_slice(data.as_slice().unwrap()),
         )
@@ -280,6 +284,7 @@ impl Texture {
                 format: wgpu::TextureFormat::Rgba8Unorm,
                 usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                 label: Some("Texture.new_single_color_texture"),
+                view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
             },
             bytemuck::cast_slice(&[color.x as u8, color.y as u8, color.z as u8, color.w as u8]),
         )
@@ -296,6 +301,7 @@ impl Texture {
                 format: wgpu::TextureFormat::Rgba8Unorm,
                 usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                 label: Some("default_texture"),
+                view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
             },
             bytemuck::cast_slice(
                 &colors.into_iter().flat_map(|color| vec![color.x as u8, color.y as u8, color.z as u8, color.w as u8]).collect_vec(),

--- a/crates/renderer/src/collect.rs
+++ b/crates/renderer/src/collect.rs
@@ -164,7 +164,6 @@ impl RendererCollect {
             "collect",
             &[
                 get_defs_module(assets),
-                get_mesh_buffer_types(),
                 get_resources_module(),
                 GpuWorldShaderModuleKey { read_only: true }.get(assets),
                 ShaderModule::new(

--- a/crates/renderer/src/collect.rs
+++ b/crates/renderer/src/collect.rs
@@ -4,7 +4,6 @@ use ambient_core::gpu_ecs::{GpuWorldShaderModuleKey, ENTITIES_BIND_GROUP};
 use ambient_ecs::{EntityId, World};
 use ambient_gpu::{
     gpu::{Gpu, GpuKey},
-    mesh_buffer::get_mesh_buffer_types,
     multi_buffer::TypedMultiBuffer,
     shader_module::{BindGroupDesc, ComputePipeline, Shader, ShaderModule, ShaderModuleIdentifier},
     typed_buffer::TypedBuffer,

--- a/crates/renderer/src/culling.wgsl
+++ b/crates/renderer/src/culling.wgsl
@@ -90,8 +90,8 @@ fn update(entity_loc: vec2<u32>) {
     }
     for (var i=0; i < #SHADOW_CASCADES; i = i + 1) {
         let radius = bounding_sphere.w;
-        let pixel_size = vec2<f32>(radius) * 2. / params.shadow_cameras[i].orthographic_size;
-        let pixel_size = min(pixel_size.x, pixel_size.y);
+        let pixel_sizes = vec2<f32>(radius) * 2. / params.shadow_cameras[i].orthographic_size;
+        let pixel_size = min(pixel_sizes.x, pixel_sizes.y);
         if (pixel_size < 0.01) {
             break;
         }

--- a/crates/renderer/src/globals.rs
+++ b/crates/renderer/src/globals.rs
@@ -268,6 +268,7 @@ fn create_dummy_shadow_texture(gpu: Arc<Gpu>) -> Arc<Texture> {
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Depth32Float,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[wgpu::TextureFormat::Depth32Float]
         },
     ))
 }

--- a/crates/renderer/src/globals.wgsl
+++ b/crates/renderer/src/globals.wgsl
@@ -88,9 +88,9 @@ fn fetch_shadow(light_angle: f32, world_position: vec4<f32>) -> f32 {
         // The texel size is in world coordinates, transform to depth buffer by
         // dividing by the depth of the camera
         let p = cam.viewproj * world_position;
-        let p = p.xyz / p.w;
-        if (inside(p)) {
-            return fetch_shadow_cascade(i, p);
+        let p_norm = p.xyz / p.w;
+        if (inside(p_norm)) {
+            return fetch_shadow_cascade(i, p_norm);
         }
     }
     return 1.;
@@ -190,10 +190,10 @@ fn distribution_ggx(normal: vec3<f32>, h: vec3<f32>, roughness: f32) -> f32 {
     let ndoth = max(dot(normal, h), 0.0);
     let ndoth2 = ndoth * ndoth;
 
-    let numerator =a2;
-    let denom = ndoth2 * (a2 - 1.0) + 1.0;
+    let numerator = a2;
+    var denom = ndoth2 * (a2 - 1.0) + 1.0;
 
-    let denom = PI * denom * denom;
+    denom = PI * denom * denom;
     return numerator / denom;
 }
 

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -252,7 +252,7 @@ pub fn get_defs_module(_: &AssetCache) -> ShaderModule {
         [("PI", PI)]
             .iter()
             .map(|(k, v)| format!("const {k}: f32 = {v};\n"))
-            .chain([wgsl_interpolate(), include_file!("polyfill.wgsl"), MESH_BUFFER_TYPES_WGSL.to_string()])
+            .chain([wgsl_interpolate(), include_file!("polyfill.wgsl")])
             .collect::<String>(),
     )
 }

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -10,7 +10,7 @@ use ambient_ecs::{
     components, query_mut, Debuggable, Description, EntityId, MakeDefault, Name, Networked, Resource, Store, SystemGroup, World,
 };
 use ambient_gpu::{
-    mesh_buffer::{get_mesh_buffer_types, GpuMesh, MESH_BUFFER_TYPES_WGSL},
+    mesh_buffer::{GpuMesh, MESH_BUFFER_TYPES_WGSL},
     shader_module::{BindGroupDesc, Shader, ShaderModule, ShaderModuleIdentifier},
     wgsl_utils::wgsl_interpolate,
 };
@@ -311,7 +311,6 @@ pub fn get_forward_module(assets: &AssetCache, shadow_cascades: u32) -> ShaderMo
         get_globals_module(assets, shadow_cascades),
         GpuWorldShaderModuleKey { read_only: true }.get(assets),
         get_common_module(assets),
-        get_mesh_buffer_types(),
     ]
     .iter()
     .collect()

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -251,7 +251,7 @@ pub fn get_defs_module(_: &AssetCache) -> ShaderModule {
         "Definitions",
         [("PI", PI)]
             .iter()
-            .map(|(k, v)| format!("let {k}: f32 = {v};\n"))
+            .map(|(k, v)| format!("const {k}: f32 = {v};\n"))
             .chain([wgsl_interpolate(), include_file!("polyfill.wgsl"), MESH_BUFFER_TYPES_WGSL.to_string()])
             .collect::<String>(),
     )

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -252,7 +252,7 @@ pub fn get_defs_module(_: &AssetCache) -> ShaderModule {
         [("PI", PI)]
             .iter()
             .map(|(k, v)| format!("const {k}: f32 = {v};\n"))
-            .chain([wgsl_interpolate(), include_file!("polyfill.wgsl")])
+            .chain([wgsl_interpolate(), include_file!("polyfill.wgsl"), MESH_BUFFER_TYPES_WGSL.to_string()])
             .collect::<String>(),
     )
 }

--- a/crates/renderer/src/outlines.rs
+++ b/crates/renderer/src/outlines.rs
@@ -128,6 +128,7 @@ impl Outlines {
                 dimension: wgpu::TextureDimension::D2,
                 format: Self::FORMAT,
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[Self::FORMAT],
             },
         ))
     }

--- a/crates/renderer/src/renderer_common.wgsl
+++ b/crates/renderer/src/renderer_common.wgsl
@@ -21,20 +21,20 @@ fn model_to_world(loc: vec2<u32>, mesh_index: u32, vertex_index: u32) -> ModelTo
 
     if (has_entity_skin(loc)) {
         let joint = get_mesh_joint(mesh_index, vertex_index);
-        let weight = get_mesh_weight(mesh_index, vertex_index);
+        let mesh_weight = get_mesh_weight(mesh_index, vertex_index);
         let skin_offset = get_entity_skin(loc);
 
-        let ltw_x: mat4x4<f32> = skins.data[skin_offset + joint.x]; 
-        let ltw_y: mat4x4<f32> = skins.data[skin_offset + joint.y]; 
-        let ltw_z: mat4x4<f32> = skins.data[skin_offset + joint.z]; 
-        let ltw_w: mat4x4<f32> = skins.data[skin_offset + joint.w]; 
+        let ltw_x: mat4x4<f32> = skins.data[skin_offset + joint.x];
+        let ltw_y: mat4x4<f32> = skins.data[skin_offset + joint.y];
+        let ltw_z: mat4x4<f32> = skins.data[skin_offset + joint.z];
+        let ltw_w: mat4x4<f32> = skins.data[skin_offset + joint.w];
 
         var total_pos     = vec4<f32>(0.0);
         var total_norm    = vec4<f32>(0.0);
         var total_tangent = vec4<f32>(0.0);
 
         // Normalize the weights
-        let weight = weight / dot(weight, vec4<f32>(1.0));
+        let weight = mesh_weight / dot(mesh_weight, vec4<f32>(1.0));
 
         total_pos = total_pos + (ltw_x * pos) * weight.x;
         total_pos = total_pos + (ltw_y * pos) * weight.y;

--- a/crates/renderer/src/shadow_renderer.rs
+++ b/crates/renderer/src/shadow_renderer.rs
@@ -49,6 +49,7 @@ impl ShadowsRenderer {
                     | wgpu::TextureUsages::TEXTURE_BINDING
                     | wgpu::TextureUsages::COPY_SRC
                     | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[wgpu::TextureFormat::Depth32Float]
             },
         ));
         let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());

--- a/crates/renderer/src/target.rs
+++ b/crates/renderer/src/target.rs
@@ -30,6 +30,7 @@ impl RenderTarget {
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Depth32Float,
                 usage,
+                view_formats: &[wgpu::TextureFormat::Depth32Float],
             },
         ));
         let color_buffer = Arc::new(Texture::new(
@@ -42,6 +43,7 @@ impl RenderTarget {
                 dimension: wgpu::TextureDimension::D2,
                 format: sc_desc.format,
                 usage,
+                view_formats: &[sc_desc.format],
             },
         ));
         let normals_buffer = Arc::new(Texture::new(
@@ -54,6 +56,7 @@ impl RenderTarget {
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Rgba8Snorm,
                 usage,
+                view_formats: &[wgpu::TextureFormat::Rgba8Snorm],
             },
         ));
         Self {

--- a/crates/sky/src/atmospheric_scattering.wgsl
+++ b/crates/sky/src/atmospheric_scattering.wgsl
@@ -1,5 +1,5 @@
-let atmo_radius = 6471e3;
-let planet_radius = 6371e3;
+const atmo_radius = 6471e3;
+const planet_radius = 6371e3;
 
 struct Node {
     density: f32,
@@ -36,7 +36,7 @@ fn sphere_intersect(pos: vec3<f32>, dir: vec3<f32>, r: f32) -> vec2<f32> {
     );
 }
 
-let DISTANCE_THRESHOLD: f32 = 0.1;
+const DISTANCE_THRESHOLD: f32 = 0.1;
 
 fn cube_intersect(origin: f32, size: f32, ray_o: vec3<f32>, dir: vec3<f32>) ->
 f32 {

--- a/crates/sky/src/clouds.wgsl
+++ b/crates/sky/src/clouds.wgsl
@@ -41,8 +41,8 @@ struct Sample {
     vol: Volume,
 };
 
-let air_volume   = Volume(vec3<f32>(1e-6, 1e-6, 1e-6));
-let cloud_volume = Volume(vec3<f32>(0.1,  0.1,  0.1));
+const air_volume   = Volume(vec3<f32>(1e-6, 1e-6, 1e-6));
+const cloud_volume = Volume(vec3<f32>(0.1,  0.1,  0.1));
 
 fn smooth_min(a: Sample, b: Sample, t: f32) -> Sample {
     let h = max(t - abs(a.dist - b.dist), 0.0);

--- a/crates/terrain/src/brushes/mod.rs
+++ b/crates/terrain/src/brushes/mod.rs
@@ -194,6 +194,7 @@ impl TerrainBrush {
                         | wgpu::TextureUsages::COPY_DST
                         | wgpu::TextureUsages::COPY_SRC
                         | wgpu::TextureUsages::STORAGE_BINDING,
+                    view_formats: &[wgpu::TextureFormat::R32Float],
                 },
             )),
             intermediate_normalmap: Arc::new(Texture::new(
@@ -209,6 +210,7 @@ impl TerrainBrush {
                         | wgpu::TextureUsages::COPY_DST
                         | wgpu::TextureUsages::COPY_SRC
                         | wgpu::TextureUsages::STORAGE_BINDING,
+                    view_formats: &[wgpu::TextureFormat::Rgba32Float],
                 },
             )),
         }

--- a/crates/terrain/src/brushes/water_sim.wgsl
+++ b/crates/terrain/src/brushes/water_sim.wgsl
@@ -16,7 +16,7 @@ fn get_height(coord: vec2<i32>) -> f32 {
         textureLoad(heightmap, coord, #WATER_LAYER).r;
 }
 
-let d_t = 0.02;
+const d_t = 0.02;
 
 fn calc_next_flux(cell: vec2<i32>, delta: vec2<i32>, layer: i32, cell_height: f32) -> f32 {
     let f = textureLoad(heightmap, cell, layer).r;

--- a/crates/terrain/src/lib.rs
+++ b/crates/terrain/src/lib.rs
@@ -457,6 +457,7 @@ impl TerrainState {
                     | wgpu::TextureUsages::COPY_SRC
                     | wgpu::TextureUsages::STORAGE_BINDING,
                 label: Some("heightmap"),
+                view_formats: &[wgpu::TextureFormat::R32Float],
             },
         ));
 
@@ -474,6 +475,7 @@ impl TerrainState {
                     | wgpu::TextureUsages::STORAGE_BINDING
                     | wgpu::TextureUsages::RENDER_ATTACHMENT,
                 label: Some("normalmap"),
+                view_formats: &[wgpu::TextureFormat::Rgba32Float],
             },
         ));
         FillerKey { format: normalmap.format }.get(&assets).run(

--- a/crates/ui/src/text.rs
+++ b/crates/ui/src/text.rs
@@ -227,6 +227,7 @@ pub fn systems() -> SystemGroup {
                             format: wgpu::TextureFormat::R8Unorm,
                             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                             label: Some("Text.texture"),
+                            view_formats: &[wgpu::TextureFormat::R8Unorm],
                         },
                     ));
                     let texture_view = Arc::new(texture.create_view(&wgpu::TextureViewDescriptor::default()));
@@ -349,6 +350,7 @@ pub fn systems() -> SystemGroup {
                                             format: wgpu::TextureFormat::R8Unorm,
                                             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                                             label: Some("Text.texture"),
+                                            view_formats: &[wgpu::TextureFormat::R8Unorm],
                                         },
                                     ));
                                     glyph_brush.lock().resize_texture(suggested.0, suggested.1);


### PR DESCRIPTION
Hello,
You guys don't have a policy for contributing, or I didn't find it, so I hope a pull request out of the blue is no problem. If it is, you can reject it, no problem.

Updated all code necessary to run on wgpu 0.15.
- For now, the new view_formats aren't used and just contain the same format as the texture itself.
- Expecting on the now fallible `Instance::create_surface()` method. I found other `expect()`s in the code base, so I assume it should be fine for now? There is no error handling in `Gpu::with_config()`, might be a todo.
- The [new instance descriptor](https://docs.rs/wgpu-types/0.15.1/wgpu_types/struct.InstanceDescriptor.html) uses the FXC compiler for Windows (previous default AFAIK) and all others. For all others, it shouldn't matter as it is DX12 only. For Windows, the possibility of using the DXC compiler should be explored as it seems to be [a better alternative to FXC](https://docs.rs/wgpu-types/0.15.1/wgpu_types/enum.Dx12Compiler.html#variants). But the DXC compiler requires two DLLs to be shipped with the executable. Not sure if that is something that is wanted.

Maybe I misunderstood the new view_formats parameter, so might be worth to double check that.

Closes #27.