### PR TITLE
feat: concurrent stream handling

### DIFF
--- a/crates/network/src/proto/client.rs
+++ b/crates/network/src/proto/client.rs
@@ -151,7 +151,11 @@ impl ConnectedClient {
             handler(world, assets, send, recv).instrument(debug_span!("handle_bi", name, id))
         };
 
-        handler.await;
+        let rt = ambient_sys::task::RuntimeHandle::current();
+        #[cfg(target_os = "unknown")]
+        rt.spawn_local(handler);
+        #[cfg(not(target_os = "unknown"))]
+        rt.spawn(handler);
 
         Ok(())
     }
@@ -178,7 +182,11 @@ impl ConnectedClient {
             handler(world, assets, recv).instrument(tracing::debug_span!("handle_uni", name, id))
         };
 
-        handler.await;
+        let rt = ambient_sys::task::RuntimeHandle::current();
+        #[cfg(target_os = "unknown")]
+        rt.spawn_local(handler);
+        #[cfg(not(target_os = "unknown"))]
+        rt.spawn(handler);
 
         Ok(())
     }


### PR DESCRIPTION
This will handle the streams on separate tokio/web-sys tasks which prevents new incoming streams from being starved by an in flight stream that is being read.

**Note**: this may induce issues related to assumptions that streams complete in order and that multiple streams are not processed at the same time.

Many of these could be due to short-duration mutex locking and unlocking which may cause logic interleaving in the now concurrent handlers