### PR TITLE
Split `time` into `absolute_game_time` and `absolute_epoch_time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ These PRs are not directly user-facing, but improve the development experience. 
 - **Physics**: Renamed the `visualizing` component to `visualize_collider`.
 - **Animation**: The animation system has been reworked. See the [animation documentation](https://ambientrun.github.io/Ambient/reference/animations.html) for details. Thanks to [@devjobe](https://github.com/devjobe) for laying the foundation for this!
 - **Physics**: Renamed `box_collider` to `cube_collider`.
-- **App**: Renamed the `time` component to `absolute_time`, and the `dtime` component to `delta_time`. The `frametime` function has been renamed to `delta_time`.
+- **API**: The `time` function has been split into `absolute_game_time` and `absolute_epoch_time`. The `dtime` component has been renamed to `delta_time`. The `frametime` function has been renamed to `delta_time`.
 - **Project**: Projects have been renamed to Embers; see the [ember documentation](https://ambientrun.github.io/Ambient/reference/ember.html) for details.
 - **Assets**: Asset pipelines now use TOML instead of JSON. Use the `ambient assets migrate-pipelines-toml` command to migrate. (Note that this command will be removed in the next release.)
 - **Rendering**: Removing the `outline_recursive` component from a entity will now remove the outline from its children as well.

--- a/app/src/client/wasm.rs
+++ b/app/src/client/wasm.rs
@@ -109,7 +109,6 @@ pub fn initialize(world: &mut World) -> anyhow::Result<()> {
                     // log::info!("Stopped sound with id {}", uid);
                     stream.mixer().stop(id);
                 }
-                _ => {}
             }
         }
     });

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -6,9 +6,7 @@ use std::{
     sync::Arc,
 };
 
-use ambient_core::{
-    absolute_time, app_start_time, asset_cache, delta_time, name, no_sync, project_name,
-};
+use ambient_core::{asset_cache, name, no_sync, project_name, FIXED_SERVER_TICK_TIME};
 use ambient_ecs::{
     dont_store, world_events, ComponentDesc, ComponentRegistry, Entity, Networked, SystemGroup,
     World, WorldEventsSystem, WorldStreamCompEvent,
@@ -24,7 +22,7 @@ use ambient_std::{
     asset_cache::{AssetCache, AsyncAssetKeyExt, SyncAssetKeyExt},
     asset_url::{AbsAssetUrl, ServerBaseUrlKey},
 };
-use ambient_sys::{task::RuntimeHandle, time::SystemTime};
+use ambient_sys::task::RuntimeHandle;
 use anyhow::Context;
 use axum::{
     http::{Method, StatusCode},
@@ -257,12 +255,7 @@ fn create_resources(assets: AssetCache) -> Entity {
     server_resources.merge(ambient_core::async_ecs::async_ecs_resources());
     server_resources.set(ambient_core::runtime(), RuntimeHandle::current());
 
-    let now = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap();
-    server_resources.set(absolute_time(), now);
-    server_resources.set(app_start_time(), now);
-    server_resources.set(delta_time(), 1. / 60.);
+    server_resources.merge(ambient_core::time_resources_start(FIXED_SERVER_TICK_TIME));
 
     let mut bistream_handlers = HashMap::new();
     ambient_network::server::register_rpc_bi_stream_handler(

--- a/crates/animation/src/player.rs
+++ b/crates/animation/src/player.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use ambient_core::{absolute_time, asset_cache, async_ecs::async_run, runtime};
+use ambient_core::{absolute_epoch_time, asset_cache, async_ecs::async_run, runtime};
 use ambient_ecs::{
     children, components,
     generated::components::core::animation::{
@@ -283,7 +283,7 @@ pub fn animation_player_systems() -> SystemGroup {
                     }
                 }),
             query((animation_player(), children())).to_system(|q, world, qs, _| {
-                let time = *world.resource(absolute_time());
+                let time = *world.resource(absolute_epoch_time());
                 for (id, (_, children)) in q.collect_cloned(world, qs) {
                     let mut errors = Default::default();
                     let output = sample_animation_node(world, children[0], time, &mut errors);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,14 +1,17 @@
 #[macro_use]
 extern crate lazy_static;
 
-use ambient_sys::{task::RuntimeHandle, time::Instant, time::SystemTime};
+use ambient_sys::{
+    task::RuntimeHandle,
+    time::{Instant, SystemTime},
+};
 use chrono::{DateTime, Utc};
 use hierarchy::despawn_recursive;
 use std::{sync::Arc, time::Duration};
 
 use ambient_ecs::{
-    components, parent, query, Debuggable, Description, DynSystem, FrameEvent, Name, Networked,
-    Resource, Store, System, World,
+    components, parent, query, Debuggable, Description, DynSystem, Entity, FrameEvent, Name,
+    Networked, Resource, Store, System, World,
 };
 use ambient_gpu::{gpu::Gpu, mesh_buffer::GpuMesh};
 
@@ -26,9 +29,12 @@ pub mod transform;
 pub mod window;
 
 pub use ambient_ecs::generated::components::core::app::{
-    absolute_time, delta_time, description, main_scene, map_seed, name, project_name, ref_count,
-    selectable, snap_to_ground, tags, ui_scene,
+    absolute_epoch_time, absolute_game_time, delta_time, description, main_scene, map_seed, name,
+    project_name, ref_count, selectable, snap_to_ground, tags, ui_scene,
 };
+
+/// The time between fixed updates of the server state.
+pub const FIXED_SERVER_TICK_TIME: Duration = Duration::from_micros((1_000_000. / 60.) as u64);
 
 components!("app", {
     @[Resource]
@@ -50,11 +56,13 @@ components!("app", {
     game_mode: GameMode,
 
     @[Resource, Debuggable]
-    app_start_time: Duration,
+    app_start_time: Instant,
+    @[Resource, Debuggable]
+    last_frame_time: Instant,
     @[Resource, Debuggable]
     frame_index: usize,
     @[Debuggable, Store]
-    remove_at_time: Duration,
+    remove_at_game_time: Duration,
 
     /// Generic component that indicates the entity shouldn't be sent over network
     @[Debuggable, Networked, Store]
@@ -84,10 +92,10 @@ pub struct WindowKey;
 impl SyncAssetKey<Arc<winit::window::Window>> for WindowKey {}
 
 pub fn remove_at_time_system() -> DynSystem {
-    query((remove_at_time(),)).to_system(|q, world, qs, _| {
-        let time = *world.resource(self::absolute_time());
+    query((remove_at_game_time(),)).to_system(|q, world, qs, _| {
+        let game_time = *world.resource(self::absolute_game_time());
         for (id, (remove_at_time,)) in q.collect_cloned(world, qs) {
-            if time >= remove_at_time {
+            if game_time >= remove_at_time {
                 world.despawn(id);
             }
         }
@@ -103,6 +111,40 @@ pub fn refcount_system() -> DynSystem {
                 }
             }
         })
+}
+
+/// Returns all the time-related components that need to be
+/// created at startup time.
+pub fn time_resources_start(delta_time: Duration) -> Entity {
+    let system_now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+
+    let instant_now = Instant::now();
+
+    Entity::new()
+        .with(self::app_start_time(), instant_now)
+        .with(self::absolute_epoch_time(), system_now)
+        .with(self::absolute_game_time(), Duration::ZERO)
+        .with(self::last_frame_time(), instant_now)
+        .with(self::delta_time(), delta_time.as_secs_f32())
+}
+
+// Returns all the time-related components that update every frame.
+pub fn time_resources_frame(
+    frame_time: Instant,
+    app_start_time: Instant,
+    delta_time: Duration,
+) -> Entity {
+    let epoch_time = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+
+    Entity::new()
+        .with(self::last_frame_time(), frame_time)
+        .with(self::absolute_epoch_time(), epoch_time)
+        .with(self::absolute_game_time(), frame_time - app_start_time)
+        .with(self::delta_time(), delta_time.as_secs_f32())
 }
 
 #[derive(Debug)]
@@ -133,29 +175,32 @@ impl System for FixedTimestepSystem {
 }
 
 #[derive(Debug)]
-pub struct TimeResourcesSystem {
+pub struct ClientTimeResourcesSystem {
     frame_time: Instant,
 }
-impl TimeResourcesSystem {
+impl ClientTimeResourcesSystem {
     pub fn new() -> Self {
         Self {
             frame_time: Instant::now(),
         }
     }
 }
-impl System for TimeResourcesSystem {
+impl System for ClientTimeResourcesSystem {
     fn run(&mut self, world: &mut World, _event: &FrameEvent) {
-        let delta_time = self.frame_time.elapsed().as_secs_f32();
+        let delta_time = self.frame_time.elapsed();
         self.frame_time = Instant::now();
-        let time = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap();
+
         world
-            .set(world.resource_entity(), self::absolute_time(), time)
+            .set_components(
+                world.resource_entity(),
+                time_resources_frame(
+                    self.frame_time,
+                    *world.resource(self::app_start_time()),
+                    delta_time,
+                ),
+            )
             .unwrap();
-        world
-            .set(world.resource_entity(), self::delta_time(), delta_time)
-            .unwrap();
+
         world
             .set(
                 world.resource_entity(),

--- a/crates/network/src/native/server.rs
+++ b/crates/network/src/native/server.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use ambient_core::{asset_cache, no_sync};
+use ambient_core::{asset_cache, no_sync, FIXED_SERVER_TICK_TIME};
 use ambient_ecs::{
     ArchetypeFilter, ComponentDesc, System, SystemGroup, World, WorldStream, WorldStreamCompEvent,
     WorldStreamFilter,
@@ -139,7 +139,7 @@ impl GameServer {
         )));
 
         let mut fps_counter = FpsCounter::new();
-        let mut sim_interval = interval(Duration::from_secs_f32(1. / 60.));
+        let mut sim_interval = interval(FIXED_SERVER_TICK_TIME);
         sim_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         let mut inactivity_interval = interval(Duration::from_secs_f32(5.));

--- a/crates/physics/examples/physics.rs
+++ b/crates/physics/examples/physics.rs
@@ -1,6 +1,7 @@
 use ambient_app::{gpu, AppBuilder};
 use ambient_core::{
     asset_cache, camera::active_camera, main_scene, transform::scale, FixedTimestepSystem,
+    FIXED_SERVER_TICK_TIME,
 };
 use ambient_ecs::{FnSystem, World};
 use ambient_element::ElementComponentExt;
@@ -78,15 +79,17 @@ async fn main() {
             ambient_physics::init_all_components();
             let scene = init(&mut app.world);
 
+            let tick_time = FIXED_SERVER_TICK_TIME.as_secs_f32();
+
             app.systems.add(Box::new(FixedTimestepSystem::new(
-                1. / 60.,
+                tick_time,
                 Box::new(sync_ecs_physics()),
             )));
             app.systems.add(Box::new(FixedTimestepSystem::new(
-                1. / 60.,
+                FIXED_SERVER_TICK_TIME.as_secs_f32(),
                 Box::new(FnSystem::new(move |_world, _| {
                     scene.fetch_results(true);
-                    scene.simulate(1. / 60.);
+                    scene.simulate(tick_time);
                 })),
             )));
         })

--- a/crates/physics/src/helpers.rs
+++ b/crates/physics/src/helpers.rs
@@ -1,6 +1,9 @@
 use std::collections::HashSet;
 
-use ambient_core::transform::{get_world_position, rotation, translation};
+use ambient_core::{
+    transform::{get_world_position, rotation, translation},
+    FIXED_SERVER_TICK_TIME,
+};
 use ambient_ecs::{query, ECSError, EntityId, World};
 use anyhow::{bail, Context};
 use glam::{vec3, Mat4, Vec3};
@@ -570,7 +573,8 @@ impl PhysicsObjectCollection {
             let pos = get_world_position(world, id).unwrap();
             let force = get_force(pos);
             let a = force / mass;
-            *world.get_mut(id, unit_velocity()).unwrap() += a * (1. / 60.);
+            *world.get_mut(id, unit_velocity()).unwrap() +=
+                a * FIXED_SERVER_TICK_TIME.as_secs_f32();
         }
     }
     pub fn add_radial_impulse(

--- a/crates/physics/src/lib.rs
+++ b/crates/physics/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ambient_core::asset_cache;
+use ambient_core::{asset_cache, FIXED_SERVER_TICK_TIME};
 use ambient_ecs::{
     components, query, Debuggable, DynSystem, Entity, EntityId, FnSystem, Resource, SystemGroup,
     World,
@@ -239,7 +239,7 @@ pub fn run_simulation_system() -> DynSystem {
     Box::new(FnSystem::new(|world, _| {
         ambient_profiling::scope!("run_simulation_system");
         let scene = world.resource(main_physics_scene());
-        scene.simulate(1. / 60.);
+        scene.simulate(FIXED_SERVER_TICK_TIME.as_secs_f32());
     }))
 }
 

--- a/crates/sys/src/native/time.rs
+++ b/crates/sys/src/native/time.rs
@@ -4,7 +4,8 @@ use std::{
     time::{Duration, SystemTimeError},
 };
 
-/// Represents an abstract point in time
+/// A measurement of a monotonically nondecreasing clock. Opaque and useful only with [Duration].
+///
 /// This is intentionally a newtype to discourage mixing with StdInstant as it is not supported on
 /// wasm.
 #[derive(From, Into, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -52,7 +53,11 @@ impl Instant {
     }
 }
 
-/// Measurement of the system clock
+/// A measurement of the system clock, useful for talking to external entities like the file system or other processes.
+///
+/// Distinct from the [Instant] type, this time measurement is not monotonic. This means that you can save a file to the file system,
+/// then save another file to the file system, and the second file has a [SystemTime] measurement earlier than the first.
+/// In other words, an operation that happens after another operation in real time may have an earlier [SystemTime]!
 #[derive(From, Into, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SystemTime(pub(crate) std::time::SystemTime);
 

--- a/crates/sys/src/wasm/time.rs
+++ b/crates/sys/src/wasm/time.rs
@@ -6,7 +6,7 @@ use std::{
 
 use ordered_float::NotNan;
 
-/// Represents an abstract point in time
+/// A measurement of a monotonically nondecreasing clock. Opaque and useful only with [Duration].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Instant(
     /// Time in milliseconds
@@ -59,7 +59,11 @@ impl Instant {
     }
 }
 
-/// Measurement of the system clock
+/// A measurement of the system clock, useful for talking to external entities like the file system or other processes.
+///
+/// Distinct from the [Instant] type, this time measurement is not monotonic. This means that you can save a file to the file system,
+/// then save another file to the file system, and the second file has a [SystemTime] measurement earlier than the first.
+/// In other words, an operation that happens after another operation in real time may have an earlier [SystemTime]!
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SystemTime(NotNan<f64>);
 

--- a/guest/rust/api_core/src/animation.rs
+++ b/guest/rust/api_core/src/animation.rs
@@ -9,7 +9,7 @@ use crate::{
         ecs::{children, parent},
     },
     entity,
-    prelude::{time, Entity, EntityId},
+    prelude::{absolute_epoch_time, Entity, EntityId},
 };
 
 /// This plays animations, and can handle blending and masking of animations together to create
@@ -80,9 +80,9 @@ impl PlayClipFromUrlNode {
         use crate::components::core::animation;
         let node = Entity::new()
             .with(animation::play_clip_from_url(), url.into())
-            .with(name(), "Play clip from url".to_string())
+            .with(name(), "Play clip from URL".to_string())
             .with(animation::looping(), true)
-            .with(start_time(), time())
+            .with(start_time(), absolute_epoch_time())
             .with(ref_count(), 1)
             .spawn();
         Self(AnimationNode(node))

--- a/guest/rust/api_core/src/global/runtime.rs
+++ b/guest/rust/api_core/src/global/runtime.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, task::Poll, time::Duration};
+use std::{future::Future, task::Poll, time::{Duration, Instant}};
 
 use crate::{
     components, entity,
@@ -6,9 +6,22 @@ use crate::{
     internal::executor::EXECUTOR,
 };
 
-/// The time, relative to Jan 1, 1970.
-pub fn time() -> Duration {
-    entity::get_component(entity::resources(), components::core::app::absolute_time()).unwrap()
+/// The time, relative to the start of the game. Guaranteed to be monotonic.
+pub fn absolute_game_time() -> Duration {
+    entity::get_component(
+        entity::resources(),
+        components::core::app::absolute_game_time(),
+    )
+    .unwrap()
+}
+
+/// The time, relative to Jan 1, 1970. Not guaranteed to be monotonic. Use [absolute_game_time] for most applications.
+pub fn absolute_epoch_time() -> Duration {
+    entity::get_component(
+        entity::resources(),
+        components::core::app::absolute_epoch_time(),
+    )
+    .unwrap()
 }
 
 /// The length of the previous frame, in seconds.
@@ -70,6 +83,6 @@ pub async fn block_until(condition: impl Fn() -> bool) {
 ///
 /// This must be used with `.await` in either an `async fn` or an `async` block.
 pub async fn sleep(seconds: f32) {
-    let target_time = time() + Duration::from_secs_f32(seconds);
-    block_until(|| time() > target_time).await
+    let target_time = Instant::now() + Duration::from_secs_f32(seconds);
+    block_until(|| Instant::now() > target_time).await
 }

--- a/guest/rust/clippy.toml
+++ b/guest/rust/clippy.toml
@@ -1,0 +1,5 @@
+# This is separate to the host-side Clippy settings, as the guest compiles to WASI and supports operations that wasm32-unknown doesn't
+
+disallowed-macros = []
+disallowed-types = []
+disallowed-methods = []

--- a/guest/rust/examples/basics/asset_loading/src/server.rs
+++ b/guest/rust/examples/basics/asset_loading/src/server.rs
@@ -1,4 +1,4 @@
-use std::f64::consts::TAU;
+use std::f32::consts::TAU;
 
 use ambient_api::{
     components::core::{
@@ -42,16 +42,11 @@ pub async fn main() {
     entity::wait_for_component(model, spawned()).await;
 
     ambient_api::messages::Frame::subscribe(move |_| {
-        let t = time().as_secs_f64();
+        let t = absolute_game_time().as_secs_f32();
         entity::set_component(
             model,
             rotation(),
-            Quat::from_euler(
-                EulerRot::ZXY,
-                (t % TAU) as f32,
-                (t * 2.0).sin() as f32 * 0.5,
-                0.0,
-            ),
+            Quat::from_euler(EulerRot::ZXY, t % TAU, (t * 2.0).sin() * 0.5, 0.0),
         );
     });
 }

--- a/guest/rust/examples/basics/async/src/common.rs
+++ b/guest/rust/examples/basics/async/src/common.rs
@@ -1,17 +1,17 @@
 use ambient_api::prelude::*;
 
 pub async fn main() {
-    let start_time = time();
+    let start_time = absolute_game_time();
     loop {
         println!(
             "Hello, world! {} seconds have passed.",
-            (time() - start_time).as_secs_f32()
+            (absolute_game_time() - start_time).as_secs_f32()
         );
         run_async(async move {
             sleep(0.25).await;
             println!(
                 "And hello from here! {} seconds have passed, and the previous tick took {}ms.",
-                (time() - start_time).as_secs_f32(),
+                (absolute_game_time() - start_time).as_secs_f32(),
                 delta_time() * 1_000.
             );
         });

--- a/guest/rust/examples/basics/clientside/src/client.rs
+++ b/guest/rust/examples/basics/clientside/src/client.rs
@@ -26,10 +26,10 @@ pub async fn main() {
         .with(lookat_target(), vec3(0., 0., 0.))
         .spawn();
 
-    let start_time = time();
+    let start_time = absolute_game_time();
 
     ambient_api::messages::Frame::subscribe(move |_| {
-        let t = time() - start_time;
+        let t = absolute_game_time() - start_time;
         entity::set_component(
             id,
             translation(),
@@ -43,7 +43,7 @@ pub async fn main() {
             for (id, position) in entities {
                 let [x, y] = position.to_array();
                 let grid_cell = position - glam::ivec2(side_length, side_length);
-                let t = (time() - start_time).as_secs_f32();
+                let t = (absolute_game_time() - start_time).as_secs_f32();
                 entity::mutate_component(id, translation(), |v| {
                     v.z = (x as f32 + y as f32 + t).sin() - 0.5 * grid_cell.as_vec2().length();
                 });

--- a/guest/rust/examples/games/minigolf/src/server.rs
+++ b/guest/rust/examples/games/minigolf/src/server.rs
@@ -271,7 +271,7 @@ pub fn main() {
         messages::Bonk::new(msg.ids[0]).send_client_broadcast_unreliable();
     });
 
-    let start_time = time();
+    let start_time = absolute_game_time();
 
     // Update player ball each frame.
     query((
@@ -311,7 +311,7 @@ pub fn main() {
             };
 
             let force_multiplier = {
-                let mut mul = (time() - start_time).as_secs_f32() % 2.0;
+                let mut mul = (absolute_game_time() - start_time).as_secs_f32() % 2.0;
                 if mul > 1.0 {
                     mul = 1.0 - (mul - 1.0);
                 }

--- a/guest/rust/examples/games/music_sequencer/src/client.rs
+++ b/guest/rust/examples/games/music_sequencer/src/client.rs
@@ -8,7 +8,7 @@ use ambient_api::{
         },
     },
     entity::synchronized_resources,
-    global::time,
+    global::absolute_game_time,
     messages::Frame,
     prelude::*,
 };
@@ -19,7 +19,7 @@ use components::bpm;
 #[main]
 pub fn main() {
     let mut cursor = 0;
-    let mut last_note_time = time();
+    let mut last_note_time = absolute_game_time();
     let mut last_bpm = 0;
     let mut tree = Element::new().spawn_tree();
     Frame::subscribe(move |_| {
@@ -29,7 +29,7 @@ pub fn main() {
             last_bpm = bpm;
         }
 
-        let now = time();
+        let now = absolute_game_time();
         if now - last_note_time > Duration::from_secs_f32(seconds_per_note(bpm)) {
             last_note_time = now;
             cursor = (cursor + 1) % common::NOTE_COUNT;

--- a/guest/rust/examples/ui/clock/src/client.rs
+++ b/guest/rust/examples/ui/clock/src/client.rs
@@ -19,12 +19,12 @@ fn App(hooks: &mut Hooks) -> Element {
     let size_info = hooks.use_query(window_logical_size());
     let center_x = size_info[0].1.x as f32 / 2.;
     let center_y = size_info[0].1.y as f32 / 2.;
-    let (now, set_now) = hooks.use_state(time());
+    let (now, set_now) = hooks.use_state(absolute_game_time());
     let (x, set_x) = hooks.use_state(size_info[0].1.x as f32 / 2.);
     let (y, set_y) = hooks.use_state(size_info[0].1.y as f32 / 2. - second_r);
     let (phase, set_phase) = hooks.use_state(PI / 30.);
     hooks.use_frame(move |_world| {
-        let latest = time();
+        let latest = absolute_game_time();
         if latest - now > Duration::from_secs_f32(1.0) {
             set_now(latest);
             set_phase({

--- a/guest/rust/examples/ui/todo/src/server.rs
+++ b/guest/rust/examples/ui/todo/src/server.rs
@@ -6,7 +6,7 @@ pub async fn main() {
     messages::NewItem::subscribe(|_source, data| {
         Entity::new()
             .with(todo_item(), data.description)
-            .with(todo_time(), time())
+            .with(todo_time(), absolute_game_time())
             .spawn();
     });
     messages::DeleteItem::subscribe(|_source, data| {

--- a/shared_crates/schema/src/schema/app_.toml
+++ b/shared_crates/schema/src/schema/app_.toml
@@ -15,10 +15,16 @@ name = "Delta time"
 description = "How long the previous tick took in seconds."
 attributes = ["Debuggable", "Resource"]
 
-[components."core::app::absolute_time"]
+[components."core::app::absolute_epoch_time"]
 type = "Duration"
-name = "Absolute time"
+name = "Absolute epoch time"
 description = "Absolute time since epoch (Jan 1, 1970)."
+attributes = ["Debuggable", "Resource"]
+
+[components."core::app::absolute_game_time"]
+type = "Duration"
+name = "Absolute game time"
+description = "Absolute time since the game was started."
 attributes = ["Debuggable", "Resource"]
 
 [components."core::app::element"]


### PR DESCRIPTION
The use of the UNIX epoch for the existing `time()` function resulted in `as_secs_f32` on the guest suffering from integer rounding of f32s (as the current Unix timestamp is past 2^24-1). To avoid this, I've split `time` into `absolute_game_time` and `absolute_epoch_time`, so that users can know what to expect and to pick the one that's more appropriate for their application.

Along the way, I made these other fixes: 

- Be more consistent about the use of `Instant` vs `SystemTime` for ticking
- Use a fixed server tick across the board
- Unify time handling logic across client and server