### PR TITLE
Remove EventDispatcher components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,6 @@ dependencies = [
  "ambient_sys",
  "as-any",
  "atomic_refcell",
- "closure",
  "derivative",
  "dyn-clonable",
  "futures",

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -7,7 +7,9 @@ use std::{
 };
 
 use ambient_core::{app_start_time, asset_cache, dtime, no_sync, project_name, time};
-use ambient_ecs::{world_events, ComponentDesc, ComponentRegistry, EntityData, Networked, SystemGroup, World, WorldStreamCompEvent};
+use ambient_ecs::{
+    world_events, ComponentDesc, ComponentRegistry, EntityData, Networked, SystemGroup, World, WorldEventsSystem, WorldStreamCompEvent,
+};
 use ambient_network::{
     bi_stream_handlers, datagram_handlers,
     server::{ForkingEvent, GameServer, ShutdownEvent},
@@ -100,6 +102,7 @@ fn systems(_world: &mut World) -> SystemGroup {
             Box::new(ambient_physics::physx::sync_ecs_physics()),
             Box::new(ambient_core::transform::TransformSystem::new()),
             ambient_core::remove_at_time_system(),
+            Box::new(WorldEventsSystem),
             Box::new(ambient_physics::server_systems()),
             Box::new(shared::player::server_systems()),
             Box::new(wasm::systems()),

--- a/app/src/shared/player.rs
+++ b/app/src/shared/player.rs
@@ -8,7 +8,7 @@ use ambient_core::{
 use ambient_ecs::{query, query_mut, EntityData, SystemGroup};
 use ambient_element::{element_component, Element, Hooks};
 use ambient_input::{
-    event_keyboard_input, event_mouse_input, event_mouse_motion, on_app_focus_change, on_app_mouse_wheel, player_prev_raw_input,
+    event_keyboard_input, event_mouse_input, event_mouse_motion, event_mouse_wheel, on_app_focus_change, player_prev_raw_input,
     player_raw_input, ElementState, MouseScrollDelta, PlayerRawInput,
 };
 use ambient_network::{
@@ -152,6 +152,11 @@ pub fn PlayerRawInputHandler(hooks: &mut Hooks) -> Element {
                 }
             } else if let Some(delta) = event.get(event_mouse_motion()) {
                 input.lock().mouse_position += delta;
+            } else if let Some(delta) = event.get(event_mouse_wheel()) {
+                input.lock().mouse_wheel += match delta {
+                    MouseScrollDelta::LineDelta(_, y) => y * PIXELS_PER_LINE,
+                    MouseScrollDelta::PixelDelta(pos) => pos.y as f32,
+                };
             }
         }
     });
@@ -161,19 +166,6 @@ pub fn PlayerRawInputHandler(hooks: &mut Hooks) -> Element {
             on_app_focus_change(),
             Arc::new(move |_, _, focus| {
                 set_has_focus(focus);
-            }),
-        )
-        .listener(
-            on_app_mouse_wheel(),
-            Arc::new({
-                let input = input.clone();
-                move |_, _, delta| {
-                    input.lock().mouse_wheel += match delta {
-                        MouseScrollDelta::LineDelta(_, y) => y * PIXELS_PER_LINE,
-                        MouseScrollDelta::PixelDelta(pos) => pos.y as f32,
-                    };
-                    true
-                }
             }),
         )
         .listener(

--- a/app/src/shared/player.rs
+++ b/app/src/shared/player.rs
@@ -8,7 +8,7 @@ use ambient_core::{
 use ambient_ecs::{query, query_mut, EntityData, SystemGroup};
 use ambient_element::{element_component, Element, Hooks};
 use ambient_input::{
-    event_keyboard_input, event_mouse_input, on_app_focus_change, on_app_mouse_motion, on_app_mouse_wheel, player_prev_raw_input,
+    event_keyboard_input, event_mouse_input, event_mouse_motion, on_app_focus_change, on_app_mouse_wheel, player_prev_raw_input,
     player_raw_input, ElementState, MouseScrollDelta, PlayerRawInput,
 };
 use ambient_network::{
@@ -150,6 +150,8 @@ pub fn PlayerRawInputHandler(hooks: &mut Hooks) -> Element {
                         lock.mouse_buttons.remove(&event.button);
                     }
                 }
+            } else if let Some(delta) = event.get(event_mouse_motion()) {
+                input.lock().mouse_position += delta;
             }
         }
     });
@@ -159,15 +161,6 @@ pub fn PlayerRawInputHandler(hooks: &mut Hooks) -> Element {
             on_app_focus_change(),
             Arc::new(move |_, _, focus| {
                 set_has_focus(focus);
-            }),
-        )
-        .listener(
-            on_app_mouse_motion(),
-            Arc::new({
-                let input = input.clone();
-                move |_, _, delta| {
-                    input.lock().mouse_position += delta;
-                }
             }),
         )
         .listener(

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -19,7 +19,9 @@ use ambient_core::{
     window::WindowCtl,
     window_logical_size, window_physical_size, window_scale_factor, RuntimeKey, TimeResourcesSystem, WinitEventsSystem,
 };
-use ambient_ecs::{components, Debuggable, DynSystem, EntityData, FrameEvent, MakeDefault, MaybeResource, System, SystemGroup, World};
+use ambient_ecs::{
+    components, world_events, Debuggable, DynSystem, EntityData, FrameEvent, MakeDefault, MaybeResource, System, SystemGroup, World,
+};
 use ambient_element::ambient_system;
 use ambient_gizmos::{gizmos, Gizmos};
 use ambient_gpu::{
@@ -141,6 +143,7 @@ pub fn world_instance_resources(resources: AppResources) -> EntityData {
         .set(self::window_title(), "".to_string())
         .set(self::fps_stats(), FpsSample::default())
         .set(self::asset_cache(), resources.assets.clone())
+        .set_default(world_events())
         .set(frame_index(), 0_usize)
         .set(ambient_core::mouse_position(), Vec2::ZERO)
         .set(ambient_core::app_start_time(), SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap())

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -17,7 +17,7 @@ use ambient_core::{
     mouse_position, remove_at_time_system, runtime, time,
     transform::TransformSystem,
     window::WindowCtl,
-    window_logical_size, window_physical_size, window_scale_factor, RuntimeKey, TimeResourcesSystem, WinitEventsSystem,
+    window_logical_size, window_physical_size, window_scale_factor, RuntimeKey, TimeResourcesSystem,
 };
 use ambient_ecs::{
     components, world_events, Debuggable, DynSystem, EntityData, FrameEvent, MakeDefault, MaybeResource, System, SystemGroup, World,
@@ -284,12 +284,7 @@ impl AppBuilder {
 
         let mut window_event_systems = SystemGroup::new(
             "window_event_systems",
-            vec![
-                Box::new(assets_camera_systems()),
-                Box::new(WinitEventsSystem::new()),
-                Box::new(ambient_input::event_systems()),
-                Box::new(renderers::systems()),
-            ],
+            vec![Box::new(assets_camera_systems()), Box::new(ambient_input::event_systems()), Box::new(renderers::systems())],
         );
         if self.examples_systems {
             window_event_systems.add(Box::new(ExamplesSystem));

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -21,6 +21,7 @@ use ambient_core::{
 };
 use ambient_ecs::{
     components, world_events, Debuggable, DynSystem, EntityData, FrameEvent, MakeDefault, MaybeResource, System, SystemGroup, World,
+    WorldEventsSystem,
 };
 use ambient_element::ambient_system;
 use ambient_gizmos::{gizmos, Gizmos};
@@ -95,6 +96,7 @@ pub fn world_instance_systems(full: bool) -> SystemGroup {
             Box::new(TimeResourcesSystem::new()),
             Box::new(async_ecs_systems()),
             remove_at_time_system(),
+            Box::new(WorldEventsSystem),
             if full { Box::new(ambient_input::picking::frame_systems()) } else { Box::new(DummySystem) },
             Box::new(lod_system()),
             Box::new(ambient_renderer::systems()),

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -14,7 +14,7 @@ use ambient_core::{
     frame_index, get_window_sizes,
     gpu_ecs::{gpu_world, GpuWorld, GpuWorldSyncEvent, GpuWorldUpdate},
     hierarchy::dump_world_hierarchy_to_tmp_file,
-    mouse_position, on_frame_system, remove_at_time_system, runtime, time,
+    mouse_position, remove_at_time_system, runtime, time,
     transform::TransformSystem,
     window::WindowCtl,
     window_logical_size, window_physical_size, window_scale_factor, RuntimeKey, TimeResourcesSystem, WinitEventsSystem,
@@ -94,7 +94,6 @@ pub fn world_instance_systems(full: bool) -> SystemGroup {
         vec![
             Box::new(TimeResourcesSystem::new()),
             Box::new(async_ecs_systems()),
-            on_frame_system(),
             remove_at_time_system(),
             if full { Box::new(ambient_input::picking::frame_systems()) } else { Box::new(DummySystem) },
             Box::new(lod_system()),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -112,7 +112,6 @@ components!("app", {
     @[Debuggable, Store]
     remove_at_time: Duration,
 
-    on_frame: EventDispatcher<dyn Fn(&mut World, EntityId, f32) + Sync + Send>,
 
     on_event: EventDispatcher<dyn Fn(&mut World, EntityId, &winit::event::Event<()>) + Sync + Send>,
     on_window_event: EventDispatcher<dyn Fn(&mut World, EntityId, &winit::event::WindowEvent) + Sync + Send>,
@@ -196,17 +195,6 @@ impl System<Event<'static, ()>> for WinitEventsSystem {
             _ => {}
         }
     }
-}
-
-pub fn on_frame_system() -> DynSystem {
-    query((on_frame(),)).to_system(|q, world, qs, _| {
-        let dtime = *world.resource(self::dtime());
-        for (id, (on_frame,)) in q.collect_cloned(world, qs) {
-            for handler in on_frame.iter() {
-                handler(world, id, dtime);
-            }
-        }
-    })
 }
 
 pub fn remove_at_time_system() -> DynSystem {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -113,7 +113,6 @@ components!("app", {
     remove_at_time: Duration,
 
 
-    on_event: EventDispatcher<dyn Fn(&mut World, EntityId, &winit::event::Event<()>) + Sync + Send>,
     on_window_event: EventDispatcher<dyn Fn(&mut World, EntityId, &winit::event::WindowEvent) + Sync + Send>,
     on_device_event: EventDispatcher<dyn Fn(&mut World, EntityId, &winit::event::DeviceEvent) + Sync + Send>,
 
@@ -172,11 +171,6 @@ impl WinitEventsSystem {
 }
 impl System<Event<'static, ()>> for WinitEventsSystem {
     fn run(&mut self, world: &mut World, event: &Event<'static, ()>) {
-        for (id, (dispatcher,)) in query((on_event(),)).collect_cloned(world, Some(&mut self.event_qs)) {
-            for handler in dispatcher.iter() {
-                handler(world, id, event);
-            }
-        }
         match event {
             Event::WindowEvent { event, .. } => {
                 for (id, (dispatcher,)) in query((on_window_event(),)).collect_cloned(world, Some(&mut self.window_event_qs)) {

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -792,3 +792,11 @@ impl<'de> Deserialize<'de> for ComponentSet {
 
 pub type WorldEvents = FramedEvents<EntityData>;
 pub type WorldEventReader = FramedEventsReader<EntityData>;
+
+#[derive(Debug)]
+pub struct WorldEventsSystem;
+impl System for WorldEventsSystem {
+    fn run(&mut self, world: &mut World, _event: &FrameEvent) {
+        world.resource_mut(world_events()).next_frame();
+    }
+}

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -790,11 +790,5 @@ impl<'de> Deserialize<'de> for ComponentSet {
     }
 }
 
-#[derive(Clone)]
-pub struct WorldEvent {
-    pub name: String,
-    pub data: EntityData,
-}
-
-pub type WorldEvents = FramedEvents<WorldEvent>;
-pub type WorldEventReader = FramedEventsReader<WorldEvent>;
+pub type WorldEvents = FramedEvents<EntityData>;
+pub type WorldEventReader = FramedEventsReader<EntityData>;

--- a/crates/ecs_editor/src/lib.rs
+++ b/crates/ecs_editor/src/lib.rs
@@ -73,6 +73,7 @@ impl ElementComponent for ECSEditor {
                             None => Vec4::ONE,
                         },
                     )
+                    .with_clickarea()
                     .on_mouse_up(move |_, _, _| {
                         let mut comps = components.clone();
                         if let Some(v) = comps.get(&comp).cloned() {
@@ -85,7 +86,8 @@ impl ElementComponent for ECSEditor {
                             comps.insert(comp, true);
                         }
                         set_components(comps);
-                    }),
+                    })
+                    .el(),
             ])
             .set(space_between_items(), 5.)
         };

--- a/crates/editor/src/ui/build_mode/mod.rs
+++ b/crates/editor/src/ui/build_mode/mod.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 use ambient_core::{asset_cache, async_ecs::async_run, get_mouse_clip_space_position, runtime};
 use ambient_ecs::{Component, ComponentValue, EntityId};
 use ambient_element::{Element, ElementComponent, ElementComponentExt, Group, Hooks};
-use ambient_input::{on_app_keyboard_input, MouseButton};
+use ambient_input::{event_keyboard_input, MouseButton};
 use ambient_intent::{client_push_intent, rpc_undo_head_exact};
 use ambient_network::client::GameClient;
 use ambient_sys::task::RuntimeHandle;
@@ -154,24 +154,15 @@ impl ElementComponent for EditorBuildMode {
 
             use_interval_deps(hooks, Duration::from_millis(2000), true, selection.clone(), update_targets);
         }
-
-        // Make sure to get the value *after* the `use_interval_deps`
-        let targets = targets.lock();
-
-        Dock(vec![
-            EditorPlayerInputHandler.el(),
-            ScreenContainer(screen).el(),
-            Group(vec![Element::new().listener(
-                on_app_keyboard_input(),
-                Arc::new(move |_, _, event| match event.keycode {
+        hooks.use_world_event(move |_world, event| {
+            if let Some(event) = event.get_ref(event_keyboard_input()) {
+                match event.keycode {
                     Some(VirtualKeyCode::LShift) => {
                         if event.state == ElementState::Pressed {
                             set_select_mode(SelectMode::Add);
                         } else {
                             set_select_mode(SelectMode::Set);
                         }
-                        // Do not interfere with the player movement
-                        false
                     }
                     Some(VirtualKeyCode::LControl) => {
                         if event.state == ElementState::Pressed {
@@ -179,12 +170,18 @@ impl ElementComponent for EditorBuildMode {
                         } else {
                             set_select_mode(SelectMode::Set);
                         }
-                        false
                     }
-                    _ => false,
-                }),
-            )])
-                .el(),
+                    _ => {}
+                }
+            }
+        });
+
+        // Make sure to get the value *after* the `use_interval_deps`
+        let targets = targets.lock();
+
+        Dock(vec![
+            EditorPlayerInputHandler.el(),
+            ScreenContainer(screen).el(),
             if !selection.is_empty() {
                 SelectionPanel { selection: selection.clone(), set_selection: set_selection.clone() }
                     .el()

--- a/crates/editor/src/ui/build_mode/mod.rs
+++ b/crates/editor/src/ui/build_mode/mod.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use ambient_core::{asset_cache, async_ecs::async_run, get_mouse_clip_space_position, runtime};
 use ambient_ecs::{Component, ComponentValue, EntityId};
-use ambient_element::{Element, ElementComponent, ElementComponentExt, Group, Hooks};
+use ambient_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 use ambient_input::{event_keyboard_input, MouseButton};
 use ambient_intent::{client_push_intent, rpc_undo_head_exact};
 use ambient_network::client::GameClient;

--- a/crates/editor/src/ui/build_mode/select_area.rs
+++ b/crates/editor/src/ui/build_mode/select_area.rs
@@ -1,12 +1,10 @@
-use std::sync::Arc;
-
 use ambient_core::{
-    mouse_position, on_window_event, runtime,
+    mouse_position, runtime,
     transform::{get_world_position, translation},
     window_logical_size, window_scale_factor,
 };
 use ambient_element::{Element, ElementComponent, ElementComponentExt, Hooks};
-use ambient_input::MouseButton;
+use ambient_input::{event_mouse_input, event_mouse_motion, MouseButton};
 use ambient_network::{client::GameClient, log_network_result};
 use ambient_std::{color::Color, math::interpolate};
 use ambient_ui::{
@@ -14,7 +12,7 @@ use ambient_ui::{
     UIBase, UIExt,
 };
 use glam::{vec2, vec3, Vec2, Vec3Swizzles};
-use winit::event::{ElementState, WindowEvent};
+use winit::event::ElementState;
 
 use crate::{
     intents::SelectMode,
@@ -26,7 +24,7 @@ use crate::{
 pub struct SelectArea;
 impl ElementComponent for SelectArea {
     fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
-        let (dragging, set_dragging) = hooks.use_state(None);
+        let (dragging, set_dragging) = hooks.use_state::<Option<Vec2>>(None);
         let (area_offset, set_area_offset) = hooks.use_state(Vec2::ZERO);
         let (mouse_pos, set_mouse_pos) = hooks.use_state(Vec2::ZERO);
         let (game_client, _) = hooks.consume_context::<GameClient>().unwrap();
@@ -40,6 +38,74 @@ impl ElementComponent for SelectArea {
                     log_network_result!(client.rpc(rpc_select, (SelectMethod::Manual(Default::default()), SelectMode::Clear)).await);
                 });
             })
+        });
+        hooks.use_world_event({
+            let set_dragging = set_dragging.clone();
+            let is_clicking = is_clicking.clone();
+            move |world, event| {
+                let scl = *world.resource(window_scale_factor()) as f32;
+                if let Some(position) = event.get(event_mouse_motion()) {
+                    set_mouse_pos(position / scl);
+                } else if let Some(event) = event.get_ref(event_mouse_input()) {
+                    if event.state == ElementState::Released {
+                        let mut is_clicking = is_clicking.lock();
+                        if !*is_clicking {
+                            return;
+                        }
+
+                        *is_clicking = false;
+
+                        tracing::info!("Released selection click");
+                        set_dragging(None);
+
+                        let screen_size = world.resource(window_logical_size()).as_vec2();
+
+                        if let Some(dragging) = dragging {
+                            let game_client = game_client.clone();
+                            let min_x = dragging.x.min(mouse_pos.x);
+                            let max_x = dragging.x.max(mouse_pos.x);
+                            let min_y = dragging.y.min(mouse_pos.y);
+                            let max_y = dragging.y.max(mouse_pos.y);
+                            let size = vec2(max_x - min_x, max_y - min_y);
+                            if size.x > 5. || size.y > 5. {
+                                let frustum = {
+                                    let state = game_client.game_state.lock();
+                                    let get_corner = |p, z| {
+                                        let clip_pos = interpolate(p, Vec2::ZERO, screen_size, vec2(-1., 1.), vec2(1., -1.));
+                                        state.clip_to_world_space(clip_pos.extend(z))
+                                    };
+                                    [
+                                        // Order: Bottom [ Left (Back, Front), Right (Back, Front) ] - Top [ Left (Back, Front), Right (Back, Front) ]
+                                        get_corner(vec2(min_x, min_y), 1.),
+                                        get_corner(vec2(min_x, min_y), 0.001),
+                                        get_corner(vec2(max_x, min_y), 1.),
+                                        get_corner(vec2(max_x, min_y), 0.001),
+                                        get_corner(vec2(min_x, max_y), 1.),
+                                        get_corner(vec2(min_x, max_y), 0.001),
+                                        get_corner(vec2(max_x, max_y), 1.),
+                                        get_corner(vec2(max_x, max_y), 0.001),
+                                    ]
+                                };
+                                world.resource(runtime()).clone().spawn(async move {
+                                    log_network_result!(game_client.rpc(rpc_select, (SelectMethod::Frustum(frustum), select_mode)).await);
+                                });
+                                return;
+                            }
+                        }
+
+                        let ray = {
+                            let state = game_client.game_state.lock();
+                            let p = interpolate(mouse_pos, Vec2::ZERO, screen_size, vec2(-1., 1.), vec2(1., -1.));
+                            state.screen_ray(p)
+                        };
+
+                        let game_client = game_client.clone();
+                        world.resource(runtime()).clone().spawn(async move {
+                            log_network_result!(game_client.rpc(rpc_select, (SelectMethod::Ray(ray), select_mode)).await);
+                        });
+                    }
+                }
+            }
         });
 
         UIBase
@@ -58,79 +124,6 @@ impl ElementComponent for SelectArea {
                 *is_clicking.lock() = true;
             }))
             .el()
-            .listener(
-                on_window_event(),
-                Arc::new(move |world, _, event| {
-                    let scl = *world.resource(window_scale_factor()) as f32;
-                    match event {
-                        WindowEvent::CursorMoved { position, .. } => {
-                            set_mouse_pos(vec2(position.x as f32, position.y as f32) / scl);
-                        }
-                        WindowEvent::MouseInput { state, .. } => {
-                            if state == &ElementState::Released {
-                                let mut is_clicking = is_clicking.lock();
-                                if !*is_clicking {
-                                    return;
-                                }
-
-                                *is_clicking = false;
-
-                                tracing::info!("Released selection click");
-                                set_dragging(None);
-
-                                let screen_size = world.resource(window_logical_size()).as_vec2();
-
-                                if let Some(dragging) = dragging {
-                                    let game_client = game_client.clone();
-                                    let min_x = dragging.x.min(mouse_pos.x);
-                                    let max_x = dragging.x.max(mouse_pos.x);
-                                    let min_y = dragging.y.min(mouse_pos.y);
-                                    let max_y = dragging.y.max(mouse_pos.y);
-                                    let size = vec2(max_x - min_x, max_y - min_y);
-                                    if size.x > 5. || size.y > 5. {
-                                        let frustum = {
-                                            let state = game_client.game_state.lock();
-                                            let get_corner = |p, z| {
-                                                let clip_pos = interpolate(p, Vec2::ZERO, screen_size, vec2(-1., 1.), vec2(1., -1.));
-                                                state.clip_to_world_space(clip_pos.extend(z))
-                                            };
-                                            [
-                                                // Order: Bottom [ Left (Back, Front), Right (Back, Front) ] - Top [ Left (Back, Front), Right (Back, Front) ]
-                                                get_corner(vec2(min_x, min_y), 1.),
-                                                get_corner(vec2(min_x, min_y), 0.001),
-                                                get_corner(vec2(max_x, min_y), 1.),
-                                                get_corner(vec2(max_x, min_y), 0.001),
-                                                get_corner(vec2(min_x, max_y), 1.),
-                                                get_corner(vec2(min_x, max_y), 0.001),
-                                                get_corner(vec2(max_x, max_y), 1.),
-                                                get_corner(vec2(max_x, max_y), 0.001),
-                                            ]
-                                        };
-                                        world.resource(runtime()).clone().spawn(async move {
-                                            log_network_result!(
-                                                game_client.rpc(rpc_select, (SelectMethod::Frustum(frustum), select_mode)).await
-                                            );
-                                        });
-                                        return;
-                                    }
-                                }
-
-                                let ray = {
-                                    let state = game_client.game_state.lock();
-                                    let p = interpolate(mouse_pos, Vec2::ZERO, screen_size, vec2(-1., 1.), vec2(1., -1.));
-                                    state.screen_ray(p)
-                                };
-
-                                let game_client = game_client.clone();
-                                world.resource(runtime()).clone().spawn(async move {
-                                    log_network_result!(game_client.rpc(rpc_select, (SelectMethod::Ray(ray), select_mode)).await);
-                                });
-                            }
-                        }
-                        _ => {}
-                    }
-                }),
-            )
             .children(vec![if let Some(dragging) = dragging {
                 let min_x = dragging.x.min(mouse_pos.x);
                 let max_x = dragging.x.max(mouse_pos.x);

--- a/crates/editor/src/ui/build_mode/select_area.rs
+++ b/crates/editor/src/ui/build_mode/select_area.rs
@@ -44,6 +44,7 @@ impl ElementComponent for SelectArea {
 
         UIBase
             .el()
+            .with_clickarea()
             .on_mouse_down(closure!(clone set_dragging, clone is_clicking, |world, id, button| {
                 if button != MouseButton::Left {
                     return;
@@ -56,6 +57,7 @@ impl ElementComponent for SelectArea {
                 tracing::info!("Set is_clicking to true");
                 *is_clicking.lock() = true;
             }))
+            .el()
             .listener(
                 on_window_event(),
                 Arc::new(move |world, _, event| {

--- a/crates/editor/src/ui/build_mode/selection_panel.rs
+++ b/crates/editor/src/ui/build_mode/selection_panel.rs
@@ -52,5 +52,6 @@ impl ElementComponent for SelectionPanel {
         .set(fit_horizontal(), Fit::None)
         .set(fit_vertical(), Fit::None)
         .with_clickarea()
+        .el()
     }
 }

--- a/crates/editor/src/ui/terrain_mode.rs
+++ b/crates/editor/src/ui/terrain_mode.rs
@@ -101,6 +101,7 @@ impl ElementComponent for TerrainRaycastPicker {
 
         UIBase
             .el()
+            .with_clickarea()
             .on_mouse_enter(closure!(clone set_mouseover, |_, _| { set_mouseover(true) }))
             .on_mouse_leave(closure!(clone set_mouseover, |_, _| { set_mouseover(false); }))
             .on_mouse_down(closure!(clone set_mousedown, |_, _, button| {
@@ -108,6 +109,7 @@ impl ElementComponent for TerrainRaycastPicker {
                     set_mousedown(Some(target_position.unwrap_or_default()));
                 }
             }))
+            .el()
             .listener(
                 on_frame(),
                 Arc::new(move |world, _, _| {

--- a/crates/editor/src/ui/terrain_mode.rs
+++ b/crates/editor/src/ui/terrain_mode.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ambient_core::{
-    asset_cache, get_mouse_clip_space_position, on_frame, runtime,
+    asset_cache, get_mouse_clip_space_position, runtime,
     transform::{scale, translation},
 };
 use ambient_decals::DecalShaderKey;
@@ -98,6 +98,65 @@ impl ElementComponent for TerrainRaycastPicker {
                 }
             }
         });
+        hooks.use_frame(move |world| {
+            let mouse_clip_pos = get_mouse_clip_space_position(world);
+            let mut state = game_client.game_state.lock();
+
+            // Update the target position with the result of our raycast.
+            {
+                let ray = state.screen_ray(mouse_clip_pos);
+                let filter = filter.clone();
+                let set_target_position = set_target_position.clone();
+                let game_client = game_client.clone();
+                world.resource(runtime()).clone().spawn(async move {
+                    if let Ok(resp) = game_client.rpc(rpc_pick, (ray, filter)).await {
+                        set_target_position(resp.map(|(_, dist)| ray.origin + ray.dir * dist));
+                    }
+                });
+            }
+
+            // If we have a target position, update our visualisation brush and issue
+            // terrain brush strokes if the user's mouse is active.
+            if let Some(target_position) = target_position {
+                if let Some(vis_brush_id) = vis_brush_id {
+                    let brush_size = brush_size.0;
+                    state.world.set(vis_brush_id, translation(), target_position).unwrap();
+                    state.world.set(vis_brush_id, scale(), Vec3::ONE * brush_size).unwrap();
+                    if brush_size != 0.0 {
+                        if let Ok(material) = state.world.get_ref(vis_brush_id, material()) {
+                            let picker_material: &BrushCursorMaterial = material.borrow_downcast();
+                            picker_material.upload_params(brush, target_position, brush_size, brush_strength.0, brush_shape);
+                        }
+                    }
+                }
+
+                if let Some(start_position) = mousedown {
+                    let center = target_position.xy();
+
+                    let erosion = erosion_config.clone();
+                    let game_client = game_client.clone();
+                    world.resource(runtime()).spawn({
+                        client_push_intent(
+                            game_client,
+                            intent_terrain_stroke(),
+                            TerrainBrushStroke {
+                                center,
+                                layer,
+                                brush,
+                                brush_size,
+                                brush_strength,
+                                brush_smoothness,
+                                brush_shape,
+                                start_position,
+                                erosion,
+                            },
+                            None,
+                            None,
+                        )
+                    });
+                }
+            }
+        });
 
         UIBase
             .el()
@@ -110,68 +169,6 @@ impl ElementComponent for TerrainRaycastPicker {
                 }
             }))
             .el()
-            .listener(
-                on_frame(),
-                Arc::new(move |world, _, _| {
-                    let mouse_clip_pos = get_mouse_clip_space_position(world);
-                    let mut state = game_client.game_state.lock();
-
-                    // Update the target position with the result of our raycast.
-                    {
-                        let ray = state.screen_ray(mouse_clip_pos);
-                        let filter = filter.clone();
-                        let set_target_position = set_target_position.clone();
-                        let game_client = game_client.clone();
-                        world.resource(runtime()).clone().spawn(async move {
-                            if let Ok(resp) = game_client.rpc(rpc_pick, (ray, filter)).await {
-                                set_target_position(resp.map(|(_, dist)| ray.origin + ray.dir * dist));
-                            }
-                        });
-                    }
-
-                    // If we have a target position, update our visualisation brush and issue
-                    // terrain brush strokes if the user's mouse is active.
-                    if let Some(target_position) = target_position {
-                        if let Some(vis_brush_id) = vis_brush_id {
-                            let brush_size = brush_size.0;
-                            state.world.set(vis_brush_id, translation(), target_position).unwrap();
-                            state.world.set(vis_brush_id, scale(), Vec3::ONE * brush_size).unwrap();
-                            if brush_size != 0.0 {
-                                if let Ok(material) = state.world.get_ref(vis_brush_id, material()) {
-                                    let picker_material: &BrushCursorMaterial = material.borrow_downcast();
-                                    picker_material.upload_params(brush, target_position, brush_size, brush_strength.0, brush_shape);
-                                }
-                            }
-                        }
-
-                        if let Some(start_position) = mousedown {
-                            let center = target_position.xy();
-
-                            let erosion = erosion_config.clone();
-                            let game_client = game_client.clone();
-                            world.resource(runtime()).spawn({
-                                client_push_intent(
-                                    game_client,
-                                    intent_terrain_stroke(),
-                                    TerrainBrushStroke {
-                                        center,
-                                        layer,
-                                        brush,
-                                        brush_size,
-                                        brush_strength,
-                                        brush_smoothness,
-                                        brush_shape,
-                                        start_position,
-                                        erosion,
-                                    },
-                                    None,
-                                    None,
-                                )
-                            });
-                        }
-                    }
-                }),
-            )
     }
 }
 

--- a/crates/element/Cargo.toml
+++ b/crates/element/Cargo.toml
@@ -15,7 +15,6 @@ ambient_element_component = { path = "../element_component" }
 itertools = { workspace = true }
 as-any = { workspace = true }
 dyn-clonable = { workspace = true }
-closure = { workspace = true }
 derivative = { workspace = true }
 parking_lot = { workspace = true }
 tracing = { workspace = true }

--- a/crates/element/src/element_config.rs
+++ b/crates/element/src/element_config.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
 use ambient_ecs::{Component, ComponentDesc, ComponentValue, EntityData, EntityId, World};
-use ambient_std::events::EventDispatcher;
 
 use crate::ElementComponent;
 
@@ -77,10 +76,4 @@ impl std::fmt::Debug for ElementComponents {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ElementComponents")
     }
-}
-
-#[derive(Clone)]
-pub(crate) struct ElementEventHandler {
-    add: Arc<dyn Fn(&mut World, EntityId) + Sync + Send>,
-    remove: Arc<dyn Fn(&mut World, EntityId) + Sync + Send>,
 }

--- a/crates/element/src/element_config.rs
+++ b/crates/element/src/element_config.rs
@@ -11,7 +11,6 @@ pub(crate) struct ElementConfig {
     pub part: Option<Box<dyn ElementComponent>>,
     pub components: ElementComponents,
     pub init_components: ElementComponents,
-    pub event_listeners: ElementEventHandlers,
     #[derivative(Debug = "ignore")]
     pub spawner: Arc<dyn Fn(&mut World, EntityData) -> EntityId + Sync + Send>,
     #[derivative(Debug = "ignore")]
@@ -29,7 +28,6 @@ impl ElementConfig {
             part: None,
             components: ElementComponents::new(),
             init_components: ElementComponents::new(),
-            event_listeners: ElementEventHandlers::new(),
             spawner: Arc::new(|world, props| props.spawn(world)),
             despawner: Arc::new(|world, entity| {
                 world.despawn(entity);
@@ -85,52 +83,4 @@ impl std::fmt::Debug for ElementComponents {
 pub(crate) struct ElementEventHandler {
     add: Arc<dyn Fn(&mut World, EntityId) + Sync + Send>,
     remove: Arc<dyn Fn(&mut World, EntityId) + Sync + Send>,
-}
-
-#[derive(Clone)]
-pub(crate) struct ElementEventHandlers(HashMap<usize, Vec<ElementEventHandler>>);
-impl ElementEventHandlers {
-    pub fn new() -> Self {
-        Self(HashMap::new())
-    }
-    pub fn set<T: 'static + Sync + Send + ?Sized>(&mut self, component: Component<EventDispatcher<T>>, listener: Arc<T>) {
-        let entry = self.0.entry(component.index() as usize).or_default();
-        entry.push(ElementEventHandler {
-            add: Arc::new(closure!(clone listener, |world, entity| {
-                if let Ok(event_dispatcher) = world.get_mut(entity, component) {
-                    event_dispatcher.add(listener.clone());
-                } else {
-                    world.add_component(entity, component, EventDispatcher::<T>::new_with(listener.clone())).unwrap();
-                }
-            })),
-            remove: Arc::new(move |world, entity| {
-                let event_dispatcher = world.get_mut(entity, component).unwrap();
-                event_dispatcher.remove(listener.clone());
-            }),
-        });
-    }
-    pub fn add_to_entity(&self, world: &mut World, entity: EntityId) {
-        for handlers in self.0.values() {
-            for handler in handlers {
-                (handler.add)(world, entity);
-            }
-        }
-    }
-    pub fn remove_from_entity(&self, world: &mut World, entity: EntityId) {
-        for handlers in self.0.values() {
-            for handler in handlers {
-                (handler.remove)(world, entity);
-            }
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-}
-impl std::fmt::Debug for ElementEventHandlers {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ElementEventHandlers")
-    }
 }

--- a/crates/element/src/lib.rs
+++ b/crates/element/src/lib.rs
@@ -1,12 +1,9 @@
 #[macro_use]
-extern crate closure;
-#[macro_use]
 extern crate derivative;
 
 use std::{any::Any, sync::Arc};
 
 use ambient_ecs::{components, Component, ComponentDesc, ComponentValue, EntityData, EntityId, SystemGroup, World};
-use ambient_std::events::EventDispatcher;
 use as_any::AsAny;
 use dyn_clonable::clonable;
 use parking_lot::Mutex;

--- a/crates/element/src/lib.rs
+++ b/crates/element/src/lib.rs
@@ -131,10 +131,6 @@ impl Element {
         self.config.init_components.remove(component);
         self
     }
-    pub fn listener<T: 'static + Sync + Send + ?Sized>(mut self, component: Component<EventDispatcher<T>>, listener: Arc<T>) -> Self {
-        self.config.event_listeners.set(component, listener);
-        self
-    }
     pub fn children(mut self, children: Vec<Element>) -> Self {
         self.children = children;
         self

--- a/crates/element/src/tree.rs
+++ b/crates/element/src/tree.rs
@@ -244,7 +244,6 @@ impl ElementTree {
         self.gather_parent_components(world, instance_id, &mut components);
         let instance = self.instances.get(instance_id).unwrap();
         world.add_components(instance.entity, components).unwrap();
-        instance.config.event_listeners.add_to_entity(world, instance.entity);
         if spawn {
             if let Some(on_spawned) = &instance.config.on_spawned {
                 on_spawned(world, entity);
@@ -315,7 +314,6 @@ impl ElementTree {
     fn migrate_instance(&mut self, world: &mut World, instance_id: &str, node_parent: Option<EntityId>, new_node: Element) {
         {
             let instance = self.instances.get_mut(instance_id).unwrap();
-            instance.config.event_listeners.remove_from_entity(world, instance.entity);
             instance.config = new_node.config;
             instance.parent_entity = node_parent;
         }

--- a/crates/element/tests/common/mod.rs
+++ b/crates/element/tests/common/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ambient_ecs::{components, query_mut, Resource, World};
-use ambient_std::{events::EventDispatcher, Cb};
+use ambient_std::Cb;
 use itertools::Itertools;
 
 components!("test", {

--- a/crates/element/tests/common/mod.rs
+++ b/crates/element/tests/common/mod.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use ambient_ecs::{components, query_mut, Resource, World};
-use ambient_std::events::EventDispatcher;
+use ambient_std::{events::EventDispatcher, Cb};
 use itertools::Itertools;
 
 components!("test", {
     prop_a: (),
     prop_b: u32,
-    trigger: EventDispatcher<dyn Fn(&mut World) + Send + Sync>,
+    trigger: Cb<dyn Fn(&mut World) + Send + Sync>,
     @[Resource]
     counter: u32,
     @[Resource]
@@ -30,8 +30,6 @@ pub fn initialize() -> World {
 pub fn run_triggers(world: &mut World) {
     let triggers = query_mut((), (trigger(),)).iter(world, None).map(|x| x.2 .0.clone()).collect_vec();
     for trigger in triggers.into_iter() {
-        for handler in trigger.iter() {
-            handler(world);
-        }
+        (*trigger)(world);
     }
 }

--- a/crates/element/tests/context.rs
+++ b/crates/element/tests/context.rs
@@ -2,6 +2,7 @@ use ambient_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 mod common;
 use std::sync::Arc;
 
+use ambient_std::cb;
 use common::*;
 
 #[test]
@@ -37,9 +38,9 @@ fn update_context_on_removed_element() {
             let (state, set_state) = hooks.use_state::<u32>(0);
             hooks.provide_context(|| state);
             if state < 3 {
-                Element::new().children(vec![Child.into()]).listener(
+                Element::new().children(vec![Child.into()]).set(
                     trigger(),
-                    Arc::new(move |_| {
+                    cb(move |_| {
                         set_state(state + 1);
                     }),
                 )

--- a/crates/element/tests/context.rs
+++ b/crates/element/tests/context.rs
@@ -1,6 +1,5 @@
 use ambient_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 mod common;
-use std::sync::Arc;
 
 use ambient_std::cb;
 use common::*;

--- a/crates/element/tests/events.rs
+++ b/crates/element/tests/events.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use ambient_ecs::query_mut;
 use ambient_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 mod common;

--- a/crates/element/tests/events.rs
+++ b/crates/element/tests/events.rs
@@ -48,57 +48,6 @@ fn test_outer_init() {
 }
 
 #[test]
-fn test_two_event_listeners() {
-    #[derive(Debug, Clone)]
-    pub struct Outer;
-    impl ElementComponent for Outer {
-        fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
-            let (use_inner, set_use_inner) = hooks.use_state(true);
-            if use_inner {
-                Element::from(Inner).set(
-                    trigger(),
-                    cb(move |world| {
-                        *world.resource_mut(counter()) += 1;
-                        set_use_inner(false);
-                    }),
-                )
-            } else {
-                Element::new().set(
-                    trigger(),
-                    cb(move |world| {
-                        *world.resource_mut(counter()) += 1;
-                    }),
-                )
-            }
-        }
-    }
-
-    #[derive(Debug, Clone)]
-    pub struct Inner;
-    impl ElementComponent for Inner {
-        fn render(self: Box<Self>, _: &mut Hooks) -> Element {
-            Element::new().set(
-                trigger(),
-                cb(move |world| {
-                    *world.resource_mut(counter()) += 1;
-                }),
-            )
-        }
-    }
-
-    let mut world = initialize();
-    let mut tree = Outer.el().spawn_tree(&mut world);
-
-    run_triggers(&mut world);
-    tree.update(&mut world);
-    assert_eq!(2, *world.resource(counter()));
-
-    run_triggers(&mut world);
-    tree.update(&mut world);
-    assert_eq!(3, *world.resource(counter()));
-}
-
-#[test]
 fn update_state_on_replaced_element() {
     #[derive(Debug, Clone)]
     pub struct Root;

--- a/crates/element/tests/events.rs
+++ b/crates/element/tests/events.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use ambient_ecs::query_mut;
 use ambient_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 mod common;
+use ambient_std::cb;
 use common::*;
 
 #[test]
@@ -29,7 +30,7 @@ fn test_outer_init() {
         fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
             let (count, set_count) = hooks.use_state(0);
             if count < 2 {
-                Element::new().listener(trigger(), Arc::new(move |_| set_count(count + 1)))
+                Element::new().set(trigger(), cb(move |_| set_count(count + 1)))
             } else {
                 Dummy.into()
             }
@@ -56,17 +57,17 @@ fn test_two_event_listeners() {
         fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
             let (use_inner, set_use_inner) = hooks.use_state(true);
             if use_inner {
-                Element::from(Inner).listener(
+                Element::from(Inner).set(
                     trigger(),
-                    Arc::new(move |world| {
+                    cb(move |world| {
                         *world.resource_mut(counter()) += 1;
                         set_use_inner(false);
                     }),
                 )
             } else {
-                Element::new().listener(
+                Element::new().set(
                     trigger(),
-                    Arc::new(move |world| {
+                    cb(move |world| {
                         *world.resource_mut(counter()) += 1;
                     }),
                 )
@@ -78,9 +79,9 @@ fn test_two_event_listeners() {
     pub struct Inner;
     impl ElementComponent for Inner {
         fn render(self: Box<Self>, _: &mut Hooks) -> Element {
-            Element::new().listener(
+            Element::new().set(
                 trigger(),
-                Arc::new(move |world| {
+                cb(move |world| {
                     *world.resource_mut(counter()) += 1;
                 }),
             )
@@ -106,9 +107,9 @@ fn update_state_on_replaced_element() {
     impl ElementComponent for Root {
         fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
             let (state, set_state) = hooks.use_state(0);
-            Element::new().listener(
+            Element::new().set(
                 trigger(),
-                Arc::new(move |_| {
+                cb(move |_| {
                     set_state(state + 1);
                 }),
             )
@@ -135,9 +136,9 @@ fn update_state_on_root_and_child_simultaneously() {
         fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
             let (state, set_state) = hooks.use_state(0);
             Element::new()
-                .listener(
+                .set(
                     trigger(),
-                    Arc::new(move |_| {
+                    cb(move |_| {
                         set_state(state + 1);
                     }),
                 )
@@ -151,9 +152,9 @@ fn update_state_on_root_and_child_simultaneously() {
         fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
             let (state, set_state) = hooks.use_state(0);
             *hooks.world.resource_mut(counter()) = state;
-            Element::new().listener(
+            Element::new().set(
                 trigger(),
-                Arc::new(move |_| {
+                cb(move |_| {
                     set_state(state + 1);
                 }),
             )

--- a/crates/element/tests/hooks.rs
+++ b/crates/element/tests/hooks.rs
@@ -5,6 +5,7 @@ use std::sync::{
 
 use ambient_element::{Element, ElementComponent, ElementComponentExt, ElementTree, Hooks};
 mod common;
+use ambient_std::cb;
 use common::*;
 
 #[test]
@@ -37,7 +38,7 @@ fn use_state_inc_should_work() {
             let (state, set_state) = hooks.use_state(10);
             *hooks.world.resource_mut(n_renders()) += 1;
             *hooks.world.resource_mut(counter()) = state;
-            Element::new().listener(trigger(), Arc::new(move |_| set_state(state + 1)))
+            Element::new().set(trigger(), cb(move |_| set_state(state + 1)))
         }
     }
 
@@ -61,7 +62,7 @@ fn use_state_on_removed_element_should_be_ignored() {
     impl ElementComponent for Inner {
         fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
             let (state, set_state) = hooks.use_state(0);
-            Element::new().listener(trigger(), Arc::new(move |_| set_state(state + 1)))
+            Element::new().set(trigger(), cb(move |_| set_state(state + 1)))
         }
     }
 
@@ -110,7 +111,7 @@ fn use_state_shouldnt_survive_between_instances() {
         fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
             let (state, set_state) = hooks.use_state(0);
             STATE.store(state, Ordering::Relaxed);
-            Element::new().listener(trigger(), Arc::new(move |_| set_state(state + 1)))
+            Element::new().set(trigger(), cb(move |_| set_state(state + 1)))
         }
     }
     let mut world = initialize();

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -35,7 +35,7 @@ components!("input", {
     event_received_character: char,
     event_keyboard_input: KeyboardEvent,
     event_mouse_input: MouseInput,
-    on_app_mouse_motion: EventCallback<Vec2, ()>,
+    event_mouse_motion: Vec2,
     on_app_mouse_wheel: EventCallback<MouseScrollDelta>,
     on_app_modifiers_change: EventCallback<ModifiersState, ()>,
     on_app_focus_change: EventCallback<bool, ()>,
@@ -146,11 +146,9 @@ impl System<Event<'static, ()>> for InputSystem {
             },
 
             Event::DeviceEvent { event: DeviceEvent::MouseMotion { delta }, .. } => {
-                for (id, (dispatcher,)) in query((on_app_mouse_motion(),)).collect_cloned(world, Some(&mut self.mouse_motion_qs)) {
-                    for handle in dispatcher.iter() {
-                        handle(world, id, vec2(delta.0 as f32, delta.1 as f32));
-                    }
-                }
+                world
+                    .resource_mut(world_events())
+                    .add_event(EntityData::new().set(event_mouse_motion(), vec2(delta.0 as f32, delta.1 as f32)));
             }
             _ => {}
         }

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -7,8 +7,6 @@ use serde::{Deserialize, Serialize};
 pub use winit::event::{DeviceEvent, ElementState, Event, KeyboardInput, MouseButton, MouseScrollDelta, VirtualKeyCode, WindowEvent};
 use winit::event::{ModifiersState, ScanCode};
 
-use crate::picking::picking_winit_event_system;
-
 pub mod picking;
 
 pub type EventCallback<Event, Ret = bool> = EventDispatcher<dyn Fn(&mut World, EntityId, Event) -> Ret + Sync + Send>;
@@ -50,7 +48,7 @@ pub fn init_all_components() {
 }
 
 pub fn event_systems() -> SystemGroup<Event<'static, ()>> {
-    SystemGroup::new("inputs", vec![Box::new(InputSystem::new()), Box::new(picking_winit_event_system())])
+    SystemGroup::new("inputs", vec![Box::new(InputSystem::new())])
 }
 
 #[derive(Debug)]

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -1,15 +1,12 @@
 use std::collections::HashSet;
 
-use ambient_ecs::{components, world_events, EntityData, EntityId, System, SystemGroup, World};
-use ambient_std::events::EventDispatcher;
+use ambient_ecs::{components, world_events, EntityData, System, SystemGroup};
 use glam::{vec2, Vec2};
 use serde::{Deserialize, Serialize};
 pub use winit::event::{DeviceEvent, ElementState, Event, KeyboardInput, MouseButton, MouseScrollDelta, VirtualKeyCode, WindowEvent};
 use winit::event::{ModifiersState, ScanCode};
 
 pub mod picking;
-
-pub type EventCallback<Event, Ret = bool> = EventDispatcher<dyn Fn(&mut World, EntityId, Event) -> Ret + Sync + Send>;
 
 #[derive(Debug, Clone)]
 /// Represents a keyboard event with attached modifiers

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -36,7 +36,7 @@ components!("input", {
     event_keyboard_input: KeyboardEvent,
     event_mouse_input: MouseInput,
     event_mouse_motion: Vec2,
-    on_app_mouse_wheel: EventCallback<MouseScrollDelta>,
+    event_mouse_wheel: MouseScrollDelta,
     on_app_modifiers_change: EventCallback<ModifiersState, ()>,
     on_app_focus_change: EventCallback<bool, ()>,
 
@@ -115,18 +115,7 @@ impl System<Event<'static, ()>> for InputSystem {
                 }
 
                 WindowEvent::MouseWheel { delta, .. } => {
-                    let mut fire_wheel_event = |world: &mut World| {
-                        let mut handlers = query((on_app_mouse_wheel(),)).collect_cloned(world, Some(&mut self.mouse_wheel_qs));
-                        handlers.sort_by_key(|(_, (handler,))| Reverse(handler.created_timestamp));
-                        for (id, (dispatcher,)) in handlers {
-                            for handler in dispatcher.iter() {
-                                if handler(world, id, *delta) {
-                                    return;
-                                }
-                            }
-                        }
-                    };
-                    fire_wheel_event(world);
+                    world.resource_mut(world_events()).add_event(EntityData::new().set(event_mouse_wheel(), *delta));
                 }
                 WindowEvent::ModifiersChanged(mods) => {
                     self.modifiers = *mods;

--- a/crates/input/src/picking.rs
+++ b/crates/input/src/picking.rs
@@ -4,13 +4,9 @@ use ambient_core::{
     transform::local_to_world,
     ui_scene, window_physical_size,
 };
-use ambient_ecs::{components, query, EntityData, EntityId, FnSystem, Resource, SystemGroup, World};
-use ambient_std::{
-    events::EventDispatcher,
-    shapes::{RayIntersectable, AABB},
-};
+use ambient_ecs::{components, query, EntityData, EntityId, FnSystem, Resource, SystemGroup};
+use ambient_std::shapes::{RayIntersectable, AABB};
 use glam::Vec2;
-use winit::event::{ElementState, Event, MouseButton, MouseScrollDelta, WindowEvent};
 
 components!("input", {
     @[Resource]

--- a/crates/input/src/picking.rs
+++ b/crates/input/src/picking.rs
@@ -17,6 +17,7 @@ components!("input", {
     picker_intersecting: Option<PickerIntersection>,
 
     mouse_pickable: AABB,
+    mouse_over: bool,
     on_mouse_input: EventDispatcher<dyn Fn(&mut World, EntityId, ElementState, MouseButton) + Send + Sync>,
     on_mouse_enter: EventDispatcher<dyn Fn(&mut World, EntityId) + Send + Sync>,
     on_mouse_leave: EventDispatcher<dyn Fn(&mut World, EntityId) + Send + Sync>,
@@ -69,11 +70,13 @@ pub fn frame_systems() -> SystemGroup {
             let intersecting_entity = intersecting.map(|x| x.entity);
             if prev_intersecting_entity != intersecting_entity {
                 if let Some(prev) = prev_intersecting_entity {
+                    world.add_component(prev, mouse_over(), false).unwrap();
                     if let Ok(on_leave) = world.get_ref(prev, on_mouse_leave()) {
                         on_leaves.push((on_leave.clone(), prev));
                     }
                 }
                 if let Some(new) = intersecting_entity {
+                    world.add_component(new, mouse_over(), true).unwrap();
                     if let Ok(on_enter) = world.get_ref(new, on_mouse_enter()) {
                         on_enters.push((on_enter.clone(), new));
                     }

--- a/crates/ui/examples/state.rs
+++ b/crates/ui/examples/state.rs
@@ -4,7 +4,7 @@ use ambient_app::{App, AppBuilder};
 use ambient_cameras::UICamera;
 use ambient_core::camera::active_camera;
 use ambient_element::{ElementComponent, ElementComponentExt};
-use ambient_input::on_app_mouse_motion;
+use ambient_input::event_mouse_motion;
 use ambient_ui::{padding, space_between_items, Borders, Button, Cb, FlowColumn, FlowRow, Text, STREET};
 use tracing_subscriber::EnvFilter;
 
@@ -63,13 +63,13 @@ impl ElementComponent for B {
         let (shared, _) = hooks.use_state(self.shared.clone());
         let keepalive = DroppedClosure;
 
-        Text::el(shared.0.to_string()).listener(
-            on_app_mouse_motion(),
-            Arc::new(move |_, _, _| {
+        hooks.use_world_event(move |_world, event| {
+            if let Some(_event) = event.get_ref(event_mouse_motion()) {
                 let _val = &keepalive;
-                // tracing::info!("Moving mouse to {pos}.");
-            }),
-        )
+            }
+        });
+
+        Text::el(shared.0.to_string())
     }
 }
 

--- a/crates/ui/examples/ui.rs
+++ b/crates/ui/examples/ui.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use ambient_app::{App, AppBuilder};
 use ambient_cameras::UICamera;
-use ambient_core::{camera::active_camera, hierarchy::children, on_frame, transform::translation};
+use ambient_core::{camera::active_camera, hierarchy::children, transform::translation};
 use ambient_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 use ambient_renderer::color;
 use ambient_std::color::Color;

--- a/crates/ui/examples/ui.rs
+++ b/crates/ui/examples/ui.rs
@@ -17,12 +17,13 @@ struct WobbleRect;
 impl ElementComponent for WobbleRect {
     fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
         let (state, set_state) = hooks.use_state(0.);
-        UIBase
-            .el()
-            .set(width(), 150.)
-            .set(height(), 30. + (state as f32 * 0.01).sin() * 20.)
-            .with_background(Color::rgba(1., 0., (state as f32 * 0.01).sin(), 1.))
-            .listener(on_frame(), Arc::new(move |_world, _, _| set_state(state + 1.)))
+        hooks.use_frame(move |_| set_state(state + 1.));
+        UIBase.el().set(width(), 150.).set(height(), 30. + (state as f32 * 0.01).sin() * 20.).with_background(Color::rgba(
+            1.,
+            0.,
+            (state as f32 * 0.01).sin(),
+            1.,
+        ))
     }
 }
 

--- a/crates/ui/examples/ui.rs
+++ b/crates/ui/examples/ui.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use ambient_app::{App, AppBuilder};
 use ambient_cameras::UICamera;
 use ambient_core::{camera::active_camera, hierarchy::children, transform::translation};

--- a/crates/ui/examples/ui.rs
+++ b/crates/ui/examples/ui.rs
@@ -78,7 +78,8 @@ impl ElementComponent for Example {
                         .set(width(), 30. - count as f32 * 2.)
                         .set(height(), 30. + count as f32 * 30.)
                         .with_background(Color::rgba(0.5, 0.5, 0.5, 1.))
-                        .with_clickarea(),
+                        .with_clickarea()
+                        .el(),
                     // .set(on_click(), Arc::new(move |world, _| {
                     //     set_count(count + 1);
                     // }))

--- a/crates/ui/src/button.rs
+++ b/crates/ui/src/button.rs
@@ -249,7 +249,8 @@ pub fn Button(
         .on_mouse_leave(move |world, _| {
             set_hover(false);
             world.resource(window_ctl()).send(WindowCtl::SetCursorIcon(CursorIcon::Default)).ok();
-        });
+        })
+        .el();
 
     if disabled {
         content

--- a/crates/ui/src/button.rs
+++ b/crates/ui/src/button.rs
@@ -9,7 +9,7 @@ use std::{
 use ambient_core::{runtime, window::WindowCtl, window_ctl};
 use ambient_ecs::World;
 use ambient_element::{element_component, Element, ElementComponent, ElementComponentExt, Hooks};
-use ambient_input::{on_app_focus_change, on_app_keyboard_input, on_app_mouse_input, KeyboardEvent};
+use ambient_input::{event_keyboard_input, on_app_focus_change, on_app_mouse_input, KeyboardEvent};
 use ambient_renderer::color;
 use ambient_std::{cb, color::Color, Callback, Cb};
 use closure::closure;
@@ -388,19 +388,10 @@ impl ElementComponent for Hotkey {
     fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
         let Self { on_is_pressed_changed, content, hotkey, hotkey_modifier, on_invoke } = *self;
         let (is_pressed, _) = hooks.use_state_with(|_| Arc::new(AtomicBool::new(false)));
-        content
-            .listener(
-                on_app_focus_change(),
-                Arc::new({
-                    let is_pressed = is_pressed.clone();
-                    move |_, _, _| {
-                        is_pressed.store(false, Ordering::Relaxed);
-                    }
-                }),
-            )
-            .listener(
-                on_app_keyboard_input(),
-                Arc::new(move |world, _, event| {
+        hooks.use_world_event({
+            let is_pressed = is_pressed.clone();
+            move |world, event| {
+                if let Some(event) = event.get_ref(event_keyboard_input()) {
                     if let KeyboardEvent { keycode: Some(virtual_keycode), state, modifiers, .. } = event {
                         if virtual_keycode == &hotkey {
                             if state == &ElementState::Pressed {
@@ -409,7 +400,7 @@ impl ElementComponent for Hotkey {
                                         on_is_pressed_changed.0(true);
                                     }
                                     is_pressed.store(true, Ordering::Relaxed);
-                                    return true;
+                                    return;
                                 }
                             } else {
                                 let pressed = is_pressed.load(Ordering::Relaxed);
@@ -420,13 +411,22 @@ impl ElementComponent for Hotkey {
                                         on_is_pressed_changed.0(false);
                                     }
                                     is_pressed.store(false, Ordering::Relaxed);
-                                    return true;
+                                    return;
                                 }
                             }
                         }
                     }
-                    false
-                }),
-            )
+                }
+            }
+        });
+        content.listener(
+            on_app_focus_change(),
+            Arc::new({
+                let is_pressed = is_pressed.clone();
+                move |_, _, _| {
+                    is_pressed.store(false, Ordering::Relaxed);
+                }
+            }),
+        )
     }
 }

--- a/crates/ui/src/button.rs
+++ b/crates/ui/src/button.rs
@@ -9,7 +9,7 @@ use std::{
 use ambient_core::{runtime, window::WindowCtl, window_ctl};
 use ambient_ecs::World;
 use ambient_element::{element_component, Element, ElementComponent, ElementComponentExt, Hooks};
-use ambient_input::{event_keyboard_input, event_mouse_input, on_app_focus_change, KeyboardEvent};
+use ambient_input::{event_focus_change, event_keyboard_input, event_mouse_input, KeyboardEvent};
 use ambient_renderer::color;
 use ambient_std::{cb, color::Color, Callback, Cb};
 use closure::closure;
@@ -420,17 +420,11 @@ impl ElementComponent for Hotkey {
                             }
                         }
                     }
+                } else if let Some(_event) = event.get(event_focus_change()) {
+                    is_pressed.store(false, Ordering::Relaxed);
                 }
             }
         });
-        content.listener(
-            on_app_focus_change(),
-            Arc::new({
-                let is_pressed = is_pressed.clone();
-                move |_, _, _| {
-                    is_pressed.store(false, Ordering::Relaxed);
-                }
-            }),
-        )
+        content
     }
 }

--- a/crates/ui/src/collections.rs
+++ b/crates/ui/src/collections.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, fmt::Debug, hash::Hash, ops::Deref, sync::Arc};
 
-use ambient_core::on_window_event;
 use ambient_ecs::EntityId;
 use ambient_element::{element_component, Element, ElementComponent, ElementComponentExt, Hooks};
 use ambient_input::{event_keyboard_input, event_mouse_input, KeyboardEvent};
@@ -8,7 +7,7 @@ use ambient_std::{cb, color::Color, Cb};
 use closure::closure;
 use indexmap::IndexMap;
 use itertools::Itertools;
-use winit::event::{ElementState, VirtualKeyCode, WindowEvent};
+use winit::event::{ElementState, VirtualKeyCode};
 
 use super::{Button, ButtonStyle, Dropdown, Editor, EditorOpts, FlowColumn, FlowRow, Focus, UIBase, UIExt};
 use crate::{layout::*, StylesExt, COLLECTION_ADD_ICON, COLLECTION_DELETE_ICON, MOVE_DOWN_ICON, MOVE_UP_ICON, STREET};

--- a/crates/ui/src/collections.rs
+++ b/crates/ui/src/collections.rs
@@ -192,11 +192,13 @@ impl<T: std::fmt::Debug + Clone + Default + Sync + Send + 'static> ElementCompon
                                 .into_iter()
                                 .map(move |item| {
                                     item_editor.0(item.clone(), None, Default::default())
+                                        .with_clickarea()
                                         .on_mouse_down(closure!(clone value, clone on_change, |_, _, _| {
                                             let mut value = value.clone();
                                             value.push(item.clone());
                                             on_change.0(value);
                                         }))
+                                        .el()
                                         .set(margin(), Borders::even(STREET))
                                 })
                                 .collect(),
@@ -276,9 +278,11 @@ impl<T: std::fmt::Debug + Clone + Default + Sync + Send + 'static> ElementCompon
         ])
         .el()
         .on_spawned(move |_, id| set_self_id(id))
+        .with_clickarea()
         .on_mouse_down(move |_, id, _| {
             set_focus(Focus(Some(id)));
         })
+        .el()
         .set(padding(), Borders::vertical(STREET))
         .set(fit_horizontal(), Fit::Parent)
     }

--- a/crates/ui/src/collections.rs
+++ b/crates/ui/src/collections.rs
@@ -253,7 +253,7 @@ impl<T: std::fmt::Debug + Clone + Default + Sync + Send + 'static> ElementCompon
         let (self_id, set_self_id) = hooks.use_state(EntityId::null());
         let (focus, set_focus) = hooks.consume_context::<Focus>().expect("No FocusRoot found");
         let focused = focus == Focus(Some(self_id));
-        hooks.use_world_event(move |world, event| {
+        hooks.use_world_event(move |_world, event| {
             if let Some(event) = event.get_ref(event_keyboard_input()) {
                 if !focused {
                     return;

--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -40,6 +40,7 @@ pub fn Tooltip(hooks: &mut Hooks, inner: Element, tooltip: Element) -> Element {
     }
     .el()
     .with_clickarea()
-    .listener(on_mouse_enter(), Arc::new(closure!(clone set_hover, |_, _| set_hover(true))))
-    .listener(on_mouse_leave(), Arc::new(move |_, _| set_hover(false)))
+    .on_mouse_enter(closure!(clone set_hover, |_, _| set_hover(true)))
+    .on_mouse_leave(move |_, _| set_hover(false))
+    .el()
 }

--- a/crates/ui/src/dropdown.rs
+++ b/crates/ui/src/dropdown.rs
@@ -1,8 +1,5 @@
-use std::sync::Arc;
-
 use ambient_core::transform::translation;
 use ambient_element::{element_component, Element, ElementComponentExt, Hooks};
-use ambient_input::picking::{on_mouse_enter, on_mouse_leave};
 use closure::closure;
 use glam::vec3;
 

--- a/crates/ui/src/input.rs
+++ b/crates/ui/src/input.rs
@@ -4,26 +4,26 @@ use std::{
     fmt::Debug,
     hash::Hash,
     str::FromStr,
-    sync::Arc,
     time::{Duration, SystemTime},
 };
 
-use ambient_core::{mouse_position, on_event, transform::translation, window::WindowCtl, window_ctl, window_scale_factor};
+use ambient_core::{
+    mouse_position,
+    transform::{get_world_position, translation},
+    window::WindowCtl,
+    window_ctl,
+};
 use ambient_ecs::{ComponentValue, EntityId};
 use ambient_element::{define_el_function_for_vec_element_newtype, Element, ElementComponent, ElementComponentExt, Hooks};
-use ambient_input::MouseButton;
+use ambient_input::{event_mouse_input, event_mouse_motion};
 use ambient_std::{
     cb,
-    events::EventDispatcher,
-    math::{interpolate, interpolate_clamped, Saturate},
+    math::{interpolate, interpolate_clamped},
     Cb,
 };
 use glam::*;
 use itertools::Itertools;
-use winit::{
-    event::{ElementState, Event, WindowEvent},
-    window::CursorIcon,
-};
+use winit::{event::ElementState, window::CursorIcon};
 
 use super::{Editor, EditorOpts, FlowColumn, FlowRow, Focus, Text, UIBase, UIExt};
 use crate::{
@@ -249,7 +249,8 @@ impl ElementComponent for Slider {
                 Box::new(|_| {})
             }
         });
-
+        let block_id = hooks.use_ref_with(|_| EntityId::null());
+        let is_moveable = self.on_change.is_some();
         // Sets the value with some sanitization
         let on_change_raw =
             self.on_change.map(|f| -> Cb<dyn Fn(f32) + Sync + Send> { cb(move |value: f32| f(cleanup_value(value, min, max, round))) });
@@ -257,22 +258,47 @@ impl ElementComponent for Slider {
         let on_change_factor =
             on_change_raw.clone().map(|f| cb(move |p: f32| f(if logarithmic { p.powf(E) } else { p } * (max - min) + min)));
 
+        // f(x) = p ^ e
+        // f'(f(x)) = x
+        // f'(y) = y ^ (1/e)
+        // (p ^ e) ^ (1/e) = p ^ (e / e) = p ^ 1 = p
+        let p = interpolate(value, min, max, 0., 1.);
+        let block_left_offset = if logarithmic { p.powf(1. / E) } else { p } * (slider_width - THUMB_WIDTH);
+        let block_left_offset = if block_left_offset.is_nan() || block_left_offset.is_infinite() { 0. } else { block_left_offset };
+
+        let dragging = hooks.use_ref_with(|_| false);
+        hooks.use_world_event({
+            let dragging = dragging.clone();
+            let block_id = block_id.clone();
+            move |world, event| {
+                if let Some(on_change_factor) = &on_change_factor {
+                    if let Some(event) = event.get_ref(event_mouse_input()) {
+                        if event.state == ElementState::Released {
+                            *dragging.lock() = false;
+                        }
+                    }
+                    if *dragging.lock() {
+                        if let Some(_) = event.get_ref(event_mouse_motion()) {
+                            let block_id = *block_id.lock();
+                            let block_position = get_world_position(world, block_id).unwrap_or_default();
+                            let block_width = world.get(block_id, width()).unwrap_or_default();
+                            let position = world.resource(mouse_position());
+                            on_change_factor(interpolate_clamped(position.x, block_position.x, block_width, 0., 1.));
+                        }
+                    }
+                }
+            }
+        });
+
         let rectangle = Rectangle
             .el()
             .set(width(), slider_width)
             .set(height(), 2.)
             .set(translation(), vec3(0., (SLIDER_HEIGHT - 2.) / 2., 0.))
-            .set(background_color(), primary_color());
+            .set(background_color(), primary_color())
+            .on_spawned(move |_, id| *block_id.lock() = id);
 
         let thumb = {
-            let p = interpolate(value, min, max, 0., 1.);
-            let block_left_offset = if logarithmic { p.powf(1. / E) } else { p } * (slider_width - THUMB_WIDTH);
-            let block_left_offset = if block_left_offset.is_nan() || block_left_offset.is_infinite() { 0. } else { block_left_offset };
-            // f(x) = p ^ e
-            // f'(f(x)) = x
-            // f'(y) = y ^ (1/e)
-            // (p ^ e) ^ (1/e) = p ^ (e / e) = p ^ 1 = p
-
             let thumb = UIBase
                 .el()
                 .set(width(), THUMB_WIDTH)
@@ -288,30 +314,10 @@ impl ElementComponent for Slider {
                     world.resource(window_ctl()).send(WindowCtl::SetCursorIcon(CursorIcon::Default)).ok();
                 });
 
-            if let Some(on_change_factor) = on_change_factor.clone() {
+            if is_moveable {
                 thumb
-                    .on_mouse_down(move |world, id, _| {
-                        let on_change_factor = on_change_factor.clone();
-                        let scale_factor = *world.resource(window_scale_factor());
-                        let start_pos = *world.resource(mouse_position()) / scale_factor as f32;
-                        let screen_min = start_pos.x - block_left_offset;
-                        let screen_max = screen_min + slider_width - THUMB_WIDTH;
-                        world
-                            .add_component(
-                                id,
-                                on_event(),
-                                EventDispatcher::new_with(Arc::new(move |world, id, event| match event {
-                                    Event::WindowEvent { event: WindowEvent::CursorMoved { position, .. }, .. } => {
-                                        let x = position.x as f32 / scale_factor as f32;
-                                        on_change_factor(interpolate_clamped(x, screen_min, screen_max, 0., 1.));
-                                    }
-                                    Event::WindowEvent { event: WindowEvent::MouseInput { state: ElementState::Released, .. }, .. } => {
-                                        world.remove_component(id, on_event()).unwrap();
-                                    }
-                                    _ => {}
-                                })),
-                            )
-                            .unwrap();
+                    .on_mouse_down(move |_world, _id, _| {
+                        *dragging.lock() = true;
                     })
                     .el()
             } else {
@@ -320,27 +326,7 @@ impl ElementComponent for Slider {
         };
 
         FlowRow::el([
-            UIBase
-                .el()
-                .set(width(), slider_width)
-                .set(height(), SLIDER_HEIGHT)
-                .children(vec![rectangle, thumb])
-                .with_clickarea()
-                .on_mouse_up(move |world, id, button| {
-                    if let Some(on_change_factor) = on_change_factor.clone() {
-                        if button != MouseButton::Left {
-                            return;
-                        }
-                        let scale_factor = *world.resource(window_scale_factor());
-                        let mouse_pos = *world.resource(mouse_position()) / scale_factor as f32;
-
-                        let screen_to_local = world.get(id, ambient_core::transform::mesh_to_world()).unwrap_or_default().inverse();
-                        let mouse_pos_relative = screen_to_local * Vec4::from((mouse_pos, 0.0, 1.0));
-
-                        on_change_factor((mouse_pos_relative.x / slider_width).saturate());
-                    }
-                })
-                .el(),
+            UIBase.el().set(width(), slider_width).set(height(), SLIDER_HEIGHT).children(vec![rectangle, thumb]),
             FlowRow::el([f32::edit_or_view(value, on_change_raw, EditorOpts::default()), suffix.map(Text::el).unwrap_or_default()]),
         ])
         .set(space_between_items(), STREET)

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -17,7 +17,7 @@ use ambient_element::{
     define_el_function_for_vec_element_newtype, element_component, Element, ElementComponent, ElementComponentExt, Hooks,
 };
 use ambient_input::{
-    on_app_mouse_input, on_app_mouse_motion, on_app_mouse_wheel,
+    event_mouse_input, on_app_mouse_motion, on_app_mouse_wheel,
     picking::{mouse_pickable, on_mouse_enter, on_mouse_hover, on_mouse_input, on_mouse_leave, on_mouse_wheel},
 };
 pub use ambient_std::{cb, Cb};
@@ -295,7 +295,12 @@ define_el_function_for_vec_element_newtype!(FocusRoot);
 impl ElementComponent for FocusRoot {
     fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
         let set_focus = hooks.provide_context(|| Focus(None));
-        Element::new().listener(on_app_mouse_input(), Arc::new(move |_, _, _| set_focus(Focus(None)))).children(self.0)
+        hooks.use_world_event(move |_world, event| {
+            if let Some(_event) = event.get_ref(event_mouse_input()) {
+                set_focus(Focus(None));
+            }
+        });
+        Element::new().children(self.0)
     }
 }
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -18,7 +18,7 @@ use ambient_element::{
 };
 use ambient_input::{
     event_mouse_input, event_mouse_motion, event_mouse_wheel,
-    picking::{mouse_over, mouse_pickable, on_mouse_enter, on_mouse_hover, on_mouse_input, on_mouse_leave, on_mouse_wheel},
+    picking::{mouse_over, mouse_pickable},
 };
 pub use ambient_std::{cb, Cb};
 use ambient_std::{color::Color, shapes::AABB};

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -7,9 +7,7 @@ use std::{
     },
 };
 
-use ambient_core::{
-    hierarchy::children, on_window_event, transform::*, window::WindowCtl, window_ctl, window_logical_size, window_physical_size,
-};
+use ambient_core::{hierarchy::children, transform::*, window::WindowCtl, window_ctl, window_logical_size, window_physical_size};
 pub use ambient_ecs::{EntityId, SystemGroup, World};
 pub use ambient_editor_derive::ElementEditor;
 pub use ambient_element as element;
@@ -26,7 +24,7 @@ use glam::*;
 use itertools::Itertools;
 use parking_lot::Mutex;
 use winit::{
-    event::{ElementState, ModifiersState, MouseButton, MouseScrollDelta, WindowEvent},
+    event::{ElementState, ModifiersState, MouseButton, MouseScrollDelta},
     window::CursorGrabMode,
 };
 

--- a/crates/ui/src/screens.rs
+++ b/crates/ui/src/screens.rs
@@ -37,7 +37,8 @@ impl ElementComponent for ScreenContainer {
             UIBase.el().set(screen(), ()).children(vec![WindowSized(vec![Dock(vec![content]).el().set(translation(), vec3(0., 0., 0.1))])
                 .el()
                 .with_background(*app_background_color().set_a(0.99))
-                .with_clickarea()])
+                .with_clickarea()
+                .el()])
         } else {
             Element::new()
         }
@@ -53,6 +54,7 @@ impl ElementComponent for PageScreen {
             .el()
             .with_background(*app_background_color().set_a(0.99))
             .with_clickarea()
+            .el()
     }
 }
 
@@ -64,5 +66,6 @@ impl ElementComponent for DialogScreen {
             .el()
             .with_background(*app_background_color().set_a(0.99))
             .with_clickarea()
+            .el()
     }
 }

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -1,10 +1,7 @@
-use std::sync::Arc;
-
-use ambient_core::on_window_event;
 use ambient_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 use ambient_std::Cb;
 use closure::closure;
-use winit::event::{ElementState, WindowEvent};
+use winit::event::ElementState;
 
 use super::{Button, ButtonStyle, FlowColumn, FlowRow, Text, UIExt};
 use crate::{

--- a/crates/ui/src/text_input.rs
+++ b/crates/ui/src/text_input.rs
@@ -95,6 +95,7 @@ pub fn TextInput(
     .set(min_width(), 3.)
     .set(min_height(), 13.)
     .on_spawned(move |_, id| set_self_id(id))
+    .with_clickarea()
     .on_mouse_up(move |_, id, _| {
         set_focus(Focus(Some(id)));
     })
@@ -103,7 +104,8 @@ pub fn TextInput(
     })
     .on_mouse_leave(|world, _| {
         world.resource(window_ctl()).send(WindowCtl::SetCursorIcon(CursorIcon::Default)).ok();
-    });
+    })
+    .el();
 
     if focused {
         el.set(align_horizontal(), Align::End).children(vec![Cursor.el()])

--- a/crates/ui/src/text_input.rs
+++ b/crates/ui/src/text_input.rs
@@ -1,4 +1,4 @@
-use std::{self, sync::Arc, time::Duration};
+use std::{self, time::Duration};
 
 use ambient_core::{transform::translation, window::WindowCtl, window_ctl};
 use ambient_ecs::EntityId;

--- a/crates/wasm/src/server/mod.rs
+++ b/crates/wasm/src/server/mod.rs
@@ -78,7 +78,7 @@ pub fn systems<
                     run_all(
                         world,
                         state_component,
-                        &RunContext::new(world, &event.name, event.data),
+                        &RunContext::new(world, "world_event", event),
                     );
                 }
             })),

--- a/crates/wasm/src/shared/implementation/event.rs
+++ b/crates/wasm/src/shared/implementation/event.rs
@@ -1,20 +1,18 @@
 use crate::shared::host_guest_state::BaseHostGuestState;
+use ambient_core::name;
+use ambient_ecs::world_events;
 use ambient_ecs::EntityData;
-use ambient_ecs::{world_events, WorldEvent};
 
 pub fn subscribe(shared_state: &mut BaseHostGuestState, name: &str) {
     shared_state.subscribed_events.insert(name.to_string());
 }
 
-pub fn send(shared_state: &mut BaseHostGuestState, name: &str, data: EntityData) {
-    if name.starts_with("core/") {
+pub fn send(shared_state: &mut BaseHostGuestState, event_name: &str, data: EntityData) {
+    if event_name.starts_with("core/") {
         return;
     }
     shared_state
         .world_mut()
         .resource_mut(world_events())
-        .add_event(WorldEvent {
-            name: name.to_string(),
-            data,
-        });
+        .add_event(data.set(name(), event_name.to_string()));
 }


### PR DESCRIPTION
This removes a lot of EventDispatcher components, and the Element::listener method, in preparation of making the `ambient_element` crate runnable on the guest side too.