### PR TITLE
feat: update the window title with the project name - fixes #171

### DIFF
--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -6,7 +6,7 @@ use std::{
     time::SystemTime,
 };
 
-use ambient_core::{app_start_time, asset_cache, dtime, no_sync, time};
+use ambient_core::{app_start_time, asset_cache, dtime, no_sync, project_name, time};
 use ambient_ecs::{world_events, ComponentDesc, ComponentRegistry, EntityData, Networked, SystemGroup, World, WorldStreamCompEvent};
 use ambient_network::{
     bi_stream_handlers, datagram_handlers,
@@ -66,6 +66,10 @@ pub fn start(
         server_world.init_shape_change_tracking();
 
         server_world.add_components(server_world.resource_entity(), create_resources(assets.clone())).unwrap();
+
+        // Keep track of the project name
+        let name = manifest.project.name.clone().unwrap_or_else(|| "Ambient".into());
+        server_world.add_components(server_world.resource_entity(), EntityData::new().set(project_name(), name)).unwrap();
 
         wasm::initialize(&mut server_world, project_path.clone(), &manifest).await.unwrap();
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -121,6 +121,9 @@ components!("app", {
     /// Generic component that indicates the entity shouldn't be sent over network
     @[Debuggable, Networked, Store]
     no_sync: (),
+
+    @[Resource, Name["Project Name"], Description["The name of the project, from the manifest.\n Defaults to \"Ambient\"."]]
+    project_name: String,
 });
 
 pub fn init_all_components() {


### PR DESCRIPTION
This PR adds a new `ServerData` struct that is transmitted from the server to the client during the handshake, and is intended to store various metadata that might be relevant to the client. For now all it stores is the project name, but that can be easily changed in the future.