### PR TITLE
[win32 helper] add a bat file to help listing/building/running the examples on windows

### DIFF
--- a/guest/rust/examples/README.md
+++ b/guest/rust/examples/README.md
@@ -5,3 +5,7 @@ These are examples of Ambient projects written in the Rust programming language.
 Note that they must be run with a matching version of the runtime - if you're using a 0.1.1 runtime, you must use the 0.1.1 examples, and vice versa.
 
 You may encounter unexpected behaviour if you attempt to run the latest versions of the examples (i.e. `HEAD`/`main`) with an older runtime.
+
+# Windows
+
+Provided you have ambient runtime installed on your windows machine, you can use run_samples.bat to list, build and run the examples

--- a/guest/rust/examples/run_samples.bat
+++ b/guest/rust/examples/run_samples.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: loop through all sub-directories in current directory
+for /F "delims=" %%B in ('dir /a:d /b *') do (
+    :: loop through all sub-directories in each sub-directory
+    for /F "delims=" %%A in ('dir /a:d /b %%B') do (
+
+        :: increment count of options
+        set /a count+=1
+        :: store path of option
+        set "options[!count!]=%%B\%%A"
+    )
+)
+
+:: display options
+for /L %%A in (1,1,!count!) do echo [%%A]. !options[%%A]!
+::prompts user input
+echo " --- "
+set /p filechoice="Which ambient example do you want to build and run ?"
+
+:: Location of python.exe and location of python script explicitly stated
+echo Running ambient.exe !options[%filechoice%]!...
+"ambient.exe" run "!options[%filechoice%]!"
+
+pause

--- a/guest/rust/examples/run_samples.bat
+++ b/guest/rust/examples/run_samples.bat
@@ -17,9 +17,8 @@ for /F "delims=" %%B in ('dir /a:d /b *') do (
 for /L %%A in (1,1,!count!) do echo [%%A]. !options[%%A]!
 ::prompts user input
 echo " --- "
-set /p filechoice="Which ambient example do you want to build and run ?"
+set /p filechoice="Which ambient example do you want to build an
 
-:: Location of python.exe and location of python script explicitly stated
 echo Running ambient.exe !options[%filechoice%]!...
 "ambient.exe" run "!options[%filechoice%]!"
 


### PR DESCRIPTION
**Goal :** 
Help windows users build and run the examples easily using their currently installed ambient runtime

**Implementation :**
A simple win32 bat file to be executed in the the [./guest/rust/]examples/ folder (this examples folder is also the one that is zipped upon all major releases - tags)

**Execution :** 
run_samples.bat will display (v0.2.0) :

![run_samples_bat](https://user-images.githubusercontent.com/517663/236669855-a9b7a947-9d64-4c28-8e15-0544cb57185c.png)


