### PR TITLE
Merge pending diffs before sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "ambient_std",
  "anyhow",
  "atomic_refcell",
+ "bincode",
  "bit-set",
  "bit-vec",
  "byteorder",

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -46,3 +46,6 @@ erased-serde = "0.3"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 tokio = { workspace = true }
+
+[dev-dependencies]
+bincode = { workspace = true }

--- a/crates/network/src/native/server.rs
+++ b/crates/network/src/native/server.rs
@@ -299,8 +299,6 @@ async fn handle_quinn_connection(
     let mut request_recv = FramedRecvStream::new(conn.accept_uni().await?);
     let mut push_send = FramedSendStream::new(conn.open_uni().await?);
 
-    let diffs_rx = diffs_rx.into_stream();
-
     // Send who we are
     push_send.send(ServerPush::ServerInfo(server_info)).await?;
 

--- a/crates/network/src/native/webtransport.rs
+++ b/crates/network/src/native/webtransport.rs
@@ -92,8 +92,6 @@ async fn handle_webtransport_session(
 
     let mut push_send = FramedSendStream::new(conn.open_uni(sid).await?);
 
-    let diffs_rx = diffs_rx.into_stream();
-
     // Send who we are
     push_send.send(ServerPush::ServerInfo(server_info)).await?;
 

--- a/crates/network/src/proto/server.rs
+++ b/crates/network/src/proto/server.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ambient_core::player::get_by_user_id;
-use ambient_ecs::{WorldDiff, WorldStreamFilter};
+use ambient_ecs::{FrozenWorldDiff, WorldDiff, WorldStreamFilter};
 use ambient_std::{fps_counter::FpsSample, log_result};
 use anyhow::Context;
 use bytes::Bytes;
@@ -59,7 +59,7 @@ impl std::fmt::Debug for ConnectedClient {
 /// Holds information relevant for all states of a given connection to a client
 pub struct ConnectionData {
     pub(crate) state: SharedServerState,
-    pub(crate) diff_tx: flume::Sender<Bytes>,
+    pub(crate) diff_tx: flume::Sender<FrozenWorldDiff>,
     /// Unique identifier for this session
     /// Used to declare ownership of the player entity when multiple simultaneous connections are made or reconnected
     pub(crate) connection_id: Uuid,
@@ -153,9 +153,8 @@ impl ServerProtoState {
         tracing::debug!("[{}] Creating init diff", user_id);
 
         let diff = data.world_stream_filter.initial_diff(&instance.world);
-        let diff = bincode::serialize(&diff).unwrap().into();
 
-        log_result!(data.diff_tx.send(diff));
+        log_result!(data.diff_tx.send(diff.into()));
         tracing::debug!("[{}] Init diff sent", user_id);
 
         let entity_data = create_player_entity_data(
@@ -358,11 +357,25 @@ pub async fn handle_stats<S>(
 /// Sends the world diffs over the network
 pub async fn handle_diffs<S>(
     mut stream: stream::FramedSendStream<WorldDiff, S>,
-    mut diffs_rx: impl Unpin + Stream<Item = Bytes>,
+    diffs_rx: flume::Receiver<FrozenWorldDiff>,
 ) where
     S: Unpin + AsyncWrite,
 {
-    while let Some(msg) = diffs_rx.next().await {
+    while let Ok(diff) = diffs_rx.recv_async().await {
+        // get all diffs waiting in the channel to clear the queue
+        let mut diffs = Vec::with_capacity(diffs_rx.len() + 1);
+        diffs.push(diff);
+        diffs.extend(diffs_rx.drain());
+        tracing::trace!(diffs_count = diffs.len());
+
+        // merge them together
+        let final_diff = FrozenWorldDiff::merge(&diffs);
+        let msg: Bytes = bincode::serialize(&final_diff).unwrap().into();
+        debug_assert!(
+            bincode::deserialize::<WorldDiff>(msg.as_ref()).is_ok(),
+            "Merged diff should deserialize as WorldDiff correctly"
+        );
+
         let span = tracing::debug_span!("send_world_diff");
         tracing::trace!(diff=?msg);
         if let Err(err) = stream.send_bytes(msg).instrument(span).await {

--- a/crates/network/src/rpc.rs
+++ b/crates/network/src/rpc.rs
@@ -146,8 +146,7 @@ pub async fn rpc_join_instance(args: ServerRpcArgs, new_instance_id: String) {
         ));
     state.players.get_mut(&args.user_id).unwrap().instance = new_instance_id.to_string();
 
-    let msg = bincode::serialize(&diff).unwrap().into();
-    entities_tx.send(msg).ok();
+    entities_tx.send(diff.into()).ok();
 
     // Remove old instance
     if old_player_count == 1 && old_instance_id != MAIN_INSTANCE_ID {


### PR DESCRIPTION
Quick fix for diff queue build up when sending diffs is delayed (due to bad network conditions).

Note that although it tries to be frugal on clones and allocations it still scales linearly with the number of connected players. It shouldn't be a problem for now but I would like to put some more work on our diff streaming in seperate PRs.

Because of the above it adds 2 temporary `WorldDiff` variants/flavours:
- `WorldDiffView<'a>` - storing a selection of changes
- `FrozenWorldDiff` - immutable `WorldDiff` that is cheap to share via `clone` (kind of like `Bytes`)
Which all serialise the same way (being just a collection of `WorldChange`).