### PR TITLE
fix: use explicit workspace members

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,4 +218,8 @@ jobs:
         with:
           cache-group: "main"
       - name: Check that new-project works
-        run: cargo run -- new guest/rust/examples/basics/ci_test_project && cd guest/rust/examples/basics/ci_test_project && cargo check
+        run: |
+          mkdir tmp 
+          cargo run -- new /tmp/ci_test_project
+          cd /tmp/ci_test_project
+          cargo check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,6 @@ jobs:
       - name: Check that new-project works
         run: |
           mkdir tmp 
-          cargo run -- new --api-path ../../guest/rust/api /tmp/ci_test_project
+          cargo run -- new --api-path $(pwd)/guest/rust/api /tmp/ci_test_project
           cd /tmp/ci_test_project
           cargo check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,6 @@ jobs:
       - name: Check that new-project works
         run: |
           mkdir tmp 
-          cargo run -- new /tmp/ci_test_project
+          cargo run -- new --api-path ../../guest/rust/api /tmp/ci_test_project
           cd /tmp/ci_test_project
           cargo check

--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -20,6 +20,8 @@ pub enum Commands {
         project_args: ProjectCli,
         #[arg(short, long)]
         name: Option<String>,
+        #[arg(long)]
+        api_path: Option<String>,
     },
     /// Builds and runs the project locally
     Run {

--- a/app/src/cli/new_project.rs
+++ b/app/src/cli/new_project.rs
@@ -4,7 +4,11 @@ use ambient_project::Identifier;
 use anyhow::Context;
 use convert_case::Casing;
 
-pub(crate) fn new_project(project_path: &Path, name: Option<&str>) -> anyhow::Result<()> {
+pub(crate) fn new_project(
+    project_path: &Path,
+    name: Option<&str>,
+    api_path: Option<&str>,
+) -> anyhow::Result<()> {
     // Build the identifier.
     let project_path = if let Some(name) = name {
         project_path.join(name)
@@ -64,7 +68,10 @@ pub(crate) fn new_project(project_path: &Path, name: Option<&str>) -> anyhow::Re
                 format!("ambient_api = \"{}\"", env!("CARGO_PKG_VERSION")),
                 #[cfg(not(feature = "production"))]
                 {
-                    if let Some(rev) = git_revision() {
+                    if let Some(api_path) = api_path {
+                        eprintln!("Using api path: {api_path}");
+                        format!("ambient_api = {{ path = {:?} }}", api_path)
+                    } else if let Some(rev) = git_revision() {
                         format!("ambient_api = {{ git = \"https://github.com/AmbientRun/Ambient.git\", rev = \"{}\" }}", rev)
                     } else {
                         format!("ambient_api = \"{}\"", env!("CARGO_PKG_VERSION"))
@@ -74,12 +81,17 @@ pub(crate) fn new_project(project_path: &Path, name: Option<&str>) -> anyhow::Re
             ),
         };
 
-        let mut template_cargo_toml = include_str!("new_project_template/Cargo.toml")
-            .replace("{{id}}", id.as_ref())
-            .replace(
-                "ambient_api = { path = \"../../../../guest/rust/api\" }",
-                &replacement,
-            );
+        let template_cargo_toml = include_str!("new_project_template/Cargo.toml");
+        eprintln!(
+            "in_ambient_examples: {}, replacement: {},\ntemplate: {}",
+            in_ambient_examples, replacement, template_cargo_toml
+        );
+        let mut template_cargo_toml = template_cargo_toml.replace("{{id}}", id.as_ref()).replace(
+            "ambient_api = { path = \"../../../../guest/rust/api\" }",
+            &replacement,
+        );
+
+        eprintln!("template: {}", template_cargo_toml);
 
         if in_ambient_examples {
             template_cargo_toml = template_cargo_toml.replace(
@@ -90,6 +102,8 @@ pub(crate) fn new_project(project_path: &Path, name: Option<&str>) -> anyhow::Re
 
         template_cargo_toml
     };
+
+    eprintln!("cargo.toml: {}", cargo_toml);
 
     macro_rules! include_template {
         ($path:expr) => {

--- a/app/src/cli/new_project.rs
+++ b/app/src/cli/new_project.rs
@@ -69,7 +69,6 @@ pub(crate) fn new_project(
                 #[cfg(not(feature = "production"))]
                 {
                     if let Some(api_path) = api_path {
-                        eprintln!("Using api path: {api_path}");
                         format!("ambient_api = {{ path = {:?} }}", api_path)
                     } else if let Some(rev) = git_revision() {
                         format!("ambient_api = {{ git = \"https://github.com/AmbientRun/Ambient.git\", rev = \"{}\" }}", rev)
@@ -82,16 +81,10 @@ pub(crate) fn new_project(
         };
 
         let template_cargo_toml = include_str!("new_project_template/Cargo.toml");
-        eprintln!(
-            "in_ambient_examples: {}, replacement: {},\ntemplate: {}",
-            in_ambient_examples, replacement, template_cargo_toml
-        );
         let mut template_cargo_toml = template_cargo_toml.replace("{{id}}", id.as_ref()).replace(
             "ambient_api = { path = \"../../../../guest/rust/api\" }",
             &replacement,
         );
-
-        eprintln!("template: {}", template_cargo_toml);
 
         if in_ambient_examples {
             template_cargo_toml = template_cargo_toml.replace(
@@ -102,8 +95,6 @@ pub(crate) fn new_project(
 
         template_cargo_toml
     };
-
-    eprintln!("cargo.toml: {}", cargo_toml);
 
     macro_rules! include_template {
         ($path:expr) => {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -191,9 +191,11 @@ fn main() -> anyhow::Result<()> {
     }
 
     // If new: create project, immediately exit
-    if let Commands::New { name, .. } = &cli.command {
+    if let Commands::New { name, api_path, .. } = &cli.command {
         if let Some(path) = &project_path.fs_path {
-            if let Err(err) = cli::new_project::new_project(path, name.as_deref()) {
+            if let Err(err) =
+                cli::new_project::new_project(path, name.as_deref(), api_path.as_deref())
+            {
                 eprintln!("Failed to create project: {err:?}");
             }
         } else {

--- a/guest/rust/Cargo.toml
+++ b/guest/rust/Cargo.toml
@@ -1,5 +1,48 @@
 [workspace]
-members = ["api", "api_core", "api_core/api_macros", "examples/*/*"]
+members = [
+    "api",
+    "api_core",
+    "api_core/api_macros",
+    # Basics
+    "examples/basics/asset_loading",
+    "examples/basics/async",
+    "examples/basics/clientside",
+    "examples/basics/decals",
+    "examples/basics/first_person_camera",
+    "examples/basics/fog",
+    "examples/basics/image",
+    "examples/basics/input",
+    "examples/basics/messaging",
+    "examples/basics/multiplayer",
+    "examples/basics/physics",
+    "examples/basics/primitives",
+    "examples/basics/procedural_generation",
+    "examples/basics/raw_text",
+    "examples/basics/samplers",
+    "examples/basics/screen_ray",
+    "examples/basics/skin_tracking",
+    "examples/basics/skinmesh",
+    "examples/basics/sun",
+    "examples/basics/third_person_camera",
+    "examples/basics/transparency",
+    # UI
+    "examples/ui/auto_editor",
+    "examples/ui/button",
+    "examples/ui/counter",
+    "examples/ui/dock_layout",
+    "examples/ui/editors",
+    "examples/ui/flow_layout",
+    "examples/ui/rect",
+    "examples/ui/screens",
+    "examples/ui/slider",
+    "examples/ui/text",
+    "examples/ui/todo",
+    # Games
+    "examples/games/minigolf",
+    "examples/games/music_sequencer",
+    "examples/games/pong",
+    "examples/games/tictactoe",
+]
 
 [workspace.package]
 rust-version = "1.67.0"


### PR DESCRIPTION
This fixes "failed to read manifest" errors when switching branches