### PR TITLE
Fix input issues

### DIFF
--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -22,6 +22,14 @@ pub struct PlayerRawInput {
     pub mouse_wheel: f32,
     pub mouse_buttons: HashSet<ambient_shared_types::MouseButton>,
 }
+impl PlayerRawInput {
+    pub fn clear(&mut self) {
+        self.keys.clear();
+        self.mouse_delta = vec2(0.0, 0.0);
+        self.mouse_wheel = 0.0;
+        self.mouse_buttons.clear();
+    }
+}
 
 components!("input", {
     event_modifiers_change: ModifiersState,

--- a/guest/rust/api_core/src/client/input.rs
+++ b/guest/rust/api_core/src/client/input.rs
@@ -1,4 +1,7 @@
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
 
 use crate::{
     global::{CursorIcon, Vec2},
@@ -6,6 +9,9 @@ use crate::{
         conversion::{FromBindgen, IntoBindgen},
         wit,
     },
+    message::Listener,
+    messages,
+    prelude::RuntimeMessage,
 };
 
 /// Gets the local player's most recent raw input state.
@@ -50,28 +56,29 @@ pub fn set_cursor_lock(locked: bool) {
 ///
 /// Will unlock the cursor when dropped.
 pub struct CursorLockGuard {
-    locked: bool,
+    inner: Arc<Mutex<CursorLockGuardInner>>,
+    listener: Option<Listener>,
 }
 impl CursorLockGuard {
     /// Creates a new [CursorLockGuard] with the given lock state.
-    pub fn new(locked: bool) -> Self {
-        let mut guard = Self { locked: !locked };
-        guard.set_locked(locked);
-        guard
+    pub fn new() -> Self {
+        let inner = Arc::new(Mutex::new(CursorLockGuardInner::new()));
+        Self {
+            inner: inner.clone(),
+            listener: Some(messages::WindowFocusChange::subscribe(move |msg| {
+                inner.lock().unwrap().set_locked(msg.focused)
+            })),
+        }
     }
 
     /// Locks and hides the cursor if necessary.
     pub fn set_locked(&mut self, locked: bool) {
-        if locked != self.locked {
-            set_cursor_lock(locked);
-            set_cursor_visible(!locked);
-        }
-        self.locked = locked;
+        self.inner.lock().unwrap().set_locked(locked);
     }
 
     /// Returns whether or not the cursor is currently locked.
     pub fn is_locked(&self) -> bool {
-        self.locked
+        self.inner.lock().unwrap().is_locked()
     }
 
     /// Helper that calls [Self::set_locked] with `true`.
@@ -99,6 +106,29 @@ impl CursorLockGuard {
 impl Drop for CursorLockGuard {
     fn drop(&mut self) {
         self.set_locked(false);
+        self.listener.take().unwrap().stop();
+    }
+}
+struct CursorLockGuardInner {
+    locked: bool,
+}
+impl CursorLockGuardInner {
+    fn new() -> Self {
+        Self { locked: false }
+    }
+
+    /// Locks and hides the cursor if necessary.
+    fn set_locked(&mut self, locked: bool) {
+        if locked != self.locked {
+            set_cursor_lock(locked);
+            set_cursor_visible(!locked);
+        }
+        self.locked = locked;
+    }
+
+    /// Returns whether or not the cursor is currently locked.
+    fn is_locked(&self) -> bool {
+        self.locked
     }
 }
 

--- a/guest/rust/examples/basics/first_person_camera/src/client.rs
+++ b/guest/rust/examples/basics/first_person_camera/src/client.rs
@@ -3,7 +3,7 @@ use components::{ball_ref, player_head_ref};
 
 #[main]
 fn main() {
-    let mut cursor_lock = input::CursorLockGuard::new(true);
+    let mut cursor_lock = input::CursorLockGuard::new();
     let spatial_audio_player = audio::SpatialAudioPlayer::new();
 
     spawn_query((player_head_ref(), ball_ref())).bind(move |v| {

--- a/guest/rust/examples/basics/input/src/client.rs
+++ b/guest/rust/examples/basics/input/src/client.rs
@@ -2,7 +2,7 @@ use ambient_api::prelude::*;
 
 #[main]
 pub fn main() {
-    let mut cursor_lock = input::CursorLockGuard::new(true);
+    let mut cursor_lock = input::CursorLockGuard::new();
     ambient_api::messages::Frame::subscribe(move |_| {
         let (delta, input) = input::get_delta();
         if !cursor_lock.auto_unlock_on_escape(&input) {

--- a/guest/rust/examples/basics/third_person_camera/src/client.rs
+++ b/guest/rust/examples/basics/third_person_camera/src/client.rs
@@ -53,7 +53,7 @@ fn main() {
         }
     });
 
-    let mut cursor_lock = input::CursorLockGuard::new(true);
+    let mut cursor_lock = input::CursorLockGuard::new();
     ambient_api::messages::Frame::subscribe(move |_| {
         let (delta, input) = input::get_delta();
         if !cursor_lock.auto_unlock_on_escape(&input) {

--- a/guest/rust/examples/games/minigolf/src/client.rs
+++ b/guest/rust/examples/games/minigolf/src/client.rs
@@ -2,7 +2,7 @@ use ambient_api::{components::core::physics::linear_velocity, prelude::*};
 
 #[main]
 fn main() {
-    let mut cursor_lock = input::CursorLockGuard::new(true);
+    let mut cursor_lock = input::CursorLockGuard::new();
     ambient_api::messages::Frame::subscribe(move |_| {
         let (delta, input) = input::get_delta();
         if !cursor_lock.auto_unlock_on_escape(&input) {


### PR DESCRIPTION
This should fix the two major issues with the input guard/input. 

There is one issue left - alt-tabbing out, moving the cursor out of the window, and alt-tabbing in means that your next click will just defocus the window again - but I think fixing this would require setting the cursor position, which doesn't work on the web, so let's figure out a better solution in the future.