### PR TITLE
fix: gltf import filepath

### DIFF
--- a/crates/model_import/src/gltf/mod.rs
+++ b/crates/model_import/src/gltf/mod.rs
@@ -46,7 +46,10 @@ pub async fn import(
     import: &GltfImport,
     asset_crate: &mut ModelCrate,
 ) -> anyhow::Result<RelativePathBuf> {
-    let name_ = |name: Option<&str>| name.map(|x| format!("{x}_")).unwrap_or_default();
+    let name_ = |name: Option<&str>| {
+        name.map(|x| format!("{}_", x.replace("/", "-").replace("\\", "-")))
+            .unwrap_or_default()
+    };
 
     let mut meshes = import
         .document


### PR DESCRIPTION
Fixes issue with relative paths and GLTF. 
Import filepath where the name of the object contains "/" which crates subfolders and then it can't find the images

Example:
```json
{"name":"ambientCG/Fabric052/1K-JPG","base_color":"../images/0.png" }
```

The fix replaces "/" and "\\" with "-" in GLTF names for the paths but keeps the name the same, not sure if that is or will be an issue.