### PR TITLE
chore(ci): trace target directory content for cache troubleshooting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -y libasound2-dev libglib2.0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
+          sudo apt-get install --no-install-recommends -y tree libasound2-dev libglib2.0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libcairo-dev libgtk2.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev xorg-dev ninja-build libxcb-render0-dev
       - name: Install run (headless) dependencies
         run: |
@@ -47,6 +47,9 @@ jobs:
         run: cd guest/rust && cargo build --workspace
       - name: Check that guest/rust's documentation is well-formed
         run: cd guest/rust && RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+      # Provides a history of the cache content builds over build to make troubleshooting easier
+      - name: Display target directory content
+        run: tree --du -h target
 
   build-other:
     strategy:


### PR DESCRIPTION
#153 reported a suspicious cache usage increase.

This PR introduces a new step in the build process to output the content of the `target` directory after the build. This will help investigate if something is wrong builds after builds.

I ran multiple builds with this change and couldn't observe any file change or file increase from the same commits.

Here is an example of the new step in action: https://github.com/daniellavoie/Ambient/actions/runs/4257943674/jobs/7408628309