### PR TITLE
Perf: Low hanging fruit

### DIFF
--- a/crates/core/src/transform.rs
+++ b/crates/core/src/transform.rs
@@ -277,49 +277,122 @@ impl TransformSystem {
                         }
                     }),
                     // FBX
-                    query((fbx_complex_transform(), local_to_parent()))
-                        .optional_changed(translation())
-                        .optional_changed(fbx_rotation_offset())
-                        .optional_changed(fbx_rotation_pivot())
-                        .optional_changed(fbx_pre_rotation())
-                        .optional_changed(rotation())
-                        .optional_changed(fbx_post_rotation())
-                        .optional_changed(fbx_rotation_pivot())
-                        .optional_changed(fbx_scaling_offset())
-                        .optional_changed(fbx_scaling_pivot())
-                        .optional_changed(scale())
-                        .optional_changed(fbx_scaling_pivot())
-                        .to_system(|q, world, qs, _| {
-                            // See: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
-                            // and: https://github.com/assimp/assimp/blob/add7f1355e96c6ff0df0ba3cec084f25332d154e/code/AssetLib/FBX/FBXConverter.cpp#L687
-                            for (id, _) in q.collect_cloned(world, qs) {
-                                world
-                                    .set(id, local_to_parent(), get_fbx_transform(world, id))
-                                    .unwrap();
-                            }
-                        }),
-                    query((fbx_complex_transform(), local_to_world()))
-                        .optional_changed(translation())
-                        .optional_changed(fbx_rotation_offset())
-                        .optional_changed(fbx_rotation_pivot())
-                        .optional_changed(fbx_pre_rotation())
-                        .optional_changed(rotation())
-                        .optional_changed(fbx_post_rotation())
-                        .optional_changed(fbx_rotation_pivot())
-                        .optional_changed(fbx_scaling_offset())
-                        .optional_changed(fbx_scaling_pivot())
-                        .optional_changed(scale())
-                        .optional_changed(fbx_scaling_pivot())
-                        .excl(local_to_parent())
-                        .to_system(|q, world, qs, _| {
-                            // See: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
-                            // and: https://github.com/assimp/assimp/blob/add7f1355e96c6ff0df0ba3cec084f25332d154e/code/AssetLib/FBX/FBXConverter.cpp#L687
-                            for (id, _) in q.collect_cloned(world, qs) {
-                                world
-                                    .set(id, local_to_world(), get_fbx_transform(world, id))
-                                    .unwrap();
-                            }
-                        }),
+                    query_mut(
+                        local_to_parent(),
+                        (
+                            translation(),
+                            fbx_rotation_offset(),
+                            fbx_rotation_pivot(),
+                            fbx_pre_rotation(),
+                            rotation(),
+                            fbx_post_rotation(),
+                            fbx_scaling_offset(),
+                            fbx_scaling_pivot(),
+                            scale(),
+                        ),
+                    )
+                    .optional_changed(translation())
+                    .optional_changed(fbx_rotation_offset())
+                    .optional_changed(fbx_rotation_pivot())
+                    .optional_changed(fbx_pre_rotation())
+                    .optional_changed(rotation())
+                    .optional_changed(fbx_post_rotation())
+                    .optional_changed(fbx_scaling_offset())
+                    .optional_changed(fbx_scaling_pivot())
+                    .optional_changed(scale())
+                    .incl(fbx_complex_transform())
+                    .to_system(|q, world, qs, _| {
+                        // See: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
+                        // and: https://github.com/assimp/assimp/blob/add7f1355e96c6ff0df0ba3cec084f25332d154e/code/AssetLib/FBX/FBXConverter.cpp#L687
+                        for (
+                            _,
+                            transform,
+                            (
+                                &pos,
+                                &rot_offset,
+                                &rot_pivot,
+                                &pre_rot,
+                                &rot,
+                                &post_rot,
+                                &scaling_offset,
+                                &scaling_pivot,
+                                &scaling,
+                            ),
+                        ) in q.iter(world, qs)
+                        {
+                            let o = pos + rot_offset + rot_pivot;
+                            let r = pre_rot * rot * post_rot.inverse();
+                            let p = scaling_offset + scaling_pivot
+                                - rot_pivot
+                                - scaling * scaling_pivot;
+                            let t = o + r * p;
+
+                            *transform = Mat4::from_scale_rotation_translation(
+                                    scaling,
+                                    r,
+                                    t,
+                                );
+                        }
+                    }),
+
+                    query_mut(
+                        local_to_world(),
+                        (
+                            translation(),
+                            fbx_rotation_offset(),
+                            fbx_rotation_pivot(),
+                            fbx_pre_rotation(),
+                            rotation(),
+                            fbx_post_rotation(),
+                            fbx_scaling_offset(),
+                            fbx_scaling_pivot(),
+                            scale(),
+                        ),
+                    )
+                    .optional_changed(translation())
+                    .optional_changed(fbx_rotation_offset())
+                    .optional_changed(fbx_rotation_pivot())
+                    .optional_changed(fbx_pre_rotation())
+                    .optional_changed(rotation())
+                    .optional_changed(fbx_post_rotation())
+                    .optional_changed(fbx_scaling_offset())
+                    .optional_changed(fbx_scaling_pivot())
+                    .optional_changed(scale())
+                    .incl(fbx_complex_transform())
+                    .excl(local_to_parent())
+                    .to_system(|q, world, qs, _| {
+                        // See: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
+                        // and: https://github.com/assimp/assimp/blob/add7f1355e96c6ff0df0ba3cec084f25332d154e/code/AssetLib/FBX/FBXConverter.cpp#L687
+                        for (
+                            _,
+                            transform,
+                            (
+                                &pos,
+                                &rot_offset,
+                                &rot_pivot,
+                                &pre_rot,
+                                &rot,
+                                &post_rot,
+                                &scaling_offset,
+                                &scaling_pivot,
+                                &scaling,
+                            ),
+                        ) in q.iter(world, qs)
+                        {
+                            let o = pos + rot_offset + rot_pivot;
+                            let r = pre_rot * rot * post_rot.inverse();
+                            let p = scaling_offset + scaling_pivot
+                                - rot_pivot
+                                - scaling * scaling_pivot;
+                            let t = o + r * p;
+
+                            *transform = Mat4::from_scale_rotation_translation(
+                                    scaling,
+                                    r,
+                                    t,
+                                );
+                        }
+                    }),
                 ],
             ),
             post_parented_systems: SystemGroup::new(
@@ -454,52 +527,6 @@ fn update_transform_recursive(world: &mut World, id: EntityId, mut parent_transf
             update_transform_recursive(world, child, transform);
         }
     }
-}
-fn get_fbx_transform(world: &World, id: EntityId) -> Mat4 {
-    world
-        .get(id, translation())
-        .map(Mat4::from_translation)
-        .unwrap_or_default()
-        * world
-            .get(id, fbx_rotation_offset())
-            .map(Mat4::from_translation)
-            .unwrap_or_default()
-        * world
-            .get(id, fbx_rotation_pivot())
-            .map(Mat4::from_translation)
-            .unwrap_or_default()
-        * world
-            .get(id, fbx_pre_rotation())
-            .map(Mat4::from_quat)
-            .unwrap_or_default()
-        * world
-            .get(id, rotation())
-            .map(Mat4::from_quat)
-            .unwrap_or_default()
-        * world
-            .get(id, fbx_post_rotation())
-            .map(|v| Mat4::from_quat(v).inverse())
-            .unwrap_or_default()
-        * world
-            .get(id, fbx_rotation_pivot())
-            .map(|x| Mat4::from_translation(x).inverse())
-            .unwrap_or_default()
-        * world
-            .get(id, fbx_scaling_offset())
-            .map(Mat4::from_translation)
-            .unwrap_or_default()
-        * world
-            .get(id, fbx_scaling_pivot())
-            .map(Mat4::from_translation)
-            .unwrap_or_default()
-        * world
-            .get(id, scale())
-            .map(Mat4::from_scale)
-            .unwrap_or_default()
-        * world
-            .get(id, fbx_scaling_pivot())
-            .map(|x| Mat4::from_translation(x).inverse())
-            .unwrap_or_default()
 }
 
 fn get_transform_root(world: &World, id: EntityId) -> EntityId {

--- a/crates/core/src/transform.rs
+++ b/crates/core/src/transform.rs
@@ -310,6 +310,7 @@ impl TransformSystem {
                         .optional_changed(fbx_scaling_pivot())
                         .optional_changed(scale())
                         .optional_changed(fbx_scaling_pivot())
+                        .excl(local_to_parent())
                         .to_system(|q, world, qs, _| {
                             // See: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
                             // and: https://github.com/assimp/assimp/blob/add7f1355e96c6ff0df0ba3cec084f25332d154e/code/AssetLib/FBX/FBXConverter.cpp#L687

--- a/crates/model_import/src/fbx/model.rs
+++ b/crates/model_import/src/fbx/model.rs
@@ -146,6 +146,18 @@ impl FbxModel {
         if self.double_sided {
             out_node.set(double_sided(), true);
         }
+        if self.is_complex_transform() {
+            out_node.set(fbx_complex_transform(), ());
+            out_node.set(fbx_rotation_offset(), Vec3::ZERO);
+            out_node.set(fbx_rotation_pivot(), Vec3::ZERO);
+            out_node.set(fbx_pre_rotation(), Quat::IDENTITY);
+            out_node.set(fbx_post_rotation(), Quat::IDENTITY);
+            out_node.set(fbx_scaling_offset(), Vec3::ZERO);
+            out_node.set(fbx_scaling_pivot(), Vec3::ZERO);
+            out_node.set(translation(), Vec3::ZERO);
+            out_node.set(rotation(), Quat::IDENTITY);
+            out_node.set(scale(), Vec3::ONE);
+        }
 
         if let Some(value) = self.rotation_offset {
             out_node.set(fbx_rotation_offset(), value);
@@ -170,9 +182,6 @@ impl FbxModel {
         }
         if let Some(value) = self.scaling_pivot {
             out_node.set(fbx_scaling_pivot(), value);
-        }
-        if self.is_complex_transform() {
-            out_node.set(fbx_complex_transform(), ());
         }
 
         // Need to give these values since they might be animated


### PR DESCRIPTION
Changes:
* Removed old animation blend query
* Removed duplicate work in fbx_complex_transform query
* Refactored fbx_complex_transform

Test: 400 instances of single animated character with fbx_complex_transforms:

FPS: 20 -> 40
Overall improvement: 50~ ms / frame -> 24~ ms / frame
animation_systems 15.5 ms -> 7.5 ms
TransformSystem::run 29 ms -> > 12.5 ms

Before:
[Before](https://github.com/AmbientRun/Ambient/assets/71590722/dcd540d2-d02f-4f6c-a589-d42285a6dfe1)

After:
[After](https://github.com/AmbientRun/Ambient/assets/71590722/250c3d44-f873-4d78-8ebe-f0439b6a0d4b)

fbx_complex_transform is now about 3ms of the work, the rest is transform propagation. I would probably remove completely it unless someone has good reason for it to stay. 

Perf is not horrible but the animation sampling as a lot of room for improvement. The transform system I'm not so sure about but obviously all of this could be parallelized. 