### PR TITLE
refactor(element): implicitly box return fns

### DIFF
--- a/app/src/client/mod.rs
+++ b/app/src/client/mod.rs
@@ -182,7 +182,7 @@ fn GoldenImageTest(hooks: &mut Hooks, project_path: Option<PathBuf>, seconds: f3
             exit(1);
         });
 
-        Box::new(|_| {})
+        |_| {}
     });
     Element::new()
 }

--- a/crates/editor/src/ui/build_mode/entity_browser.rs
+++ b/crates/editor/src/ui/build_mode/entity_browser.rs
@@ -40,7 +40,7 @@ impl ElementComponent for EntityBrowser {
             let all_tags = entities.iter().flat_map(|entity| &entity.2).sorted().dedup().cloned().collect_vec();
             set_entities(entities);
             set_all_tags(all_tags);
-            Box::new(|_| {})
+            |_| {}
         });
         FlowColumn::el([
             FlowRow(

--- a/crates/editor/src/ui/build_mode/guide.rs
+++ b/crates/editor/src/ui/build_mode/guide.rs
@@ -79,9 +79,9 @@ impl ElementComponent for GridGuide {
         {
             let game_state = game_client.game_state.clone();
             hooks.use_spawn(move |_| {
-                Box::new(move |_| {
+                move |_| {
                     game_state.lock().world.despawn(entity);
-                })
+                }
             });
         }
 
@@ -92,7 +92,7 @@ impl ElementComponent for GridGuide {
             let transform = Mat4::from_scale_rotation_translation(Vec3::splat(BLUEBOARD_SIZE), rotation, point);
             state.world.set(entity, local_to_world(), transform).expect("Entity was despawned");
 
-            Box::new(|_| {})
+            |_| {}
         });
 
         Element::new()
@@ -124,9 +124,9 @@ impl ElementComponent for AxisGuide {
         {
             let game_state = game_client.game_state.clone();
             hooks.use_spawn(move |_| {
-                Box::new(move |_| {
+                move |_| {
                     game_state.lock().world.despawn(entity);
-                })
+                }
             });
         }
 

--- a/crates/editor/src/ui/build_mode/select_area.rs
+++ b/crates/editor/src/ui/build_mode/select_area.rs
@@ -33,11 +33,11 @@ impl ElementComponent for SelectArea {
 
         let client = game_client.clone();
         hooks.use_spawn(move |_| {
-            Box::new(move |w| {
+            move |w| {
                 w.resource(runtime()).spawn(async move {
                     log_network_result!(client.rpc(rpc_select, (SelectMethod::Manual(Default::default()), SelectMode::Clear)).await);
                 });
-            })
+            }
         });
 
         hooks.use_runtime_message::<messages::WindowMouseMotion>(move |world, event| {

--- a/crates/editor/src/ui/mod.rs
+++ b/crates/editor/src/ui/mod.rs
@@ -122,7 +122,7 @@ pub fn EditorUI(hooks: &mut Hooks) -> Element {
                     log_network_result!(game_client.rpc(rpc_join_instance, MAIN_INSTANCE_ID.to_string()).await);
                 }
             });
-            Box::new(|_| {})
+            |_| {}
         }
     });
 

--- a/crates/editor/src/ui/terrain_mode.rs
+++ b/crates/editor/src/ui/terrain_mode.rs
@@ -84,9 +84,9 @@ impl ElementComponent for TerrainRaycastPicker {
                 .spawn_static(&mut game_state.lock().world);
 
             set_vis_brush_id(Some(new_vis_brush_id));
-            Box::new(move |_ui_world| {
+            move |_ui_world| {
                 game_state.lock().world.despawn(new_vis_brush_id);
-            })
+            }
         });
         hooks.use_runtime_message::<messages::WindowMouseInput>({
             let set_mousedown = set_mousedown.clone();

--- a/crates/network/src/client.rs
+++ b/crates/network/src/client.rs
@@ -353,7 +353,7 @@ impl ElementComponent for GameClientView {
         // When the GameClientView is despawned, stop the task.
         {
             let task = task.clone();
-            hooks.use_spawn(move |_| Box::new(move |_| task.abort()));
+            hooks.use_spawn(move |_| move |_| task.abort());
         }
 
         if let Some(err) = error {

--- a/crates/terrain/src/lib.rs
+++ b/crates/terrain/src/lib.rs
@@ -657,7 +657,7 @@ pub fn use_async_asset<T: Asset + Clone + Sync + Send + std::fmt::Debug + 'stati
         world.resource(runtime()).spawn(async move {
             set_value(Some(asset_key.get(&assets).await));
         });
-        Box::new(|_| {})
+        |_| {}
     });
     value
 }
@@ -707,7 +707,7 @@ impl ElementComponent for Terrain {
         //                 Err(err) => log::error!("Failed to load terrain textures: {:?}", err)
         //             }
         //         });
-        //         Box::new(|_| {})
+        //         |_| {}
         //     }),
         // );
         hooks.use_frame(closure!(clone material_def, |world| {

--- a/crates/ui_native/src/lib.rs
+++ b/crates/ui_native/src/lib.rs
@@ -83,13 +83,13 @@ pub fn HighjackMouse(
             ctl.send(WindowCtl::GrabCursor(CursorGrabMode::Locked)).ok();
             ctl.send(WindowCtl::ShowCursor(false)).ok();
         }
-        Box::new(move |world| {
+        move |world| {
             if hide_mouse {
                 let ctl = world.resource(window_ctl());
                 ctl.send(WindowCtl::GrabCursor(CursorGrabMode::None)).ok();
                 ctl.send(WindowCtl::ShowCursor(true)).ok();
             }
-        })
+        }
     });
 
     hooks.use_runtime_message::<messages::WindowMouseMotion>({

--- a/guest/rust/examples/basics/skinmesh/src/client.rs
+++ b/guest/rust/examples/basics/skinmesh/src/client.rs
@@ -65,7 +65,7 @@ fn App(hooks: &mut Hooks, unit: EntityId) -> Element {
             },
         );
 
-        Box::new(|_| {})
+        |_| {}
     });
 
     FocusRoot::el([FlowRow::el([

--- a/shared_crates/element/src/hooks.rs
+++ b/shared_crates/element/src/hooks.rs
@@ -157,9 +157,13 @@ impl<'a> Hooks<'a> {
     /// Execute a function upon the world the first time is mounted, E.g;
     /// rendered.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub fn use_spawn<F: FnOnce(&mut World) -> DespawnFn + Sync + Send + 'static>(&mut self, func: F) {
+    pub fn use_spawn<F: FnOnce(&mut World) -> R + Sync + Send + 'static, R: FnOnce(&mut World) + Sync + Send + 'static>(
+        &mut self,
+        func: F,
+    ) {
         if let Some(ref mut on_spawn) = self.on_spawn {
-            on_spawn.push(Box::new(func) as SpawnFn);
+            let spawn_fn: SpawnFn = Box::new(move |w| Box::new(func(w)));
+            on_spawn.push(spawn_fn);
         }
     }
 
@@ -190,7 +194,7 @@ impl<'a> Hooks<'a> {
                 let listener = T::subscribe(move |event| {
                     (handler.lock().as_ref().unwrap())(&mut World, &event);
                 });
-                Box::new(|_| listener.stop())
+                |_| listener.stop()
             });
         }
     }
@@ -234,7 +238,7 @@ impl<'a> Hooks<'a> {
                 set_state(Some(res))
             });
 
-            Box::new(move |_| task.abort())
+            move |_| task.abort()
         });
 
         state
@@ -351,10 +355,10 @@ impl<'a> Hooks<'a> {
     ///
     /// The provided functions returns a function which is run when the part is
     /// removed or `use_effect` is run again.
-    pub fn use_effect<D: PartialEq + Debug + Sync + Send + 'static>(
+    pub fn use_effect<D: PartialEq + Debug + Sync + Send + 'static, R: FnOnce(&mut World) + Sync + Send + 'static>(
         &mut self,
         dependencies: D,
-        run: impl FnOnce(&mut World, &D) -> Box<dyn FnOnce(&mut World) + Sync + Send> + Sync + Send,
+        run: impl FnOnce(&mut World, &D) -> R + Sync + Send,
     ) {
         struct Cleanup(Box<dyn FnOnce(&mut World) + Sync + Send>);
         impl Debug for Cleanup {
@@ -367,12 +371,12 @@ impl<'a> Hooks<'a> {
         {
             let cleanup_prev = cleanup_prev.clone();
             self.use_spawn(move |_| {
-                Box::new(move |world| {
+                move |world| {
                     let mut cleanup_prev = cleanup_prev.lock();
                     if let Some(cleanup_prev) = cleanup_prev.take() {
                         cleanup_prev.0(world);
                     }
-                })
+                }
             });
         }
 
@@ -384,7 +388,7 @@ impl<'a> Hooks<'a> {
                 cleanup_prev.0(self.world);
             }
             profiling::scope!("use_effect_run");
-            *cleanup_prev = Some(Cleanup(run(self.world, &dependencies)));
+            *cleanup_prev = Some(Cleanup(Box::new(run(self.world, &dependencies))));
             *prev_deps = Some(dependencies);
         }
     }
@@ -430,11 +434,11 @@ impl<'a> Hooks<'a> {
                 let refresh = refresh.clone();
                 move |_| refresh()
             });
-            Box::new(|_| {
+            |_| {
                 s.stop();
                 d.stop();
                 c.stop();
-            })
+            }
         });
         query.evaluate()
     }
@@ -450,9 +454,9 @@ impl<'a> Hooks<'a> {
                     cb();
                 }
             });
-            Box::new(move |_| {
+            move |_| {
                 thread.abort();
-            })
+            }
         });
         #[cfg(feature = "guest")]
         self.use_spawn(move |world| {
@@ -468,9 +472,9 @@ impl<'a> Hooks<'a> {
                     }
                 });
             }
-            Box::new(move |_| {
+            move |_| {
                 exit.store(true, std::sync::atomic::Ordering::SeqCst);
-            })
+            }
         });
     }
 
@@ -498,9 +502,9 @@ impl<'a> Hooks<'a> {
                 }
             });
 
-            Box::new(move |_| {
+            move |_| {
                 task.abort();
-            })
+            }
         });
         #[cfg(feature = "guest")]
         self.use_effect(dependencies.clone(), move |world, _| {
@@ -520,9 +524,9 @@ impl<'a> Hooks<'a> {
                     }
                 });
             }
-            Box::new(move |_| {
+            move |_| {
                 exit.store(true, std::sync::atomic::Ordering::SeqCst);
-            })
+            }
         });
     }
 }

--- a/shared_crates/element/tests/hooks.rs
+++ b/shared_crates/element/tests/hooks.rs
@@ -176,9 +176,9 @@ fn use_effect() {
             hooks.use_effect(self.value, |world, _| {
                 *world.resource_mut(counter()) += 1;
                 *world.resource_mut(n_renders()) += 1;
-                Box::new(|world| {
+                |world| {
                     *world.resource_mut(counter()) -= 1;
-                })
+                }
             });
             Element::new()
         }

--- a/shared_crates/ui/src/button.rs
+++ b/shared_crates/ui/src/button.rs
@@ -241,7 +241,7 @@ pub fn Button(
         if let Some(on_is_pressed_changed) = on_is_pressed_changed {
             on_is_pressed_changed(world, is_pressed);
         }
-        Box::new(|_| {})
+        |_| {}
     });
     hooks.use_runtime_message::<messages::WindowMouseInput>({
         to_owned![set_is_pressed, on_invoked, set_is_working];

--- a/shared_crates/ui/src/editor/slider.rs
+++ b/shared_crates/ui/src/editor/slider.rs
@@ -91,7 +91,7 @@ impl ElementComponent for Slider {
                     }
                 }
 
-                Box::new(|_| {})
+                |_| {}
             }
         });
         let block_id = hooks.use_ref_with(|_| EntityId::null());

--- a/shared_crates/ui/src/editor/text_editor.rs
+++ b/shared_crates/ui/src/editor/text_editor.rs
@@ -60,11 +60,11 @@ pub fn TextEditor(
             if auto_focus {
                 set_focused(true);
             }
-            Box::new(move |_| {
+            move |_| {
                 if focused {
                     set_focused(false);
                 }
-            })
+            }
         }
     });
     hooks.use_runtime_message::<messages::WindowKeyboardCharacter>({


### PR DESCRIPTION
While doing #337, I noticed that the `Box`ing could be done automatically for the return functions in `use_spawn` and `use_effect`. Pretty straightforward ergonomics improvement.