### PR TITLE
Add Dump UI World button and remap hotkeys

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -9,7 +9,6 @@ use ambient_core::{
     camera::camera_systems,
     frame_index,
     gpu_ecs::{gpu_world, GpuWorld, GpuWorldSyncEvent, GpuWorldUpdate},
-    hierarchy::dump_world_hierarchy_to_tmp_file,
     remove_at_time_system, runtime, time,
     transform::TransformSystem,
     window::cursor_position,
@@ -610,9 +609,7 @@ impl System<Event<'static, ()>> for ExamplesSystem {
                     },
                 ..
             } => match virtual_keycode {
-                VirtualKeyCode::F1 => dump_world_hierarchy_to_tmp_file(world),
-                VirtualKeyCode::F2 => world.dump_to_tmp_file(),
-                VirtualKeyCode::F3 => world.resource(examples_renderer()).lock().dump_to_tmp_file(),
+                VirtualKeyCode::F9 => world.resource(examples_renderer()).lock().dump_to_tmp_file(),
                 _ => {}
             },
             _ => {}

--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -55,6 +55,15 @@ pub fn Debugger(hooks: &mut Hooks, get_state: GetDebuggerState) -> Element {
             .hotkey(VirtualKeyCode::F1)
             .style(ButtonStyle::Flat)
             .el(),
+            Button::new("Dump UI World", {
+                move |world| {
+                    dump_world_hierarchy_to_tmp_file(world);
+                }
+            })
+            .hotkey_modifier(ModifiersState::SHIFT)
+            .hotkey(VirtualKeyCode::F2)
+            .style(ButtonStyle::Flat)
+            .el(),
             Button::new("Dump Client World", {
                 let get_state = get_state.clone();
                 move |_world| {
@@ -62,7 +71,7 @@ pub fn Debugger(hooks: &mut Hooks, get_state: GetDebuggerState) -> Element {
                 }
             })
             .hotkey_modifier(ModifiersState::SHIFT)
-            .hotkey(VirtualKeyCode::F1)
+            .hotkey(VirtualKeyCode::F3)
             .style(ButtonStyle::Flat)
             .el(),
             Button::new("Dump Server World", {
@@ -81,7 +90,7 @@ pub fn Debugger(hooks: &mut Hooks, get_state: GetDebuggerState) -> Element {
                 }
             })
             .hotkey_modifier(ModifiersState::SHIFT)
-            .hotkey(VirtualKeyCode::F6)
+            .hotkey(VirtualKeyCode::F4)
             .style(ButtonStyle::Flat)
             .el(),
             Button::new("Dump Client Renderer", {
@@ -96,7 +105,7 @@ pub fn Debugger(hooks: &mut Hooks, get_state: GetDebuggerState) -> Element {
                 }
             })
             .hotkey_modifier(ModifiersState::SHIFT)
-            .hotkey(VirtualKeyCode::F3)
+            .hotkey(VirtualKeyCode::F5)
             .style(ButtonStyle::Flat)
             .el(),
             Button::new("Show Shadow Frustums", {
@@ -128,7 +137,7 @@ pub fn Debugger(hooks: &mut Hooks, get_state: GetDebuggerState) -> Element {
                 }
             })
             .hotkey_modifier(ModifiersState::SHIFT)
-            .hotkey(VirtualKeyCode::F4)
+            .hotkey(VirtualKeyCode::F6)
             .style(ButtonStyle::Flat)
             .el(),
             Button::new("Show World Boundings", {
@@ -144,17 +153,19 @@ pub fn Debugger(hooks: &mut Hooks, get_state: GetDebuggerState) -> Element {
                 }
             })
             .hotkey_modifier(ModifiersState::SHIFT)
-            .hotkey(VirtualKeyCode::F5)
+            .hotkey(VirtualKeyCode::F7)
             .style(ButtonStyle::Flat)
             .el(),
-            ShaderDebug { get_state: get_state.clone() }.el(),
             Button::new("Show Shadow Maps", {
                 move |_| {
                     set_show_shadows(!show_shadows);
                 }
             })
+            .hotkey_modifier(ModifiersState::SHIFT)
+            .hotkey(VirtualKeyCode::F8)
             .style(ButtonStyle::Flat)
             .el(),
+            ShaderDebug { get_state: get_state.clone() }.el(),
         ])
         .el()
         .set(space_between_items(), 5.),
@@ -221,8 +232,6 @@ fn ShaderDebug(hooks: &mut Hooks, get_state: GetDebuggerState) -> Element {
     Dropdown {
         content: Button::new("Shader Debug", move |_| set_show(!show))
             .toggled(show)
-            .hotkey(VirtualKeyCode::F7)
-            .hotkey_modifier(ModifiersState::SHIFT)
             .el(),
         dropdown: FlowColumn::el([
             Button::new("Show metallic roughness", {

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -85,6 +85,11 @@ impl System<Event<'static, ()>> for InputSystem {
                     world.resource_mut(world_events()).add_event(Entity::new().with(event_received_character(), *c));
                 }
 
+                WindowEvent::ModifiersChanged(mods) => {
+                    self.modifiers = *mods;
+                    world.resource_mut(world_events()).add_event(Entity::new().with(event_modifiers_change(), *mods));
+                }
+
                 WindowEvent::KeyboardInput { input, .. } => {
                     let event = KeyboardEvent {
                         scancode: input.scancode,
@@ -130,9 +135,6 @@ impl System<Event<'static, ()>> for InputSystem {
                             )
                             .with(event_mouse_wheel_pixels(), matches!(delta, MouseScrollDelta::PixelDelta(..))),
                     );
-                }
-                WindowEvent::ModifiersChanged(mods) => {
-                    world.resource_mut(world_events()).add_event(Entity::new().with(event_modifiers_change(), *mods));
                 }
 
                 _ => {}

--- a/crates/ui/src/button.rs
+++ b/crates/ui/src/button.rs
@@ -400,24 +400,19 @@ impl ElementComponent for Hotkey {
             move |world, event| {
                 if let Some(event) = event.get_ref(event_keyboard_input()) {
                     if let KeyboardEvent { keycode: Some(virtual_keycode), state, modifiers, .. } = event {
-                        if virtual_keycode == &hotkey {
+                        let shortcut_pressed = modifiers == &hotkey_modifier && virtual_keycode == &hotkey;
+                        if shortcut_pressed {
+                            on_invoke.0(world);
                             if state == &ElementState::Pressed {
-                                if modifiers == &hotkey_modifier {
-                                    if let Some(on_is_pressed_changed) = on_is_pressed_changed.clone() {
-                                        on_is_pressed_changed.0(true);
-                                    }
-                                    is_pressed.store(true, Ordering::Relaxed);
+                                if let Some(on_is_pressed_changed) = on_is_pressed_changed.clone() {
+                                    on_is_pressed_changed.0(true);
                                 }
+                                is_pressed.store(true, Ordering::Relaxed);
                             } else {
-                                let pressed = is_pressed.load(Ordering::Relaxed);
-
-                                if pressed {
-                                    on_invoke.0(world);
-                                    if let Some(on_is_pressed_changed) = on_is_pressed_changed.clone() {
-                                        on_is_pressed_changed.0(false);
-                                    }
-                                    is_pressed.store(false, Ordering::Relaxed);
+                                if let Some(on_is_pressed_changed) = on_is_pressed_changed.clone() {
+                                    on_is_pressed_changed.0(false);
                                 }
+                                is_pressed.store(false, Ordering::Relaxed);
                             }
                         }
                     }


### PR DESCRIPTION
Fixes https://github.com/AmbientRun/Ambient/issues/193.

There was a bug that prevented `hotkey_modifier` from working, the modifiers weren't being set in the keyboard event.
I decided not to implement the write_debug function in this commit since I would rather not involve it in a minor feature such as this.