### PR TITLE
Add casts to physxx where c_char is involved

### DIFF
--- a/libs/physxx/src/actor.rs
+++ b/libs/physxx/src/actor.rs
@@ -62,13 +62,13 @@ impl<T: AsPxActor + 'static> PxActor for T {
     }
     fn get_name(&self) -> String {
         unsafe {
-            let p = physx_sys::PxActor_getName(self.as_actor().0);
+            let p = physx_sys::PxActor_getName(self.as_actor().0) as *const std::ffi::c_char;
             CStr::from_ptr(p).to_str().unwrap().to_string()
         }
     }
     /// Note; physx doesn't copy the string, so the string needs to be kept alive somewhere else
     fn set_name(&self, name: &CString) {
-        unsafe { physx_sys::PxActor_setName_mut(self.as_actor().0, name.as_ptr()) }
+        unsafe { physx_sys::PxActor_setName_mut(self.as_actor().0, name.as_ptr() as *const i8) }
     }
 }
 

--- a/libs/physxx/src/serialization.rs
+++ b/libs/physxx/src/serialization.rs
@@ -163,7 +163,7 @@ impl PxDefaultFileOutputStream {
     pub fn new(name: impl AsRef<Path>) -> Self {
         Self(unsafe {
             let name = CString::new(name.as_ref().as_os_str().to_str().unwrap()).unwrap();
-            physx_sys::PxDefaultFileOutputStream_new_alloc(name.as_ptr())
+            physx_sys::PxDefaultFileOutputStream_new_alloc(name.as_ptr() as *const i8)
         })
     }
 }
@@ -185,7 +185,7 @@ impl PxDefaultFileInputData {
     pub fn new(name: impl AsRef<Path>) -> Self {
         Self(unsafe {
             let name = CString::new(name.as_ref().as_os_str().to_str().unwrap()).unwrap();
-            physx_sys::PxDefaultFileInputData_new_alloc(name.as_ptr())
+            physx_sys::PxDefaultFileInputData_new_alloc(name.as_ptr() as *const i8)
         })
     }
 }


### PR DESCRIPTION
Because `c_char` has different signedness on different targets (it's `u8` on aarch64 on linux) but `physx-sys` 0.8.2 uses `i8` in the generated code ([for example here](https://github.com/EmbarkStudios/physx-rs/blob/6b3a94534016270f8f6ebc665cd97ba7ce858d84/physx-sys/src/physx_generated.rs#L2069)).