### PR TITLE
fix: Ulid::new() panic on web

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,14 +1,15 @@
 [target.'cfg(all())']
 rustflags = [
-  # Global lints/warnings.
-  # See https://github.com/EmbarkStudios/rust-ecosystem/issues/22 for why they need to be specified here
-  #
-  # We don't need a default implementation for every type that implements a new function
-  "-Aclippy::new_without_default",
-  # We have a lot of complex types
-  "-Aclippy::type_complexity",
-  "-Dclippy::dbg_macro",
-  "-Dclippy::disallowed_types"
+    # Global lints/warnings.
+    # See https://github.com/EmbarkStudios/rust-ecosystem/issues/22 for why they need to be specified here
+    #
+    # We don't need a default implementation for every type that implements a new function
+    "-Aclippy::new_without_default",
+    # We have a lot of complex types
+    "-Aclippy::type_complexity",
+    "-Dclippy::dbg_macro",
+    "-Dclippy::disallowed_types",
+    "-Dclippy::disallowed_methods",
 ]
 
 [target.'cfg(target_os = "unknown")']
@@ -18,3 +19,4 @@ rustflags = ["--cfg=web_sys_unstable_apis"]
 [alias]
 campfire = "run --package campfire --"
 cf = "run --package campfire --"
+

--- a/clippy.toml
+++ b/clippy.toml
@@ -10,4 +10,9 @@ disallowed-types = [
     { path = "std::time::Instant", reason = "time is not implemented on wasm" },
     { path = "std::time::SystemTime", reason = "time is not implemented on wasm" },
 ]
+
+disallowed-methods = [
+    { path = "ulid::Ulid::new", reason = "panics on wasm: https://github.com/dylanhart/ulid-rs/issues/52" },
+]
+
 allow-dbg-in-tests = true

--- a/crates/std/Cargo.toml
+++ b/crates/std/Cargo.toml
@@ -10,12 +10,13 @@ repository = "https://github.com/AmbientRun/Ambient"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ambient_asset_cache = { path = "../asset_cache/", optional = true , version = "0.2.1" }
-ambient_sys = { path = "../sys" , version = "0.2.1" }
-ambient_cb = { path = "../../libs/cb" , version = "0.2.1" }
-ambient_color = { path = "../../libs/color" , version = "0.2.1" }
-ambient_friendly_id = { path = "../../libs/friendly_id" , version = "0.2.1" }
-ambient_math = { path = "../../libs/math" , version = "0.2.1" }
+ambient_asset_cache = { path = "../asset_cache/", optional = true, version = "0.2.1" }
+ambient_sys = { path = "../sys", version = "0.2.1" }
+
+ambient_cb = { path = "../../libs/cb", version = "0.2.1" }
+ambient_color = { path = "../../libs/color", version = "0.2.1" }
+ambient_friendly_id = { path = "../../libs/friendly_id", version = "0.2.1" }
+ambient_math = { path = "../../libs/math", version = "0.2.1" }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 ulid = { workspace = true }

--- a/crates/std/src/uncategorized/mesh.rs
+++ b/crates/std/src/uncategorized/mesh.rs
@@ -40,7 +40,7 @@ impl MeshBuilder {
         }
 
         Ok(Mesh {
-            id: ulid::Ulid::new(),
+            id: crate::ulid(),
             positions: self.positions,
             colors: self.colors,
             normals: self.normals,

--- a/crates/sys/src/native/time.rs
+++ b/crates/sys/src/native/time.rs
@@ -114,7 +114,9 @@ impl Interval {
     }
 
     pub fn new_at(start: Instant, period: Duration) -> Self {
-        Self { inner: tokio::time::interval_at(start.0.into(), period) }
+        Self {
+            inner: tokio::time::interval_at(start.0.into(), period),
+        }
     }
 
     pub async fn tick(&mut self) -> Instant {

--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -624,6 +624,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "ulid",
  "url",
  "wgpu",
 ]
@@ -4889,6 +4890,16 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ulid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a3aaa69b04e5b66cc27309710a569ea23593612387d67daaf102e73aa974fd"
+dependencies = [
+ "rand",
+ "serde",
+]
 
 [[package]]
 name = "unicode-bidi"


### PR DESCRIPTION
This resolves the use of Ulid calling `SystemTime::now` which is not implemented on the `wasm32-unknown-unknown` targets, as the `unknown` means that there *is* no libstd or OS, hence time is not available/implemented and just panics.

The way of getting the time is binding to JavaScript using `wasm-bindgen` and calling js `Data.now`.

In addition, the use of `Ulid::now` is now disallowed by clippy in CI