### PR TITLE
Update quinn to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5221,16 +5221,16 @@ checksum = "658fa1faf7a4cc5f057c9ee5ef560f717ad9d8dc66d975267f709624d6e1ab88"
 
 [[package]]
 name = "quinn"
-version = "0.8.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b435e71d9bfa0d8889927231970c51fb89c58fa63bffcab117c9c7a41e5ef8f"
+checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
 dependencies = [
  "bytes",
- "futures-channel",
- "futures-util",
- "fxhash",
+ "futures-io",
+ "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
+ "rustc-hash",
  "rustls",
  "thiserror",
  "tokio",
@@ -5240,17 +5240,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce546b9688f767a57530652488420d419a8b1f44a478b451c3d1ab6d992a55"
+checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
 dependencies = [
  "bytes",
- "fxhash",
  "rand 0.8.5",
  "ring",
+ "rustc-hash",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile 0.2.1",
  "slab",
  "thiserror",
  "tinyvec",
@@ -5260,16 +5259,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.1.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07946277141531aea269befd949ed16b2c85a780ba1043244eda0969e538e54"
+checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
 dependencies = [
- "futures-util",
  "libc",
  "quinn-proto",
  "socket2",
- "tokio",
  "tracing",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5519,7 +5517,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile 1.0.2",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5695,18 +5693,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.2",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
-dependencies = [
- "base64 0.13.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ env_logger = "0.10.0"
 async-recursion = "1.0.0"
 anyhow = { version = "1.0", features = ["backtrace"] }
 bitflags = "1.3"
-quinn = "0.8.5"
+quinn = { version = "0.9", features = ["futures-io"] }
 rustls = { version = "0.20.6", features = ["dangerous_configuration", "quic"] }
 parking_lot = { version = "0.12.0", features = ["serde"] }
 clap = { version = "4.0", features = ["derive"] }

--- a/crates/network/src/protocol.rs
+++ b/crates/network/src/protocol.rs
@@ -1,13 +1,13 @@
 use ambient_ecs::{ComponentRegistry, ExternalComponentDesc, WorldDiff};
 use anyhow::{Context, Result};
-use futures::{io::BufReader, StreamExt};
-use quinn::{NewConnection, RecvStream};
+use futures::io::BufReader;
+use quinn::{Connection, RecvStream};
 
 use crate::{next_bincode_bi_stream, open_bincode_bi_stream, IncomingStream, NetworkError, OutgoingStream};
 
 #[derive(Debug)]
 pub struct ClientProtocol {
-    pub(crate) conn: NewConnection,
+    pub(crate) conn: Connection,
     pub(crate) stat_stream: IncomingStream,
     client_info: ClientInfo,
     pub(crate) diff_stream: IncomingStream,
@@ -16,11 +16,11 @@ pub struct ClientProtocol {
 }
 
 impl ClientProtocol {
-    pub async fn new(mut conn: NewConnection, player_id: String) -> Result<Self> {
+    pub async fn new(mut conn: Connection, player_id: String) -> Result<Self> {
         // Say who we are
         // The server will respond appropriately and return things such as
         // username (TODO)
-        let (mut tx, mut rx) = open_bincode_bi_stream(&conn.connection).await?;
+        let (mut tx, mut rx) = open_bincode_bi_stream(&conn).await?;
         tx.send(&player_id).await?;
 
         // The server will acknowledge and send the credentials back
@@ -46,7 +46,7 @@ impl ClientProtocol {
     }
 
     pub async fn next_event(&mut self) -> anyhow::Result<BufReader<RecvStream>> {
-        let stream = self.conn.uni_streams.next().await.ok_or(NetworkError::EndOfStream).context("Event stream closed")??;
+        let stream = self.conn.accept_uni().await.map_err(NetworkError::from).context("Event stream closed")?;
 
         let stream = BufReader::new(stream);
         Ok(stream)
@@ -57,17 +57,13 @@ impl ClientProtocol {
     }
 
     pub(crate) fn connection(&self) -> quinn::Connection {
-        self.conn.connection.clone()
-    }
-
-    pub fn uni_streams(&self) -> &quinn::IncomingUniStreams {
-        &self.conn.uni_streams
+        self.conn.clone()
     }
 }
 
 /// The server side protocol instantiation of the client communication
 pub struct ServerProtocol {
-    pub(crate) conn: NewConnection,
+    pub(crate) conn: Connection,
 
     pub(crate) diff_stream: OutgoingStream,
     pub(crate) stat_stream: OutgoingStream,
@@ -75,9 +71,9 @@ pub struct ServerProtocol {
 }
 
 impl ServerProtocol {
-    pub async fn new(mut conn: NewConnection, server_info: ServerInfo) -> Result<Self, NetworkError> {
+    pub async fn new(conn: Connection, server_info: ServerInfo) -> Result<Self, NetworkError> {
         // The client now sends the player id
-        let (mut tx, mut rx) = next_bincode_bi_stream(&mut conn).await?;
+        let (mut tx, mut rx) = next_bincode_bi_stream(&conn).await?;
 
         let user_id: String = rx.next().await?;
 
@@ -94,10 +90,10 @@ impl ServerProtocol {
         tx.send(&server_info).await?;
 
         // Great, now open all required streams
-        let mut diff_stream = OutgoingStream::open_uni(&conn.connection).await?;
+        let mut diff_stream = OutgoingStream::open_uni(&conn).await?;
         // Send "something" to notify the client of the new stream
         diff_stream.send(&()).await?;
-        let mut stat_stream = OutgoingStream::open_uni(&conn.connection).await?;
+        let mut stat_stream = OutgoingStream::open_uni(&conn).await?;
         stat_stream.send(&()).await?;
 
         Ok(Self { conn, diff_stream, stat_stream, client_info })


### PR DESCRIPTION
Newer version has a bit nicer API.

It uses custom futures instead of stream so in many cases one can get away with immutable borrows (stream needs mut) and there's no need for extra `Option` that comes from using stream's `next()` directly.