### PR TITLE
feat(gpu): Simple graphics settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "async-trait",
  "bytemuck",
  "byteorder",
+ "directories",
  "futures",
  "glam 0.22.0",
  "image",
@@ -725,8 +726,10 @@ dependencies = [
  "ndarray",
  "ordered-float",
  "parking_lot",
+ "serde",
  "thiserror",
  "tokio",
+ "toml 0.7.3",
  "tracing",
  "wgpu 0.15.1",
  "wgpu 0.16.0",
@@ -2912,6 +2915,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "directories-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,6 +2931,18 @@ checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5287,6 +5311,12 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ russimp = { version = "1.0.6", features = ['prebuilt'] }
 symphonia = { version = "0.5", default-features = false, features = ["mp3", "pcm", "wav"] }
 vorbis_rs = "0.3.0"
 colored = "2.0.0"
+directories = "5.0.1"
 
 #
 # WASM dependencies. Should be able to move off these once this all begins to stabilise a little.

--- a/crates/gpu/Cargo.toml
+++ b/crates/gpu/Cargo.toml
@@ -32,6 +32,9 @@ futures = { workspace = true }
 parking_lot = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+directories = { workspace = true }
+toml = { workspace = true }
+serde = { workspace = true }
 
 [features]
 hotload-includes = ['ambient_std/hotload-includes']

--- a/crates/gpu/src/lib.rs
+++ b/crates/gpu/src/lib.rs
@@ -5,6 +5,7 @@ pub mod gpu_run;
 pub mod mesh_buffer;
 pub mod mipmap;
 pub mod multi_buffer;
+pub mod settings;
 pub mod shader_module;
 pub mod std_assets;
 pub mod texture;

--- a/crates/gpu/src/settings.rs
+++ b/crates/gpu/src/settings.rs
@@ -1,0 +1,78 @@
+use anyhow::{bail, Context, Result};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Default, Debug)]
+pub struct Settings {
+    #[serde(default)]
+    resolution: Resolution,
+    #[serde(default)]
+    vsync: Vsync,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct Resolution((u32, u32));
+
+impl Default for Resolution {
+    fn default() -> Self {
+        Self((800, 600))
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct Vsync(bool);
+
+impl Default for Vsync {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+impl Settings {
+    pub fn resolution(&self) -> (u32, u32) {
+        self.resolution.0
+    }
+
+    pub fn vsync(&self) -> bool {
+        self.vsync.0
+    }
+}
+
+impl Settings {
+    pub fn load_from_config() -> Result<Settings> {
+        const QUALIFIER: &str = "com";
+        const ORGANIZATION: &str = "Ambient";
+        const APPLICATION: &str = "Ambient";
+        const FILE_NAME: &str = "settings.toml";
+
+        let Some(project_dirs) = ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION) else {
+            bail!("Failed to open home directory");
+        };
+
+        let settings_dir = project_dirs.config_dir();
+        if !settings_dir.exists() {
+            std::fs::create_dir_all(&settings_dir).with_context(|| {
+                format!(
+                    "Creating {APPLICATION} settings directory at {}",
+                    settings_dir.display()
+                )
+            })?;
+        }
+
+        let settings_path = settings_dir.join(FILE_NAME);
+        tracing::info!("Reading {FILE_NAME} from {}", settings_path.display());
+        let settings = if settings_path.exists() {
+            let settings = std::fs::read_to_string(&settings_path)?;
+            let settings: Settings =
+                toml::from_str(&settings).with_context(|| format!("Deserializing {FILE_NAME}"))?;
+            settings
+        } else {
+            Settings::default()
+        };
+
+        std::fs::write(&settings_path, &toml::to_string(&settings)?)
+            .with_context(|| format!("Writing {FILE_NAME}"))?;
+
+        Ok(settings)
+    }
+}


### PR DESCRIPTION
Apps now try to find and load `settings.toml` from a specific directory. Currently the only two supported settings are the window size at boot time and VSync.

Present mode now prefers to VSync to avoid running apps at excessive frame rates.