### PR TITLE
Improve audio pipeline; audio format convert control

### DIFF
--- a/crates/build/src/pipelines/mod.rs
+++ b/crates/build/src/pipelines/mod.rs
@@ -9,7 +9,7 @@ use image::ImageFormat;
 use out_asset::{OutAsset, OutAssetContent, OutAssetPreview};
 use serde::{Deserialize, Serialize};
 
-use self::{materials::MaterialsPipeline, models::ModelsPipeline};
+use self::{audio::AudioPipeline, materials::MaterialsPipeline, models::ModelsPipeline};
 
 pub mod audio;
 pub mod context;
@@ -27,8 +27,8 @@ pub enum PipelineConfig {
     /// Will import specific materials without needing to be part of a model.
     Materials(MaterialsPipeline),
     /// The audio asset pipeline.
-    /// Will import supported audio file formats and produce Ogg Vorbis files to be used by the runtime.
-    Audio,
+    /// Will import supported audio file formats and produce Ogg Vorbis or WAV files to be used by the runtime.
+    Audio(AudioPipeline),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -53,7 +53,7 @@ impl Pipeline {
         let mut assets = match &self.pipeline {
             PipelineConfig::Models(config) => models::pipeline(&ctx, config.clone()).await,
             PipelineConfig::Materials(config) => materials::pipeline(&ctx, config.clone()).await,
-            PipelineConfig::Audio => audio::pipeline(&ctx).await,
+            PipelineConfig::Audio(config) => audio::pipeline(&ctx, config.clone()).await,
         };
         for asset in &mut assets {
             asset.tags.extend(self.tags.clone());

--- a/docs/src/reference/audio.md
+++ b/docs/src/reference/audio.md
@@ -10,16 +10,36 @@ Check the `assets` folder in the [physics example](https://github.com/AmbientRun
 
 Audio should be loaded and played in clientside WASM/`client.rs` (the API is not supported on the server). [Messages](project.md#messages--messages) can be used by the server to tell the client to play a sound effect.
 
-## Caveat
+# Examples with audio
 
-At present, we support `wav`, `mp3` and `ogg` through `ffmpeg`. Note that if a non-`ogg` format is used, it will be converted to `ogg`, and you will need to use the `ogg` extension in your code.
+- `./guest/rust/examples/basics/physics`
+- `./guest/rust/examples/games/pong`
+- `./guest/rust/examples/games/minigolf`
+- `./guest/rust/examples/games/music_sequencer`
+
+## Deciding whether to convert audio formats
+
+Currently, we support `wav`, `mp3`, and `ogg` audio file formats. If you use an `mp3` format, it will be converted to `ogg` during the build process. However, you can use either ".mp3" or ".ogg" in the `audio::load` function.
 
 ```rust
-// "src/client.rs" in the "pong" example
 #[main]
 pub fn main() {
-    // if your audio file is "bgm.wav", you still need to use "ogg" here
+    // if your audio file is "bgm.mp3", you can use either "mp3" or "ogg" here
     let bgm = audio::load(asset::url("assets/bgm.ogg").unwrap());
     bgm.looping(true).scale(0.2).play();
 }
 ```
+
+In some cases, you may want to explicitly control whether the audio is converted in order to save space or maintain the best audio quality. This is particularly relevant for `wav` files, which are large when unconverted but offer lossless playback. You can manage this setting in the `pipeline.json` file.
+
+```json
+{
+    "pipeline": {
+        "type": "Audio",
+        "convert": false
+    }
+}
+```
+
+If you convert a `wav` file, then you need to use ".ogg" in `audio::load`.
+If the `convert` entry is missing, the default behaviour is no convertion.

--- a/guest/rust/api_core/src/client/audio.rs
+++ b/guest/rust/api_core/src/client/audio.rs
@@ -2,9 +2,10 @@ use crate::internal::wit;
 
 /// Load an audio file from `url`, and return an [AudioTrack] that can be used to play the audio.
 pub fn load(url: String) -> AudioTrack {
-    wit::client_audio::load(&url);
+    let actuall_url = url.replace(".mp3", ".ogg");
+    wit::client_audio::load(&actuall_url);
     AudioTrack {
-        name: url,
+        name: actuall_url,
         looping: false,
         volume: 1.0,
     }

--- a/guest/rust/examples/games/music_sequencer/assets/pipeline.json
+++ b/guest/rust/examples/games/music_sequencer/assets/pipeline.json
@@ -1,7 +1,8 @@
 [
     {
         "pipeline": {
-          "type": "Audio"
+          "type": "Audio",
+          "convert": false
         }
     }
 ]

--- a/guest/rust/examples/games/music_sequencer/src/common.rs
+++ b/guest/rust/examples/games/music_sequencer/src/common.rs
@@ -3,14 +3,14 @@
 use ambient_api::prelude::*;
 
 pub const SOUNDS: [(&str, &str); 8] = [
-    ("Kick Drum", "assets/BD2500.ogg"),
-    ("Snare Drum", "assets/SD7550.ogg"),
-    ("Closed Hihat", "assets/CH.ogg"),
-    ("Open Hihat", "assets/OH75.ogg"),
-    ("Low Conga", "assets/LC00.ogg"),
-    ("Mid Conga", "assets/MC00.ogg"),
-    ("High Tom", "assets/HT75.ogg"),
-    ("Mid Tom", "assets/MT75.ogg"),
+    ("Kick Drum", "assets/BD2500.wav"),
+    ("Snare Drum", "assets/SD7550.wav"),
+    ("Closed Hihat", "assets/CH.wav"),
+    ("Open Hihat", "assets/OH75.wav"),
+    ("Low Conga", "assets/LC00.wav"),
+    ("Mid Conga", "assets/MC00.wav"),
+    ("High Tom", "assets/HT75.wav"),
+    ("Mid Tom", "assets/MT75.wav"),
 ];
 
 pub const BEAT_COUNT: usize = 16;


### PR DESCRIPTION
Since the music sequencer uses some `wav` samples, I picked up the previous unfinished PR: https://github.com/AmbientRun/Ambient/pull/320

Now it's possible to control whether to convert `wav` or use it as is in the pipeline:

```
  {
      "pipeline": {
        "type": "Audio",
        "convert": false
      }
  }
```

I also documented the usage.

For `mp3`, I still feel that it's better to do the replacement in URL if the users still want to use `.mp3`, which is quite natural. There has to be a conversion anyway, so it's better to do the URL check/replacement in case of a 404 error.

`wav` is a different story: if converted, they must use `ogg`, and users should have known this if they specify it in the `pipeline.jons` by themselves.