### PR TITLE
Fix version formatting in network crate

### DIFF
--- a/app/src/cli/new_project.rs
+++ b/app/src/cli/new_project.rs
@@ -71,7 +71,7 @@ pub(crate) fn new_project(
                 {
                     if let Some(api_path) = api_path {
                         format!("ambient_api = {{ path = {:?} }}", api_path)
-                    } else if let Some(rev) = parse_git_revision(git_version::git_version!()) {
+                    } else if let Some(rev) = git_revision() {
                         format!("ambient_api = {{ git = \"https://github.com/AmbientRun/Ambient.git\", rev = \"{}\" }}", rev)
                     } else {
                         format!("ambient_api = \"{}\"", env!("CARGO_PKG_VERSION"))
@@ -131,4 +131,11 @@ pub(crate) fn new_project(
     log::info!("Project \"{name}\" with id `{id}` created at {project_path:?}");
 
     Ok(())
+}
+
+#[cfg(not(feature = "production"))]
+fn git_revision() -> Option<String> {
+    parse_git_revision(git_version::git_version!(
+        args = ["--abbrev=10", "--always", "--long"]
+    ))
 }

--- a/crates/network/src/proto/mod.rs
+++ b/crates/network/src/proto/mod.rs
@@ -28,8 +28,10 @@ pub fn get_version_with_revision() -> String {
     format!(
         "{}-{}",
         VERSION,
-        ambient_std::parse_git_revision(git_version::git_version!())
-            .expect("Failed to find git revision. Please open an issue with `git describe`")
+        ambient_std::parse_git_revision(git_version::git_version!(
+            args = ["--abbrev=10", "--always", "--long"]
+        ))
+        .expect("Failed to find git revision. Please open an issue with `git describe`")
     )
 }
 


### PR DESCRIPTION
https://github.com/AmbientRun/Ambient/issues/559

`--abbrev=10` - use at least 10 characters from commit hash (should we use the full 40?)
`--always` - always show something, that is at least a commit hash (so it works for commits that don't have any tags in their path to the root)
`--long` - always put all fields, otherwise it will skip the commit hash if the commit is tagged