### PR TITLE
rotate the camera without right click

### DIFF
--- a/guest/rust/examples/games/minigolf/src/client.rs
+++ b/guest/rust/examples/games/minigolf/src/client.rs
@@ -5,11 +5,7 @@ fn main() {
     ambient_api::messages::Frame::subscribe(move |_| {
         let (delta, input) = player::get_raw_input_delta();
 
-        let camera_rotation = if input.mouse_buttons.contains(&MouseButton::Right) {
-            delta.mouse_position
-        } else {
-            Vec2::ZERO
-        };
+        let camera_rotation = delta.mouse_position;
 
         let camera_zoom = delta.mouse_wheel;
         let shoot = delta.mouse_buttons.contains(&MouseButton::Left);

--- a/guest/rust/examples/games/minigolf/src/client.rs
+++ b/guest/rust/examples/games/minigolf/src/client.rs
@@ -3,7 +3,7 @@ use ambient_api::{components::core::physics::linear_velocity, player::MouseButto
 #[main]
 fn main() {
     ambient_api::messages::Frame::subscribe(move |_| {
-        let (delta, input) = player::get_raw_input_delta();
+        let (delta, _input) = player::get_raw_input_delta();
 
         let camera_rotation = delta.mouse_position;
 


### PR DESCRIPTION
It would be more intuitive if the camera can rotate by mouse moving immediately since there is no text description. When I approached this demo, I had some difficulties figuring out how to rotate the camera. `MouseButton::Right` doesn't seem to work for me as I use BetterTouchTool's two-finger tap as a right click and disable Mac Trackpad's secondary click in Mac preferences. May need to open another issue if anyone else reports.