### PR TITLE
Fix skinned mesh corruption (issue #378)

### DIFF
--- a/crates/gpu/src/mesh_buffer.rs
+++ b/crates/gpu/src/mesh_buffer.rs
@@ -245,6 +245,7 @@ impl MeshBuffer {
             self.skinned_buffer
                 .front
                 .write(metadata.skinned_offset as u64, &data);
+            internal_mesh.skinned_count += len as u64;
         }
 
         self.index_buffer.front.resize(


### PR DESCRIPTION
This subtle omission caused `mesh_buffer::update()` to effectively clear the memory of `skinned_buffer` because the updated size is always 0 bytes large.