### PR TITLE
GpuMesh::from_mesh now takes &AssetCache

### DIFF
--- a/crates/gpu/src/mesh_buffer.rs
+++ b/crates/gpu/src/mesh_buffer.rs
@@ -38,8 +38,8 @@ pub struct GpuMesh {
 }
 
 impl GpuMesh {
-    pub fn from_mesh(assets: AssetCache, mesh: &Mesh) -> Arc<GpuMesh> {
-        MeshBufferKey.get(&assets).lock().insert(mesh)
+    pub fn from_mesh(assets: &AssetCache, mesh: &Mesh) -> Arc<GpuMesh> {
+        MeshBufferKey.get(assets).lock().insert(mesh)
     }
     pub fn name(&self) -> &str {
         &self.name
@@ -89,7 +89,7 @@ impl AsyncAssetKey<AssetResult<Arc<GpuMesh>>> for GpuMeshFromUrl {
         let mesh = MeshFromUrl::new(self.url, self.cache_on_disk)
             .get(&assets)
             .await?;
-        Ok(GpuMesh::from_mesh(assets, &mesh))
+        Ok(GpuMesh::from_mesh(&assets, &mesh))
     }
 }
 

--- a/crates/meshes/src/lib.rs
+++ b/crates/meshes/src/lib.rs
@@ -23,7 +23,7 @@ pub use uvsphere::*;
 pub struct QuadMeshKey;
 impl SyncAssetKey<Arc<GpuMesh>> for QuadMeshKey {
     fn load(&self, assets: AssetCache) -> Arc<GpuMesh> {
-        GpuMesh::from_mesh(assets, &Mesh::from(QuadMesh::default()))
+        GpuMesh::from_mesh(&assets, &Mesh::from(QuadMesh::default()))
     }
 }
 /// Same as [QuadMeshKey], but unit-sized (e.g. length alongside axes is 1.0 at most)
@@ -32,7 +32,7 @@ pub struct UnitQuadMeshKey;
 impl SyncAssetKey<Arc<GpuMesh>> for UnitQuadMeshKey {
     fn load(&self, assets: AssetCache) -> Arc<GpuMesh> {
         GpuMesh::from_mesh(
-            assets,
+            &assets,
             &Mesh::from(QuadMesh::from_position_size(-Vec2::ONE * 0.5, Vec2::ONE)),
         )
     }
@@ -42,7 +42,7 @@ impl SyncAssetKey<Arc<GpuMesh>> for UnitQuadMeshKey {
 pub struct CubeMeshKey;
 impl SyncAssetKey<Arc<GpuMesh>> for CubeMeshKey {
     fn load(&self, assets: AssetCache) -> Arc<GpuMesh> {
-        GpuMesh::from_mesh(assets, &Mesh::from(CubeMesh::default()))
+        GpuMesh::from_mesh(&assets, &Mesh::from(CubeMesh::default()))
     }
 }
 /// Same as [CubeMeshKey], but unit-sized (e.g. length alongside axes is 1.0 at most)
@@ -51,7 +51,7 @@ pub struct UnitCubeMeshKey;
 impl SyncAssetKey<Arc<GpuMesh>> for UnitCubeMeshKey {
     fn load(&self, assets: AssetCache) -> Arc<GpuMesh> {
         GpuMesh::from_mesh(
-            assets,
+            &assets,
             &Mesh::from(CubeMesh {
                 position: -Vec3::ONE * 0.5,
                 size: Vec3::ONE,
@@ -65,7 +65,7 @@ impl SyncAssetKey<Arc<GpuMesh>> for UnitCubeMeshKey {
 pub struct SphereMeshKey(pub UVSphereMesh);
 impl SyncAssetKey<Arc<GpuMesh>> for SphereMeshKey {
     fn load(&self, assets: AssetCache) -> Arc<GpuMesh> {
-        GpuMesh::from_mesh(assets, &Mesh::from(self.0))
+        GpuMesh::from_mesh(&assets, &Mesh::from(self.0))
     }
 }
 
@@ -73,7 +73,7 @@ impl SyncAssetKey<Arc<GpuMesh>> for SphereMeshKey {
 pub struct TorusMeshKey(pub TorusMesh);
 impl SyncAssetKey<Arc<GpuMesh>> for TorusMeshKey {
     fn load(&self, assets: AssetCache) -> Arc<GpuMesh> {
-        GpuMesh::from_mesh(assets, &Mesh::from(self.0))
+        GpuMesh::from_mesh(&assets, &Mesh::from(self.0))
     }
 }
 
@@ -81,7 +81,7 @@ impl SyncAssetKey<Arc<GpuMesh>> for TorusMeshKey {
 pub struct CapsuleMeshKey(pub CapsuleMesh);
 impl SyncAssetKey<Arc<GpuMesh>> for CapsuleMeshKey {
     fn load(&self, assets: AssetCache) -> Arc<GpuMesh> {
-        GpuMesh::from_mesh(assets, &Mesh::from(self.0))
+        GpuMesh::from_mesh(&assets, &Mesh::from(self.0))
     }
 }
 
@@ -93,7 +93,7 @@ impl SyncAssetKey<Arc<GpuMesh>> for UIRectMeshKey {
         quad.flip_uvs = true;
         let mut mesh = Mesh::from(quad);
         mesh.name = "ui_rect".to_string();
-        GpuMesh::from_mesh(assets, &mesh)
+        GpuMesh::from_mesh(&assets, &mesh)
     }
 }
 
@@ -101,7 +101,7 @@ impl SyncAssetKey<Arc<GpuMesh>> for UIRectMeshKey {
 pub struct GridMeshKey(pub GridMesh);
 impl SyncAssetKey<Arc<GpuMesh>> for GridMeshKey {
     fn load(&self, assets: AssetCache) -> Arc<GpuMesh> {
-        GpuMesh::from_mesh(assets, &Mesh::from(self.0.clone()))
+        GpuMesh::from_mesh(&assets, &Mesh::from(self.0.clone()))
     }
 }
 

--- a/crates/text/src/lib.rs
+++ b/crates/text/src/lib.rs
@@ -411,7 +411,7 @@ pub fn systems(use_gpu: bool) -> SystemGroup {
                                 let cpu_mesh = mesh_from_glyph_vertices(vertices);
                                 let mut data = Entity::new();
                                 if use_gpu {
-                                    data.set(mesh(), GpuMesh::from_mesh(assets.clone(), &cpu_mesh));
+                                    data.set(mesh(), GpuMesh::from_mesh(&assets, &cpu_mesh));
                                 }
                                 world.add_components(id, data).unwrap();
                                 break;


### PR DESCRIPTION
Creating a `GpuMesh` no longer requires cloning `AssetCache`, which is a relatively expensive operation.