### PR TITLE
Re-use ambient executable in build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,53 +92,6 @@ jobs:
       - name: Display target directory content
         run: tree --du -h target
 
-  golden-image-tests:
-    # Note: we must use a newer Ubuntu for golden image tests, because older
-    # llvmpipe versions can randomly fail.
-    runs-on: ubuntu-latest
-    env:
-      RUST_LOG: ambient_gpu=info
-    steps:
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup target add --toolchain stable wasm32-wasi
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y tree libasound2-dev libglib2.0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
-            libcairo-dev libgtk2.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev xorg-dev ninja-build libxcb-render0-dev
-      - name: Install run (headless) dependencies
-        run: |
-          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
-          sudo apt-get update
-          sudo apt install -y libxcb-xfixes0-dev mesa-vulkan-drivers
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: golden-images
-          cache-on-failure: true
-          workspaces: |
-            .
-            guest/rust
-      - name: Build Ambient
-        run: cargo build --release
-      - name: Run golden image tests
-        run: cargo cf golden-images check
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: screenshots
-          path: |
-            guest/rust/examples/*/*/screenshot.png
-            guest/rust/examples/*/*/fail_screenshot.png
-
   build-api-and-doc:
     runs-on: ubuntu-20.04
 
@@ -187,7 +140,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ambient-${{ matrix.os }}
-          path: target/release/ambient*
+          path: |
+            target/release/ambient
+            target/release/ambient.exe
 
   build-guest-rust:
     strategy:
@@ -208,6 +163,38 @@ jobs:
       - name: Build guest/rust
         run: cd guest/rust && cargo build --workspace
 
+  golden-image-tests:
+    needs: build
+    # Note: we must use a newer Ubuntu for golden image tests, because older
+    # llvmpipe versions can randomly fail.
+    runs-on: ubuntu-latest
+    env:
+      RUST_LOG: ambient_gpu=info
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: rustup target add --toolchain stable wasm32-wasi
+      - name: Download ambient executable
+        uses: actions/download-artifact@v3
+        with:
+          name: ambient-${{ matrix.os }}
+      - run: chmod a+x ambient
+      - name: Install run (headless) dependencies
+        run: |
+          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
+          sudo apt-get update
+          sudo apt install -y libxcb-xfixes0-dev mesa-vulkan-drivers
+
+      - name: Run golden image tests
+        run: cargo cf golden-images --ambient-path=./ambient check
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: screenshots
+          path: |
+            guest/rust/examples/*/*/screenshot.png
+            guest/rust/examples/*/*/fail_screenshot.png
+
   test-new-project-works:
     needs: build
     strategy:
@@ -225,7 +212,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Download ambient executable
         uses: actions/download-artifact@v3
-        id: download
         with:
           name: ambient-${{ matrix.os }}
       - run: chmod a+x ambient

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v3
       - name: Download ambient executable
         uses: actions/download-artifact@v3
         id: download
@@ -232,6 +233,6 @@ jobs:
       - name: Check that new-project works
         run: |
           mkdir tmp
-          ./ambient new /tmp/ci_test_project
+          ./ambient new --api-path $(pwd)/guest/rust/api /tmp/ci_test_project
           cd /tmp/ci_test_project
           cargo check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Download ambient executable
         uses: actions/download-artifact@v3
         with:
-          name: ambient-${{ matrix.os }}
+          name: ambient-ubuntu-latest
       - run: chmod a+x ambient
       - name: Install run (headless) dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,14 +175,32 @@ jobs:
             libcairo-dev libgtk2.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev xorg-dev ninja-build libxcb-render0-dev
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Leafwing-Studios/cargo-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
-          cache-group: "main"
+          prefix-key: main
+          workspaces: .
       - name: Build
         run: cargo build --workspace
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0"
+
+  build-guest-rust:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+          - os: windows-latest
+          - os: ubuntu-20.04
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: guest-rust
+          workspaces: guest/rust
       - name: Build guest/rust
         run: cd guest/rust && cargo build --workspace
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,10 +175,9 @@ jobs:
             libcairo-dev libgtk2.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev xorg-dev ninja-build libxcb-render0-dev
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Leafwing-Studios/cargo-cache@v1
         with:
-          prefix-key: main
-          workspaces: .
+          cache-group: "main"
       - name: Build
         run: cargo build --workspace --release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,15 +228,10 @@ jobs:
         id: download
         with:
           name: ambient-${{ matrix.os }}
-      - run: ls
-      - run: pwd
-      - run: echo ${{steps.download.outputs.download-path}}
-      - run: ls ${{steps.download.outputs.download-path}}
-      - run: ls ambient-${{ matrix.os }}
-      - run: chmod a+x ambient-${{ matrix.os }}/ambient
+      - run: chmod a+x ambient
       - name: Check that new-project works
         run: |
           mkdir tmp
-          ambient-${{ matrix.os }}/ambient new --api-path $(pwd)/guest/rust/api /tmp/ci_test_project
+          ./ambient new --api-path $(pwd)/guest/rust/api /tmp/ci_test_project
           cd /tmp/ci_test_project
           cargo check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Download ambient executable
         uses: actions/download-artifact@v3
         with:
-          name: ambient-ubuntu-latest
+          name: ambient-ubuntu-20.04
       - run: chmod a+x ambient
       - name: Install run (headless) dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,6 @@ jobs:
       - name: Check that new-project works
         run: |
           mkdir tmp
-          ./ambient new --api-path $(pwd)/guest/rust/api /tmp/ci_test_project
+          ./ambient new /tmp/ci_test_project
           cd /tmp/ci_test_project
           cargo check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,11 +225,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Download ambient executable
         uses: actions/download-artifact@v3
+        id: download
         with:
           name: ambient-${{ matrix.os }}
+      - run: ls
+      - run: pwd
+      - run: echo ${{steps.download.outputs.download-path}}
+      - run: ls ${{steps.download.outputs.download-path}}
+      - run: ls ambient-${{ matrix.os }}
+      - run: chmod a+x ambient-${{ matrix.os }}/ambient
       - name: Check that new-project works
         run: |
           mkdir tmp
-          ./target/release/ambient new --api-path $(pwd)/guest/rust/api /tmp/ci_test_project
+          ambient-${{ matrix.os }}/ambient new --api-path $(pwd)/guest/rust/api /tmp/ci_test_project
           cd /tmp/ci_test_project
           cargo check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,10 +180,15 @@ jobs:
           prefix-key: main
           workspaces: .
       - name: Build
-        run: cargo build --workspace
+        run: cargo build --workspace --release
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0"
+      - name: Upload ambient exectuable artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ambient-${{ matrix.os }}
+          path: target/release/ambient*
 
   build-guest-rust:
     strategy:
@@ -205,6 +210,7 @@ jobs:
         run: cd guest/rust && cargo build --workspace
 
   test-new-project-works:
+    needs: build
     strategy:
       matrix:
         include:
@@ -216,27 +222,14 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Free up disk space
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-      - name: Install build dependencies
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y tree libasound2-dev libglib2.0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
-            libcairo-dev libgtk2.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev xorg-dev ninja-build libxcb-render0-dev
-      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Leafwing-Studios/cargo-cache@v1
+      - name: Download ambient executable
+        uses: actions/download-artifact@v3
         with:
-          cache-group: "main"
+          name: ambient-${{ matrix.os }}
       - name: Check that new-project works
         run: |
           mkdir tmp
-          cargo run -- new --api-path $(pwd)/guest/rust/api /tmp/ci_test_project
+          ./target/release/ambient new --api-path $(pwd)/guest/rust/api /tmp/ci_test_project
           cd /tmp/ci_test_project
           cargo check

--- a/app/src/cli/new_project.rs
+++ b/app/src/cli/new_project.rs
@@ -70,7 +70,7 @@ pub(crate) fn new_project(
                 {
                     if let Some(api_path) = api_path {
                         format!("ambient_api = {{ path = {:?} }}", api_path)
-                    } else if let Some(rev) = git_revision() {
+                    } else if let Some(rev) = git_revision(git_version::git_version!()) {
                         format!("ambient_api = {{ git = \"https://github.com/AmbientRun/Ambient.git\", rev = \"{}\" }}", rev)
                     } else {
                         format!("ambient_api = \"{}\"", env!("CARGO_PKG_VERSION"))
@@ -132,11 +132,24 @@ pub(crate) fn new_project(
     Ok(())
 }
 
-fn git_revision() -> Option<String> {
-    let s = git_version::git_version!().split('-').collect::<Vec<_>>();
-    if s.len() == 2 {
+fn git_revision(version: &str) -> Option<String> {
+    let s = version.split('-').collect::<Vec<_>>();
+    if s.len() <= 2 {
         Some(s[0].to_string())
     } else {
         Some(s.get(3)?[1..].to_string())
     }
+}
+
+#[test]
+fn test_git_revision() {
+    assert_eq!(git_revision("9f244c3"), Some("9f244c3".to_string()));
+    assert_eq!(
+        git_revision("9f244c3-modified"),
+        Some("9f244c3".to_string())
+    );
+    assert_eq!(
+        git_revision("0.3.0-dev-g9f244c3"),
+        Some("9f244c3".to_string())
+    );
 }

--- a/app/src/cli/new_project.rs
+++ b/app/src/cli/new_project.rs
@@ -149,7 +149,7 @@ fn test_git_revision() {
         Some("9f244c3".to_string())
     );
     assert_eq!(
-        git_revision("0.3.0-dev-g9f244c3"),
+        git_revision("git-0.3.0-dev-g9f244c3"),
         Some("9f244c3".to_string())
     );
 }

--- a/crates/animation/src/lib.rs
+++ b/crates/animation/src/lib.rs
@@ -21,8 +21,8 @@ fn test_animation() {
     use ambient_core::transform::{self, translation};
     use glam::vec3;
 
-    ambient_ecs::init_components();
     transform::init_components();
+    ambient_ecs::init_components();
 
     let mut int = AnimationTrackInterpolator::new();
     let track = AnimationTrack {


### PR DESCRIPTION
This gets rid of the build cache for the golden-images and test-new-project-works.
Those two build steps now instead depend on the result of an earlier step.

Hopefully this will result in better cache performance