### PR TITLE
Add conditionally bundled certificates and cli certificate overrides

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -43,7 +43,9 @@ ambient_ecs_editor = { path = "../crates/ecs_editor" }
 ambient_editor_derive = { path = "../shared_crates/editor_derive" }
 ambient_element = { path = "../shared_crates/element" }
 ambient_project = { path = "../shared_crates/project" }
-ambient_shared_types = { path = "../shared_crates/shared_types", features = ["native"] }
+ambient_shared_types = { path = "../shared_crates/shared_types", features = [
+    "native",
+] }
 
 tracing-tree = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
@@ -76,9 +78,10 @@ glam = { workspace = true }
 rusty-hook = "^0.11.2"
 
 [features]
-default = []
+no_bundled_certs = []
+default = ["assimp"]
 deploy = ["ambient_deploy"]
-production = ["assimp"]
+production = ["assimp", "no_bundled_certs"]
 profile = ["ambient_app/profile"]
 assimp = ["ambient_model_import/russimp"]
 tracing = ["tracing-tree", "tracing-subscriber", "tracing-log"]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -79,7 +79,7 @@ rusty-hook = "^0.11.2"
 
 [features]
 no_bundled_certs = []
-default = ["assimp"]
+default = []
 deploy = ["ambient_deploy"]
 production = ["assimp", "no_bundled_certs"]
 profile = ["ambient_app/profile"]

--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -135,11 +135,11 @@ pub struct HostCli {
     pub proxy_pre_cache_assets: bool,
 
     /// Certificate for TLS
-    #[arg(long, requires("key"), default_value("localhost.crt"))]
-    pub cert: PathBuf,
+    #[arg(long, requires("key"))]
+    pub cert: Option<PathBuf>,
     /// Private key for the certificate
-    #[arg(long, default_value("localhost.key"))]
-    pub key: PathBuf,
+    #[arg(long)]
+    pub key: Option<PathBuf>,
 }
 
 impl Cli {

--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -89,7 +89,7 @@ pub struct RunCli {
     pub user_id: Option<String>,
 
     /// Specify a trusted certificate authority
-    #[arg(long, default_value = "./localhost.crt")]
+    #[arg(long)]
     pub ca: Option<PathBuf>,
 }
 

--- a/app/src/client/mod.rs
+++ b/app/src/client/mod.rs
@@ -62,21 +62,14 @@ pub async fn run(
             }
         }
     } else {
-        None
-    };
-
-    #[cfg(not(feature = "no_bundled_certs"))]
-    let cert = if let Some(ca) = &run.ca {
-        match std::fs::read(ca) {
-            Ok(v) => Some(v),
-            Err(err) => {
-                tracing::error!("Failed to load certificate from file: {}", err);
-                None
-            }
+        #[cfg(not(feature = "no_bundled_certs"))]
+        {
+            Some(super::CERT.to_vec())
         }
-    } else {
-        tracing::info!("Using bundled self-signed certificate as trusted root");
-        Some(super::CERT.to_vec())
+        #[cfg(feature = "no_bundled_certs")]
+        {
+            None
+        }
     };
 
     AppBuilder::new()

--- a/app/src/client/mod.rs
+++ b/app/src/client/mod.rs
@@ -52,7 +52,6 @@ pub async fn run(
 
     let is_debug = std::env::var("AMBIENT_DEBUGGER").is_ok() || run.debugger;
 
-    #[cfg(feature = "no_bundled_certs")]
     let cert = if let Some(ca) = &run.ca {
         match std::fs::read(ca) {
             Ok(v) => Some(v),

--- a/app/src/client/mod.rs
+++ b/app/src/client/mod.rs
@@ -52,6 +52,33 @@ pub async fn run(
 
     let is_debug = std::env::var("AMBIENT_DEBUGGER").is_ok() || run.debugger;
 
+    #[cfg(feature = "no_bundled_certs")]
+    let cert = if let Some(ca) = &run.ca {
+        match std::fs::read(ca) {
+            Ok(v) => Some(v),
+            Err(err) => {
+                tracing::error!("Failed to load certificate from file: {}", err);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    #[cfg(not(feature = "no_bundled_certs"))]
+    let cert = if let Some(ca) = &run.ca {
+        match std::fs::read(ca) {
+            Ok(v) => Some(v),
+            Err(err) => {
+                tracing::error!("Failed to load certificate from file: {}", err);
+                None
+            }
+        }
+    } else {
+        tracing::info!("Using bundled self-signed certificate as trusted root");
+        Some(super::CERT.to_vec())
+    };
+
     AppBuilder::new()
         .ui_renderer(true)
         .with_asset_cache(assets)
@@ -65,7 +92,7 @@ pub async fn run(
                 show_debug: is_debug,
                 golden_image_test: run.golden_image_test,
                 golden_image_output_dir,
-                ca_file: run.ca.clone(),
+                cert,
             }
             .el()
             .spawn_interactive(&mut app.world);
@@ -106,7 +133,7 @@ fn MainApp(
     user_id: String,
     show_debug: bool,
     golden_image_test: Option<f32>,
-    ca_file: Option<PathBuf>,
+    cert: Option<Vec<u8>>,
 ) -> Element {
     let (loaded, set_loaded) = hooks.use_state(false);
 
@@ -152,7 +179,7 @@ fn MainApp(
 
                 (systems(), resources)
             }),
-            ca_file,
+            cert,
             create_rpc_registry: cb(shared::create_server_rpc_registry),
             inner: Dock::el(vec![
                 TitleUpdater.el(),

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -16,6 +16,12 @@ use cli::{Cli, Commands};
 use log::LevelFilter;
 use server::QUIC_INTERFACE_PORT;
 
+#[cfg(not(feature = "no_bundled_certs"))]
+const CERT: &[u8] = include_bytes!("../../localhost.crt");
+
+#[cfg(not(feature = "no_bundled_certs"))]
+const CERT_KEY: &[u8] = include_bytes!("../../localhost.key");
+
 fn setup_logging() -> anyhow::Result<()> {
     const MODULES: &[(LevelFilter, &[&str])] = &[
         (
@@ -290,6 +296,28 @@ fn main() -> anyhow::Result<()> {
             format!("127.0.0.1:{QUIC_INTERFACE_PORT}").parse()?
         }
     } else if let Some(host) = &cli.host() {
+        #[cfg(feature = "no_bundled_certs")]
+        let crypto = if let (Some(cert_file), Some(key_file)) = (&host.cert, &host.key) {
+            let cert = std::fs::read(cert_file)?;
+            let key = std::fs::read(key_file)?;
+            ambient_network::native::server::Crypto { cert, key }
+        } else {
+            anyhow::bail!("--cert and --key are required without bundled certs.");
+        };
+
+        #[cfg(not(feature = "no_bundled_certs"))]
+        let crypto = if let (Some(cert_file), Some(key_file)) = (&host.cert, &host.key) {
+            let cert = std::fs::read(cert_file)?;
+            let key = std::fs::read(key_file)?;
+            ambient_network::native::server::Crypto { cert, key }
+        } else {
+            tracing::info!("Using bundled certificate and key");
+            ambient_network::native::server::Crypto {
+                cert: CERT.to_vec(),
+                key: CERT_KEY.to_vec(),
+            }
+        };
+
         let port = server::start(
             &runtime,
             assets.clone(),
@@ -297,10 +325,7 @@ fn main() -> anyhow::Result<()> {
             project_path.url,
             manifest.as_ref().expect("no manifest"),
             metadata.as_ref().expect("no build metadata"),
-            ambient_network::native::server::Crypto {
-                cert_file: host.cert.clone(),
-                key_file: host.key.clone(),
-            },
+            crypto,
         );
         format!("127.0.0.1:{port}").parse()?
     } else {

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -22,7 +22,7 @@ ambient_renderer = { path = "../renderer", version = "0.2.1" }
 ambient_element = { path = "../../shared_crates/element", version = "0.2.1" }
 ambient_app = { path = "../app", version = "0.2.1" }
 ambient_proxy = "0.3.0"
-ambient_world_audio = { path = "../world_audio" , version = "0.2.1" }
+ambient_world_audio = { path = "../world_audio", version = "0.2.1" }
 
 itertools = { workspace = true }
 dashmap = { workspace = true }

--- a/crates/network/src/native/client.rs
+++ b/crates/network/src/native/client.rs
@@ -26,7 +26,6 @@ use rand::Rng;
 use rustls::{Certificate, RootCertStore};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::PathBuf,
     sync::Arc,
     time::Duration,
 };
@@ -34,7 +33,7 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct GameClientView {
     pub server_addr: SocketAddr,
-    pub ca_file: Option<PathBuf>,
+    pub cert: Option<Vec<u8>>,
     pub user_id: String,
     pub systems_and_resources: Cb<dyn Fn() -> (SystemGroup, Entity) + Sync + Send>,
     pub error_view: Cb<dyn Fn(String) -> Element + Sync + Send>,
@@ -53,7 +52,7 @@ impl ElementComponent for GameClientView {
             create_rpc_registry,
             on_loaded,
             inner,
-            ca_file,
+            cert,
         } = *self;
 
         let gpu = hooks.world.resource(gpu()).clone();
@@ -128,7 +127,7 @@ impl ElementComponent for GameClientView {
 
         hooks.use_task(move |_| {
             let task = async move {
-                let conn = open_connection(server_addr, ca_file)
+                let conn = open_connection(server_addr, cert.map(Certificate))
                     .await
                     .with_context(|| format!("Failed to connect to endpoint: {server_addr:?}"))?;
 
@@ -333,12 +332,12 @@ async fn handle_connection(
 #[tracing::instrument(level = "debug")]
 async fn open_connection(
     server_addr: SocketAddr,
-    ca_file: Option<PathBuf>,
+    cert: Option<Certificate>,
 ) -> anyhow::Result<Connection> {
     log::debug!("Connecting to world instance: {server_addr:?}");
 
     let endpoint =
-        create_client_endpoint_random_port(ca_file).context("Failed to create client endpoint")?;
+        create_client_endpoint_random_port(cert).context("Failed to create client endpoint")?;
 
     log::debug!("Got endpoint");
     let conn = endpoint.connect(server_addr, "localhost")?.await?;
@@ -347,13 +346,12 @@ async fn open_connection(
     Ok(conn)
 }
 
-pub fn create_client_endpoint_random_port(cert_file: Option<PathBuf>) -> anyhow::Result<Endpoint> {
+pub fn create_client_endpoint_random_port(cert: Option<Certificate>) -> anyhow::Result<Endpoint> {
     let mut roots = load_native_roots();
-    if let Some(cert_file) = cert_file {
+
+    if let Some(cert) = cert {
         roots
-            .add(&Certificate(
-                std::fs::read(&cert_file).context("Failed to read custom certificate")?,
-            ))
+            .add(&cert)
             .context("Failed to add custom certificate")?;
     }
 
@@ -362,6 +360,7 @@ pub fn create_client_endpoint_random_port(cert_file: Option<PathBuf>) -> anyhow:
             let mut rng = rand::thread_rng();
             rng.gen_range(15000..25000)
         };
+
         let client_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), client_port);
 
         if let Ok(mut endpoint) = Endpoint::client(client_addr) {

--- a/crates/network/src/native/server.rs
+++ b/crates/network/src/native/server.rs
@@ -92,8 +92,8 @@ impl GameServer {
                 Ok(server) => {
                     return Ok(server);
                 }
-                Err(_err) => {
-                    tracing::warn!("Failed to create server on port {}", port);
+                Err(err) => {
+                    tracing::warn!("Failed to create server on port {port}.\n{err:?}");
                 }
             }
         }

--- a/docs/src/user/running.md
+++ b/docs/src/user/running.md
@@ -23,6 +23,23 @@ From here on, you can open up the project in your favorite IDE and start editing
 
 For more details about the API, see [API](./api.md).
 
+## Certificate
+
+By default, _ambient_ bundles a self-signed certificate that is used by the server and trusted by the client.
+
+To use your own certificate specify `--cert`, `--key`, for the server, and `--ca` for the client if the certificate authority which signed the certificate is not in the system roots. If specified, the bundled certificates will _not_ be used as a fallback.
+
+```sh
+ambient serve --cert ./localhost.crt --key ./localhost.key
+
+```
+
+```sh
+ambient join 127.0.0.1:9000
+```
+
+**Note**: `--ca path_to_ca` must be specified if the used certificate is not in the system roots
+
 ## Multiplayer
 
 Every Ambient project is multiplayer by default. To start the project in server-only mode, use the following command:


### PR DESCRIPTION
This adds a bundled (include_bytes) certificate and key that can be disabled in production using `no_bundled_certs` (default with `production` feature.

This also allows ambient to be used with our self-signed certificates outside the ambient repo root as it would previously fail to find the cert file and key.

See the modified docs for usage 😊 

If a cert file,key, or ca is specified it will not fall back on the bundled certificates if they fail to load to avoid a false trust security vulnerability if the file is silently removed.