### PR TITLE
feat: Entity::assert_all() (resolves #200)

### DIFF
--- a/crates/ecs/src/entity.rs
+++ b/crates/ecs/src/entity.rs
@@ -177,8 +177,10 @@ impl Entity {
     /// Example:
     ///
     /// ```should_panic
-    /// # components!("doctest, {my_non_networked_component: String}")
-    /// let entity = Entity::new().set(my_non_networked_component(), "Can't serialize me!");
+    /// # use ambient_ecs::{components, Entity, Networked};
+    /// # components!("doctest", {my_non_networked_component: String,});
+    /// # init_components();
+    /// let entity = Entity::new().with(my_non_networked_component(), "Can't serialize me!".into());
     /// entity.assert_all(Networked);
     /// ```
     ///

--- a/crates/ecs/src/entity.rs
+++ b/crates/ecs/src/entity.rs
@@ -1,19 +1,15 @@
 use std::{
-    self,
-    fmt::{self, Debug},
-    iter::Flatten,
+    self, fmt::{self, Debug}, iter::Flatten
 };
 
 use ambient_std::sparse_vec::SparseVec;
 use itertools::Itertools;
 use serde::{
-    de::{self, DeserializeSeed, MapAccess, Visitor},
-    ser::SerializeMap,
-    Deserialize, Deserializer, Serialize, Serializer,
+    de::{self, DeserializeSeed, MapAccess, Visitor}, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer
 };
 
 use super::{with_component_registry, Component, ComponentValue, ECSError, EntityId, World};
-use crate::{ComponentDesc, ComponentEntry, ComponentSet, ECSDeserializationWarnings, Serializable};
+use crate::{ComponentAttribute, ComponentDesc, ComponentEntry, ComponentSet, ECSDeserializationWarnings, Serializable};
 
 #[derive(Clone)]
 pub struct Entity {
@@ -171,6 +167,27 @@ impl Entity {
     }
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Asserts that all components in this Entity have the provided attribute.
+    ///
+    /// # Panics
+    /// Will panic if this Entity has any components that do NOT have the provided attribute.
+    ///
+    /// Example:
+    ///
+    /// ```should_panic
+    /// # components!("doctest, {my_non_networked_component: String}")
+    /// let entity = Entity::new().set(my_non_networked_component(), "Can't serialize me!");
+    /// entity.assert_all(Networked);
+    /// ```
+    ///
+    pub fn assert_all<A: ComponentAttribute>(&self, attribute: A) {
+        for comp in self.components() {
+            if !comp.has_attribute::<A>() {
+                panic!("Component {} does not have attribute {}", comp.type_name(), attribute.type_name());
+            }
+        }
     }
 }
 impl Default for Entity {


### PR DESCRIPTION
This adds a function for asserting that all components of an `Entity` have a given attribute, panicking if any do not. Suggested by @ten3roberts in #200.