### PR TITLE
Clean up Ambient native entrypoint

### DIFF
--- a/app/src/cli/assets.rs
+++ b/app/src/cli/assets.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::{Args, Subcommand};
+
+use super::ProjectPath;
+
+#[derive(Subcommand, Clone, Debug)]
+pub enum AssetCommand {
+    /// Migrate json pipelines to toml
+    #[command(name = "migrate-pipelines-toml")]
+    MigratePipelinesToml(MigrateOptions),
+    /// Import new assets with interactive prompts
+    #[command(name = "import")]
+    Import(ImportOptions),
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct MigrateOptions {
+    #[arg(index = 1, default_value = "./assets")]
+    /// The path to the assets folder
+    pub path: PathBuf,
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct ImportOptions {
+    #[arg(index = 1)]
+    /// The path to the assets you want to import
+    pub path: PathBuf,
+    #[arg(long)]
+    /// Whether to convert audio files to OGG
+    pub convert_audio: bool,
+    /// Whether to generate a collider from the model
+    #[arg(long)]
+    pub collider_from_model: bool,
+}
+
+pub async fn handle(command: &AssetCommand) -> anyhow::Result<()> {
+    match command {
+        AssetCommand::MigratePipelinesToml(opt) => {
+            let path = ProjectPath::new_local(opt.path.clone())?;
+            ambient_build::migrate::toml::process(path.fs_path.unwrap())
+                .await
+                .context("Failed to migrate pipelines")?;
+        }
+        AssetCommand::Import(opt) => match opt.path.extension() {
+            Some(ext) => {
+                if ext == "wav" || ext == "mp3" || ext == "ogg" {
+                    let convert = opt.convert_audio;
+                    ambient_build::pipelines::import_audio(opt.path.clone(), convert)
+                        .context("failed to import audio")?;
+                } else if ext == "fbx" || ext == "glb" || ext == "gltf" || ext == "obj" {
+                    let collider_from_model = opt.collider_from_model;
+                    ambient_build::pipelines::import_model(opt.path.clone(), collider_from_model)
+                        .context("failed to import models")?;
+                } else if ext == "jpg" || ext == "png" || ext == "gif" || ext == "webp" {
+                    // TODO: import textures API may change, so this is just a placeholder
+                    todo!();
+                } else {
+                    anyhow::bail!("Unsupported file type");
+                }
+            }
+            None => anyhow::bail!("Unknown file type"),
+        },
+    }
+
+    Ok(())
+}

--- a/app/src/cli/build.rs
+++ b/app/src/cli/build.rs
@@ -1,0 +1,64 @@
+use ambient_native_std::{asset_cache::AssetCache, asset_url::AbsAssetUrl};
+use anyhow::Context;
+
+use crate::shared;
+
+use super::{ProjectCli, ProjectPath};
+
+pub async fn build(
+    project: Option<&ProjectCli>,
+    project_path: ProjectPath,
+    assets: &AssetCache,
+) -> anyhow::Result<(ProjectPath, Option<AbsAssetUrl>)> {
+    let Some(project) = project else {
+        return Ok((project_path, None));
+    };
+
+    if project.no_build {
+        return Ok((project_path, None));
+    }
+
+    let Some(project_path) = project_path.fs_path else {
+        return Ok((project_path, None));
+    };
+
+    let build_path = project_path.join("build");
+    // The build step uses its own semantic to ensure that there is
+    // no contamination, so that the built project can use its own
+    // semantic based on the flat hierarchy.
+    let mut semantic = ambient_project_semantic::Semantic::new().await?;
+    let primary_ember_scope_id = shared::ember::add(None, &mut semantic, &project_path).await?;
+
+    let manifest = semantic
+        .items
+        .get(primary_ember_scope_id)?
+        .manifest
+        .clone()
+        .context("no manifest for scope")?;
+
+    let build_config = ambient_build::BuildConfiguration {
+        build_path: build_path.clone(),
+        assets: assets.clone(),
+        semantic: &mut semantic,
+        optimize: project.release,
+        clean_build: project.clean_build,
+        build_wasm_only: project.build_wasm_only,
+    };
+
+    let project_name = manifest
+        .ember
+        .name
+        .as_deref()
+        .unwrap_or_else(|| manifest.ember.id.as_str());
+
+    tracing::info!("Building project {:?}", project_name);
+
+    let output_path = ambient_build::build(build_config, primary_ember_scope_id)
+        .await
+        .context("Failed to build project")?;
+
+    anyhow::Ok((
+        ProjectPath::new_local(output_path)?,
+        Some(AbsAssetUrl::from_file_path(build_path)),
+    ))
+}

--- a/app/src/cli/client.rs
+++ b/app/src/cli/client.rs
@@ -1,0 +1,53 @@
+use ambient_audio::AudioStream;
+use ambient_core::window::ExitStatus;
+use ambient_native_std::asset_cache::AssetCache;
+use ambient_network::native::client::ResolvedAddr;
+use anyhow::Context;
+
+use crate::client;
+
+use super::{ProjectPath, RunCli};
+
+pub fn handle(
+    run: &RunCli,
+    rt: &tokio::runtime::Runtime,
+    assets: AssetCache,
+    server_addr: ResolvedAddr,
+    original_project_path: ProjectPath,
+) -> anyhow::Result<()> {
+    // Hey! listen, it is time to setup audio
+    let audio_stream = if !run.mute_audio {
+        log::info!("Creating audio stream");
+        match AudioStream::new().context("Failed to initialize audio stream") {
+            Ok(v) => Some(v),
+            Err(err) => {
+                log::error!("Failed to initialize audio stream: {err}");
+                None
+            }
+        }
+    } else {
+        log::info!("Audio is disabled");
+        None
+    };
+
+    let mixer = if run.mute_audio {
+        None
+    } else {
+        audio_stream.as_ref().map(|v| v.mixer().clone())
+    };
+
+    // If we have run parameters, start a client and join a server
+    let exit_status = rt.block_on(client::run(
+        assets,
+        server_addr,
+        run,
+        original_project_path.fs_path,
+        mixer,
+    ));
+
+    if exit_status == ExitStatus::FAILURE {
+        anyhow::bail!("client::run failed with {exit_status:?}");
+    }
+
+    Ok(())
+}

--- a/app/src/cli/deploy.rs
+++ b/app/src/cli/deploy.rs
@@ -1,0 +1,42 @@
+use ambient_native_std::{asset_cache::AssetCache, asset_url::AbsAssetUrl};
+
+use crate::retrieve_project_path_and_manifest;
+
+use super::ProjectPath;
+
+pub async fn handle(
+    project_path: &ProjectPath,
+    assets: &AssetCache,
+    build_path: Option<&AbsAssetUrl>,
+    token: &str,
+    api_server: &str,
+    force_upload: bool,
+    ensure_running: bool,
+    context: &str,
+) -> Result<(), anyhow::Error> {
+    let (project_path, manifest, _build_path) =
+        retrieve_project_path_and_manifest(project_path, assets, build_path).await?;
+
+    let Some(project_fs_path) = &project_path.fs_path else {
+        anyhow::bail!("Can only deploy a local project");
+    };
+
+    let deployment_id =
+        ambient_deploy::deploy(api_server, token, project_fs_path, &manifest, force_upload).await?;
+
+    log::info!(
+        "Assets deployed successfully. Deployment id: {}. Deploy url: https://assets.ambient.run/{}",
+        deployment_id,
+        deployment_id,
+    );
+
+    if ensure_running {
+        let spec = ambient_cloud_client::ServerSpec::new_with_deployment(deployment_id)
+            .with_context(context.to_string());
+        let server =
+            ambient_cloud_client::ensure_server_running(assets, api_server, token.into(), spec)
+                .await?;
+        log::info!("Deployed ember is running at {}", server.host);
+    }
+    Ok(())
+}

--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -4,6 +4,17 @@ use clap::{Args, Parser, Subcommand};
 
 pub mod new_project;
 
+pub mod assets;
+pub mod build;
+pub mod client;
+pub mod deploy;
+pub mod server;
+
+mod project_path;
+pub use project_path::*;
+
+use self::assets::AssetCommand;
+
 #[derive(Parser, Clone)]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -83,36 +94,6 @@ pub enum Commands {
         #[command(subcommand)]
         command: AssetCommand,
     },
-}
-
-#[derive(Args, Clone, Debug)]
-pub struct MigrateOptions {
-    #[arg(index = 1, default_value = "./assets")]
-    /// The path to the assets folder
-    pub path: PathBuf,
-}
-
-#[derive(Args, Clone, Debug)]
-pub struct ImportOptions {
-    #[arg(index = 1)]
-    /// The path to the assets you want to import
-    pub path: PathBuf,
-    #[arg(long)]
-    /// Whether to convert audio files to OGG
-    pub convert_audio: bool,
-    /// Whether to generate a collider from the model
-    #[arg(long)]
-    pub collider_from_model: bool,
-}
-
-#[derive(Subcommand, Clone, Debug)]
-pub enum AssetCommand {
-    /// Migrate json pipelines to toml
-    #[command(name = "migrate-pipelines-toml")]
-    MigratePipelinesToml(MigrateOptions),
-    /// Import new assets with interactive prompts
-    #[command(name = "import")]
-    Import(ImportOptions),
 }
 
 #[derive(Subcommand, Clone, Copy, Debug)]

--- a/app/src/cli/new_project.rs
+++ b/app/src/cli/new_project.rs
@@ -5,11 +5,17 @@ use ambient_project::SnakeCaseIdentifier;
 use anyhow::Context;
 use convert_case::Casing;
 
-pub(crate) fn new_project(
-    project_path: &Path,
+use super::ProjectPath;
+
+pub(crate) fn handle(
+    project_path: &ProjectPath,
     name: Option<&str>,
     api_path: Option<&str>,
 ) -> anyhow::Result<()> {
+    let Some(project_path) = &project_path.fs_path else {
+        anyhow::bail!("Cannot create project in a remote directory.");
+    };
+
     // Build the identifier.
     let project_path = if let Some(name) = name {
         project_path.join(name)

--- a/app/src/cli/project_path.rs
+++ b/app/src/cli/project_path.rs
@@ -1,0 +1,65 @@
+use ambient_native_std::asset_url::AbsAssetUrl;
+use anyhow::Context;
+use std::{path::PathBuf, str::FromStr};
+
+#[derive(Debug, Clone)]
+pub struct ProjectPath {
+    pub url: AbsAssetUrl,
+    pub fs_path: Option<std::path::PathBuf>,
+}
+
+impl ProjectPath {
+    pub fn new_local(path: impl Into<PathBuf>) -> anyhow::Result<Self> {
+        let path = path.into();
+        let current_dir = std::env::current_dir().context("Error getting current directory")?;
+        let path = if path.is_absolute() {
+            path
+        } else {
+            ambient_std::path::normalize(&current_dir.join(path))
+        };
+
+        if path.exists() && !path.is_dir() {
+            anyhow::bail!("Project path {path:?} exists and is not a directory.");
+        }
+        let url = AbsAssetUrl::from_directory_path(path);
+        let fs_path = url.to_file_path().ok().flatten();
+
+        Ok(Self { url, fs_path })
+    }
+
+    pub fn is_remote(&self) -> bool {
+        self.fs_path.is_none()
+    }
+
+    // 'static to limit only to compile-time known paths
+    pub fn push(&self, path: &'static str) -> AbsAssetUrl {
+        self.url.push(path).unwrap()
+    }
+}
+
+impl TryFrom<Option<String>> for ProjectPath {
+    type Error = anyhow::Error;
+
+    fn try_from(project_path: Option<String>) -> anyhow::Result<Self> {
+        match project_path {
+            Some(project_path)
+                if project_path.starts_with("http://")
+                    || project_path.starts_with("https://")
+                    || project_path.starts_with("file:/") =>
+            {
+                let url = AbsAssetUrl::from_str(&project_path)?;
+                if let Some(local) = url.to_file_path()? {
+                    Self::new_local(local)
+                } else {
+                    Ok(Self { url, fs_path: None })
+                }
+            }
+            Some(project_path) => Self::new_local(project_path),
+            None => {
+                let url = AbsAssetUrl::from_directory_path(std::env::current_dir()?);
+                let fs_path = url.to_file_path().ok().flatten();
+                Ok(Self { url, fs_path })
+            }
+        }
+    }
+}

--- a/app/src/cli/server.rs
+++ b/app/src/cli/server.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+
+use ambient_native_std::{asset_cache::AssetCache, asset_url::AbsAssetUrl};
+use ambient_network::native::client::ResolvedAddr;
+use anyhow::Context;
+
+use crate::{
+    retrieve_project_path_and_manifest, server,
+    shared::certs::{CERT, CERT_KEY},
+};
+
+use super::{HostCli, ProjectPath};
+
+pub async fn handle(
+    host: &HostCli,
+    view_asset_path: Option<PathBuf>,
+    project_path: ProjectPath,
+    build_path: Option<AbsAssetUrl>,
+    assets: &AssetCache,
+) -> anyhow::Result<ResolvedAddr> {
+    let (project_path, manifest, build_path) =
+        retrieve_project_path_and_manifest(&project_path, &assets, build_path.as_ref()).await?;
+
+    let crypto = if let (Some(cert_file), Some(key_file)) = (&host.cert, &host.key) {
+        let raw_cert = std::fs::read(cert_file).context("Failed to read certificate file")?;
+        let cert_chain = if raw_cert.starts_with(b"-----BEGIN CERTIFICATE-----") {
+            rustls_pemfile::certs(&mut raw_cert.as_slice())
+                .context("Failed to parse certificate file")?
+        } else {
+            vec![raw_cert]
+        };
+        let raw_key = std::fs::read(key_file).context("Failed to read certificate key")?;
+        let key = if raw_key.starts_with(b"-----BEGIN ") {
+            rustls_pemfile::read_all(&mut raw_key.as_slice())
+                .context("Failed to parse certificate key")?
+                .into_iter()
+                .find_map(|item| match item {
+                    rustls_pemfile::Item::RSAKey(key) => Some(key),
+                    rustls_pemfile::Item::PKCS8Key(key) => Some(key),
+                    rustls_pemfile::Item::ECKey(key) => Some(key),
+                    _ => None,
+                })
+                .ok_or_else(|| anyhow::anyhow!("No private key found"))?
+        } else {
+            raw_key
+        };
+        ambient_network::native::server::Crypto { cert_chain, key }
+    } else {
+        #[cfg(feature = "no_bundled_certs")]
+        {
+            anyhow::bail!("--cert and --key are required without bundled certs.");
+        }
+        #[cfg(not(feature = "no_bundled_certs"))]
+        {
+            tracing::info!("Using bundled certificate and key");
+            ambient_network::native::server::Crypto {
+                cert_chain: vec![CERT.to_vec()],
+                key: CERT_KEY.to_vec(),
+            }
+        }
+    };
+
+    let working_directory = project_path
+        .fs_path
+        .clone()
+        .unwrap_or(std::env::current_dir()?);
+
+    let addr = server::start(
+        assets.clone(),
+        host,
+        view_asset_path,
+        working_directory,
+        project_path.url.clone(),
+        build_path,
+        manifest,
+        crypto,
+    )
+    .await;
+
+    Ok(ResolvedAddr::localhost_with_port(addr.port()))
+}

--- a/app/src/client/mod.rs
+++ b/app/src/client/mod.rs
@@ -22,7 +22,7 @@ use glam::uvec2;
 
 use crate::{
     cli::{GoldenImageCommand, RunCli},
-    shared,
+    shared::{self, certs::CERT},
 };
 
 mod wasm;
@@ -58,7 +58,7 @@ pub async fn run(
     } else {
         #[cfg(not(feature = "no_bundled_certs"))]
         {
-            Some(super::CERT.to_vec())
+            Some(CERT.to_vec())
         }
         #[cfg(feature = "no_bundled_certs")]
         {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,10 +1,3 @@
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-};
-
-use ambient_audio::AudioStream;
-use ambient_core::window::ExitStatus;
 use ambient_native_std::{
     asset_cache::{AssetCache, SyncAssetKeyExt},
     asset_url::{AbsAssetUrl, ContentBaseUrlKey},
@@ -19,16 +12,10 @@ mod server;
 mod shared;
 
 use ambient_physics::physx::PhysicsKey;
-use anyhow::{bail, Context};
-use cli::{AssetCommand, Cli, Commands, ProjectCli};
+use anyhow::Context;
+use cli::{Cli, Commands, ProjectPath};
 use log::LevelFilter;
 use server::QUIC_INTERFACE_PORT;
-
-#[cfg(not(feature = "no_bundled_certs"))]
-const CERT: &[u8] = include_bytes!("../../localhost.crt");
-
-#[cfg(not(feature = "no_bundled_certs"))]
-const CERT_KEY: &[u8] = include_bytes!("../../localhost.key");
 
 fn main() -> anyhow::Result<()> {
     let rt = ambient_sys::task::make_native_multithreaded_runtime()?;
@@ -62,26 +49,21 @@ fn main() -> anyhow::Result<()> {
 
     // If new: create project, immediately exit
     if let Commands::New { name, api_path, .. } = &cli.command {
-        return new_project_cmd(&project_path, name, api_path);
+        return cli::new_project::handle(&project_path, name.as_deref(), api_path.as_deref())
+            .context("Failed to create project");
     }
 
     if let Commands::Assets { command } = &cli.command {
-        return rt.block_on(assets_cmd(command));
+        return rt.block_on(cli::assets::handle(command));
     }
 
-    // Build the project if required. Note that this only runs if the project is local.
+    // Build the project if required. Note that this only runs if the project is local,
+    // and if a build has actually been requested.
     //
     // Update the project path to match the build path if necessary.
     let original_project_path = project_path.clone();
-    let (project_path, build_path) = if let Some((project, project_path)) = project
-        .as_ref()
-        .filter(|p| !p.no_build)
-        .zip(project_path.fs_path.as_deref())
-    {
-        rt.block_on(build_project(project, project_path, &assets))?
-    } else {
-        (project_path.clone(), None)
-    };
+    let (project_path, build_path) =
+        rt.block_on(cli::build::build(project, project_path, &assets))?;
 
     // If this is just a build, exit now
     if matches!(&cli.command, Commands::Build { .. }) {
@@ -98,7 +80,7 @@ fn main() -> anyhow::Result<()> {
         ..
     } = &cli.command
     {
-        return rt.block_on(deploy_cli(
+        return rt.block_on(cli::deploy::handle(
             &project_path,
             &assets,
             build_path.as_ref(),
@@ -137,18 +119,16 @@ fn main() -> anyhow::Result<()> {
             ResolvedAddr::localhost_with_port(QUIC_INTERFACE_PORT)
         }
     } else if let Some(host) = &cli.host() {
-        let (project_path, manifest, build_path) = rt.block_on(
-            retrieve_project_path_and_manifest(&project_path, &assets, build_path.as_ref()),
-        )?;
-
-        rt.block_on(server_run_cmd(
+        rt.block_on(cli::server::handle(
             host,
+            if let cli::Commands::View { asset_path, .. } = &cli.command {
+                Some(asset_path.clone())
+            } else {
+                None
+            },
             project_path,
-            runtime,
-            &assets,
-            &cli,
             build_path,
-            manifest,
+            &assets,
         ))?
     } else {
         unreachable!()
@@ -156,7 +136,7 @@ fn main() -> anyhow::Result<()> {
 
     // Time to join!
     if let Some(run) = cli.run() {
-        client_run_cmd(run, &rt, assets, server_addr, original_project_path)?;
+        cli::client::handle(run, &rt, assets, server_addr, original_project_path)?;
     } else {
         // Otherwise, wait for the Ctrl+C signal
         match rt.block_on(tokio::signal::ctrl_c()) {
@@ -168,52 +148,15 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn deploy_cli(
-    project_path: &ProjectPath,
-    assets: &AssetCache,
-    build_path: Option<&AbsAssetUrl>,
-    token: &str,
-    api_server: &str,
-    force_upload: bool,
-    ensure_running: bool,
-    context: &str,
-) -> Result<(), anyhow::Error> {
-    let (project_path, manifest, _build_path) =
-        retrieve_project_path_and_manifest(project_path, assets, build_path).await?;
-
-    let Some(project_fs_path) = &project_path.fs_path else {
-            anyhow::bail!("Can only deploy a local project");
-        };
-
-    let deployment_id =
-        ambient_deploy::deploy(api_server, token, project_fs_path, &manifest, force_upload).await?;
-
-    log::info!(
-        "Assets deployed successfully. Deployment id: {}. Deploy url: https://assets.ambient.run/{}",
-        deployment_id,
-        deployment_id,
-    );
-
-    if ensure_running {
-        let spec = ambient_cloud_client::ServerSpec::new_with_deployment(deployment_id)
-            .with_context(context.to_string());
-        let server =
-            ambient_cloud_client::ensure_server_running(assets, api_server, token.into(), spec)
-                .await?;
-        log::info!("Deployed ember is running at {}", server.host);
-    }
-    Ok(())
-}
-
+// Read the project manifest from the project path (which may have been updated by the build step)
+// We attempt both the root and build/ as `ambient.toml` is in the former for local builds,
+// and in the latter for deployed builds. This will likely be improved if/when deployments
+// no longer have their own build directory.
 async fn retrieve_project_path_and_manifest(
     project_path: &ProjectPath,
     assets: &AssetCache,
     build_path: Option<&AbsAssetUrl>,
 ) -> anyhow::Result<(ProjectPath, ambient_project::Manifest, AbsAssetUrl)> {
-    // Read the project manifest from the project path (which may have been updated by the build step)
-    // We attempt both the root and build/ as `ambient.toml` is in the former for local builds,
-    // and in the latter for deployed builds. This will likely be improved if/when deployments
-    // no longer have their own build directory.
     async fn get_new_project_path_and_manifest(
         project_path: &ProjectPath,
         assets: &AssetCache,
@@ -237,212 +180,6 @@ async fn retrieve_project_path_and_manifest(
         .cloned()
         .unwrap_or_else(|| project_path.url.push("build").unwrap());
     Ok((project_path, manifest, build_path))
-}
-
-async fn build_project(
-    project: &ProjectCli,
-    project_path: &Path,
-    assets: &AssetCache,
-) -> anyhow::Result<(ProjectPath, Option<AbsAssetUrl>)> {
-    let build_path = project_path.join("build");
-    // The build step uses its own semantic to ensure that there is
-    // no contamination, so that the built project can use its own
-    // semantic based on the flat hierarchy.
-    let mut semantic = ambient_project_semantic::Semantic::new().await?;
-    let primary_ember_scope_id = shared::ember::add(None, &mut semantic, project_path).await?;
-
-    let manifest = semantic
-        .items
-        .get(primary_ember_scope_id)?
-        .manifest
-        .clone()
-        .context("no manifest for scope")?;
-
-    let build_config = ambient_build::BuildConfiguration {
-        build_path: build_path.clone(),
-        assets: assets.clone(),
-        semantic: &mut semantic,
-        optimize: project.release,
-        clean_build: project.clean_build,
-        build_wasm_only: project.build_wasm_only,
-    };
-
-    let project_name = manifest
-        .ember
-        .name
-        .as_deref()
-        .unwrap_or_else(|| manifest.ember.id.as_str());
-
-    tracing::info!("Building project {:?}", project_name);
-
-    let output_path = ambient_build::build(build_config, primary_ember_scope_id)
-        .await
-        .context("Failed to build project")?;
-
-    anyhow::Ok((
-        ProjectPath::new_local(output_path)?,
-        Some(AbsAssetUrl::from_file_path(build_path)),
-    ))
-}
-
-async fn server_run_cmd(
-    host: &cli::HostCli,
-    project_path: ProjectPath,
-    runtime: &tokio::runtime::Handle,
-    assets: &AssetCache,
-    cli: &Cli,
-    build_path: AbsAssetUrl,
-    manifest: ambient_project::Manifest,
-) -> anyhow::Result<ResolvedAddr> {
-    let crypto = if let (Some(cert_file), Some(key_file)) = (&host.cert, &host.key) {
-        let raw_cert = std::fs::read(cert_file).context("Failed to read certificate file")?;
-        let cert_chain = if raw_cert.starts_with(b"-----BEGIN CERTIFICATE-----") {
-            rustls_pemfile::certs(&mut raw_cert.as_slice())
-                .context("Failed to parse certificate file")?
-        } else {
-            vec![raw_cert]
-        };
-        let raw_key = std::fs::read(key_file).context("Failed to read certificate key")?;
-        let key = if raw_key.starts_with(b"-----BEGIN ") {
-            rustls_pemfile::read_all(&mut raw_key.as_slice())
-                .context("Failed to parse certificate key")?
-                .into_iter()
-                .find_map(|item| match item {
-                    rustls_pemfile::Item::RSAKey(key) => Some(key),
-                    rustls_pemfile::Item::PKCS8Key(key) => Some(key),
-                    rustls_pemfile::Item::ECKey(key) => Some(key),
-                    _ => None,
-                })
-                .ok_or_else(|| anyhow::anyhow!("No private key found"))?
-        } else {
-            raw_key
-        };
-        ambient_network::native::server::Crypto { cert_chain, key }
-    } else {
-        #[cfg(feature = "no_bundled_certs")]
-        {
-            anyhow::bail!("--cert and --key are required without bundled certs.");
-        }
-        #[cfg(not(feature = "no_bundled_certs"))]
-        {
-            tracing::info!("Using bundled certificate and key");
-            ambient_network::native::server::Crypto {
-                cert_chain: vec![CERT.to_vec()],
-                key: CERT_KEY.to_vec(),
-            }
-        }
-    };
-
-    let working_directory = project_path
-        .fs_path
-        .clone()
-        .unwrap_or(std::env::current_dir()?);
-
-    let addr = server::start(
-        runtime,
-        assets.clone(),
-        cli.clone(),
-        working_directory,
-        project_path.url.clone(),
-        build_path,
-        manifest,
-        crypto,
-    )
-    .await;
-
-    Ok(ResolvedAddr::localhost_with_port(addr.port()))
-}
-
-fn client_run_cmd(
-    run: &cli::RunCli,
-    rt: &tokio::runtime::Runtime,
-    assets: AssetCache,
-    server_addr: ResolvedAddr,
-    original_project_path: ProjectPath,
-) -> anyhow::Result<()> {
-    // Hey! listen, it is time to setup audio
-    let audio_stream = if !run.mute_audio {
-        log::info!("Creating audio stream");
-        match AudioStream::new().context("Failed to initialize audio stream") {
-            Ok(v) => Some(v),
-            Err(err) => {
-                log::error!("Failed to initialize audio stream: {err}");
-                None
-            }
-        }
-    } else {
-        log::info!("Audio is disabled");
-        None
-    };
-
-    let mixer = if run.mute_audio {
-        None
-    } else {
-        audio_stream.as_ref().map(|v| v.mixer().clone())
-    };
-
-    // If we have run parameters, start a client and join a server
-    let exit_status = rt.block_on(client::run(
-        assets,
-        server_addr,
-        run,
-        original_project_path.fs_path,
-        mixer,
-    ));
-
-    if exit_status == ExitStatus::FAILURE {
-        bail!("client::run failed with {exit_status:?}");
-    }
-
-    Ok(())
-}
-
-fn new_project_cmd(
-    project_path: &ProjectPath,
-    name: &Option<String>,
-    api_path: &Option<String>,
-) -> anyhow::Result<()> {
-    if let Some(path) = &project_path.fs_path {
-        if let Err(err) = cli::new_project::new_project(path, name.as_deref(), api_path.as_deref())
-        {
-            eprintln!("Failed to create project: {err:?}");
-        }
-    } else {
-        eprintln!("Cannot create project in a remote directory.");
-    }
-    Ok(())
-}
-
-async fn assets_cmd(command: &AssetCommand) -> anyhow::Result<()> {
-    match command {
-        AssetCommand::MigratePipelinesToml(opt) => {
-            let path = ProjectPath::new_local(opt.path.clone())?;
-            ambient_build::migrate::toml::process(path.fs_path.unwrap())
-                .await
-                .context("Failed to migrate pipelines")?;
-        }
-        AssetCommand::Import(opt) => match opt.path.extension() {
-            Some(ext) => {
-                if ext == "wav" || ext == "mp3" || ext == "ogg" {
-                    let convert = opt.convert_audio;
-                    ambient_build::pipelines::import_audio(opt.path.clone(), convert)
-                        .context("failed to import audio")?;
-                } else if ext == "fbx" || ext == "glb" || ext == "gltf" || ext == "obj" {
-                    let collider_from_model = opt.collider_from_model;
-                    ambient_build::pipelines::import_model(opt.path.clone(), collider_from_model)
-                        .context("failed to import models")?;
-                } else if ext == "jpg" || ext == "png" || ext == "gif" || ext == "webp" {
-                    // TODO: import textures API may change, so this is just a placeholder
-                    todo!();
-                } else {
-                    bail!("Unsupported file type");
-                }
-            }
-            None => bail!("Unknown file type"),
-        },
-    }
-
-    Ok(())
 }
 
 fn setup_logging() -> anyhow::Result<()> {
@@ -544,67 +281,5 @@ fn setup_logging() -> anyhow::Result<()> {
             .try_init()?;
 
         Ok(())
-    }
-}
-
-#[derive(Debug, Clone)]
-struct ProjectPath {
-    url: AbsAssetUrl,
-    fs_path: Option<std::path::PathBuf>,
-}
-
-impl ProjectPath {
-    fn new_local(path: impl Into<PathBuf>) -> anyhow::Result<Self> {
-        let path = path.into();
-        let current_dir = std::env::current_dir().context("Error getting current directory")?;
-        let path = if path.is_absolute() {
-            path
-        } else {
-            ambient_std::path::normalize(&current_dir.join(path))
-        };
-
-        if path.exists() && !path.is_dir() {
-            anyhow::bail!("Project path {path:?} exists and is not a directory.");
-        }
-        let url = AbsAssetUrl::from_directory_path(path);
-        let fs_path = url.to_file_path().ok().flatten();
-
-        Ok(Self { url, fs_path })
-    }
-
-    fn is_remote(&self) -> bool {
-        self.fs_path.is_none()
-    }
-
-    // 'static to limit only to compile-time known paths
-    fn push(&self, path: &'static str) -> AbsAssetUrl {
-        self.url.push(path).unwrap()
-    }
-}
-
-impl TryFrom<Option<String>> for ProjectPath {
-    type Error = anyhow::Error;
-
-    fn try_from(project_path: Option<String>) -> anyhow::Result<Self> {
-        match project_path {
-            Some(project_path)
-                if project_path.starts_with("http://")
-                    || project_path.starts_with("https://")
-                    || project_path.starts_with("file:/") =>
-            {
-                let url = AbsAssetUrl::from_str(&project_path)?;
-                if let Some(local) = url.to_file_path()? {
-                    Self::new_local(local)
-                } else {
-                    Ok(Self { url, fs_path: None })
-                }
-            }
-            Some(project_path) => Self::new_local(project_path),
-            None => {
-                let url = AbsAssetUrl::from_directory_path(std::env::current_dir()?);
-                let fs_path = url.to_file_path().ok().flatten();
-                Ok(Self { url, fs_path })
-            }
-        }
     }
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use ambient_audio::AudioStream;
 use ambient_core::window::ExitStatus;
@@ -17,7 +20,7 @@ mod shared;
 
 use ambient_physics::physx::PhysicsKey;
 use anyhow::{bail, Context};
-use cli::{AssetCommand, Cli, Commands};
+use cli::{AssetCommand, Cli, Commands, ProjectCli};
 use log::LevelFilter;
 use server::QUIC_INTERFACE_PORT;
 
@@ -59,53 +62,11 @@ fn main() -> anyhow::Result<()> {
 
     // If new: create project, immediately exit
     if let Commands::New { name, api_path, .. } = &cli.command {
-        if let Some(path) = &project_path.fs_path {
-            if let Err(err) =
-                cli::new_project::new_project(path, name.as_deref(), api_path.as_deref())
-            {
-                eprintln!("Failed to create project: {err:?}");
-            }
-        } else {
-            eprintln!("Cannot create project in a remote directory.");
-        }
-        return Ok(());
+        return new_project_cmd(&project_path, name, api_path);
     }
 
     if let Commands::Assets { command } = &cli.command {
-        return rt.block_on(async {
-            match command {
-                AssetCommand::MigratePipelinesToml(opt) => {
-                    let path = ProjectPath::new_local(opt.path.clone())?;
-                    ambient_build::migrate::toml::process(path.fs_path.unwrap())
-                        .await
-                        .context("Failed to migrate pipelines")?;
-                }
-                AssetCommand::Import(opt) => match opt.path.extension() {
-                    Some(ext) => {
-                        if ext == "wav" || ext == "mp3" || ext == "ogg" {
-                            let convert = opt.convert_audio;
-                            ambient_build::pipelines::import_audio(opt.path.clone(), convert)
-                                .context("failed to import audio")?;
-                        } else if ext == "fbx" || ext == "glb" || ext == "gltf" || ext == "obj" {
-                            let collider_from_model = opt.collider_from_model;
-                            ambient_build::pipelines::import_model(
-                                opt.path.clone(),
-                                collider_from_model,
-                            )
-                            .context("failed to import models")?;
-                        } else if ext == "jpg" || ext == "png" || ext == "gif" || ext == "webp" {
-                            // TODO: import textures API may change, so this is just a placeholder
-                            todo!();
-                        } else {
-                            bail!("Unsupported file type");
-                        }
-                    }
-                    None => bail!("Unknown file type"),
-                },
-            }
-
-            Ok(())
-        });
+        return assets_cmd(&rt, command);
     }
 
     // Build the project if required. Note that this only runs if the project is local.
@@ -117,48 +78,7 @@ fn main() -> anyhow::Result<()> {
         .filter(|p| !p.no_build)
         .zip(project_path.fs_path.as_deref())
     {
-        rt.block_on(async {
-            let build_path = project_path.join("build");
-            // The build step uses its own semantic to ensure that there is
-            // no contamination, so that the built project can use its own
-            // semantic based on the flat hierarchy.
-            let mut semantic = ambient_project_semantic::Semantic::new().await?;
-            let primary_ember_scope_id =
-                shared::ember::add(None, &mut semantic, project_path).await?;
-
-            let manifest = semantic
-                .items
-                .get(primary_ember_scope_id)?
-                .manifest
-                .clone()
-                .context("no manifest for scope")?;
-
-            let build_config = ambient_build::BuildConfiguration {
-                build_path: build_path.clone(),
-                assets: assets.clone(),
-                semantic: &mut semantic,
-                optimize: project.release,
-                clean_build: project.clean_build,
-                build_wasm_only: project.build_wasm_only,
-            };
-
-            let project_name = manifest
-                .ember
-                .name
-                .as_deref()
-                .unwrap_or_else(|| manifest.ember.id.as_str());
-
-            tracing::info!("Building project {:?}", project_name);
-
-            let output_path = ambient_build::build(build_config, primary_ember_scope_id)
-                .await
-                .context("Failed to build project")?;
-
-            anyhow::Ok((
-                ProjectPath::new_local(output_path)?,
-                Some(AbsAssetUrl::from_file_path(build_path)),
-            ))
-        })?
+        build_project(&rt, project, project_path, &assets)?
     } else {
         (project_path.clone(), None)
     };
@@ -167,32 +87,6 @@ fn main() -> anyhow::Result<()> {
     if matches!(&cli.command, Commands::Build { .. }) {
         return Ok(());
     }
-
-    // Read the project manifest from the project path (which may have been updated by the build step)
-    // We attempt both the root and build/ as `ambient.toml` is in the former for local builds,
-    // and in the latter for deployed builds. This will likely be improved if/when deployments
-    // no longer have their own build directory.
-    async fn get_new_project_path_and_manifest(
-        project_path: ProjectPath,
-        assets: &AssetCache,
-    ) -> anyhow::Result<(ProjectPath, ambient_project::Manifest)> {
-        let paths = [project_path.url.clone(), project_path.push("build")];
-
-        for path in &paths {
-            if let Ok(toml) = path.push("ambient.toml")?.download_string(assets).await {
-                return Ok((
-                    Some(path.to_string()).try_into()?,
-                    ambient_project::Manifest::parse(&toml)?,
-                ));
-            }
-        }
-
-        anyhow::bail!("Failed to find ambient.toml in project");
-    }
-
-    let (project_path, manifest) =
-        rt.block_on(get_new_project_path_and_manifest(project_path, &assets))?;
-    let build_path = build_path.unwrap_or_else(|| project_path.url.push("build").unwrap());
 
     // If this is just a deploy then deploy and exit
     if let Commands::Deploy {
@@ -204,6 +98,10 @@ fn main() -> anyhow::Result<()> {
         ..
     } = &cli.command
     {
+        // TODO: use the build path instead of the project path for deploys
+        let (project_path, manifest, _build_path) =
+            retrieve_project_path_and_manifest(&rt, project_path, &assets, build_path)?;
+
         return rt.block_on(async {
             let Some(project_fs_path) = &project_path.fs_path else {
                 anyhow::bail!("Can only deploy a local project");
@@ -265,101 +163,26 @@ fn main() -> anyhow::Result<()> {
             ResolvedAddr::localhost_with_port(QUIC_INTERFACE_PORT)
         }
     } else if let Some(host) = &cli.host() {
-        let crypto = if let (Some(cert_file), Some(key_file)) = (&host.cert, &host.key) {
-            let raw_cert = std::fs::read(cert_file).context("Failed to read certificate file")?;
-            let cert_chain = if raw_cert.starts_with(b"-----BEGIN CERTIFICATE-----") {
-                rustls_pemfile::certs(&mut raw_cert.as_slice())
-                    .context("Failed to parse certificate file")?
-            } else {
-                vec![raw_cert]
-            };
-            let raw_key = std::fs::read(key_file).context("Failed to read certificate key")?;
-            let key = if raw_key.starts_with(b"-----BEGIN ") {
-                rustls_pemfile::read_all(&mut raw_key.as_slice())
-                    .context("Failed to parse certificate key")?
-                    .into_iter()
-                    .find_map(|item| match item {
-                        rustls_pemfile::Item::RSAKey(key) => Some(key),
-                        rustls_pemfile::Item::PKCS8Key(key) => Some(key),
-                        rustls_pemfile::Item::ECKey(key) => Some(key),
-                        _ => None,
-                    })
-                    .ok_or_else(|| anyhow::anyhow!("No private key found"))?
-            } else {
-                raw_key
-            };
-            ambient_network::native::server::Crypto { cert_chain, key }
-        } else {
-            #[cfg(feature = "no_bundled_certs")]
-            {
-                anyhow::bail!("--cert and --key are required without bundled certs.");
-            }
-            #[cfg(not(feature = "no_bundled_certs"))]
-            {
-                tracing::info!("Using bundled certificate and key");
-                ambient_network::native::server::Crypto {
-                    cert_chain: vec![CERT.to_vec()],
-                    key: CERT_KEY.to_vec(),
-                }
-            }
-        };
+        let (project_path, manifest, build_path) =
+            retrieve_project_path_and_manifest(&rt, project_path, &assets, build_path)?;
 
-        let working_directory = project_path
-            .fs_path
-            .clone()
-            .unwrap_or(std::env::current_dir()?);
-
-        let addr = rt.block_on(server::start(
+        server_run_cmd(
+            host,
+            project_path,
+            &rt,
             runtime,
-            assets.clone(),
-            cli.clone(),
-            working_directory,
-            project_path.url.clone(),
+            &assets,
+            &cli,
             build_path,
             manifest,
-            crypto,
-        ));
-
-        ResolvedAddr::localhost_with_port(addr.port())
+        )?
     } else {
         unreachable!()
     };
 
     // Time to join!
     if let Some(run) = cli.run() {
-        // Hey! listen, it is time to setup audio
-
-        let audio_stream = if !run.mute_audio {
-            log::info!("Creating audio stream");
-            match AudioStream::new().context("Failed to initialize audio stream") {
-                Ok(v) => Some(v),
-                Err(err) => {
-                    log::error!("Failed to initialize audio stream: {err}");
-                    None
-                }
-            }
-        } else {
-            log::info!("Audio is disabled");
-            None
-        };
-
-        let mixer = if run.mute_audio {
-            None
-        } else {
-            audio_stream.as_ref().map(|v| v.mixer().clone())
-        };
-
-        // If we have run parameters, start a client and join a server
-        let exit_status = rt.block_on(client::run(
-            assets,
-            server_addr,
-            run,
-            original_project_path.fs_path,
-            mixer,
-        ));
-        if exit_status == ExitStatus::FAILURE {
-            bail!("client::run failed with {exit_status:?}");
-        }
+        client_run_cmd(run, &rt, assets, server_addr, original_project_path)?;
     } else {
         // Otherwise, wait for the Ctrl+C signal
         match rt.block_on(tokio::signal::ctrl_c()) {
@@ -369,6 +192,250 @@ fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn retrieve_project_path_and_manifest(
+    rt: &tokio::runtime::Runtime,
+    project_path: ProjectPath,
+    assets: &AssetCache,
+    build_path: Option<AbsAssetUrl>,
+) -> anyhow::Result<(ProjectPath, ambient_project::Manifest, AbsAssetUrl)> {
+    // Read the project manifest from the project path (which may have been updated by the build step)
+    // We attempt both the root and build/ as `ambient.toml` is in the former for local builds,
+    // and in the latter for deployed builds. This will likely be improved if/when deployments
+    // no longer have their own build directory.
+    async fn get_new_project_path_and_manifest(
+        project_path: ProjectPath,
+        assets: &AssetCache,
+    ) -> anyhow::Result<(ProjectPath, ambient_project::Manifest)> {
+        let paths = [project_path.url.clone(), project_path.push("build")];
+
+        for path in &paths {
+            if let Ok(toml) = path.push("ambient.toml")?.download_string(assets).await {
+                return Ok((
+                    Some(path.to_string()).try_into()?,
+                    ambient_project::Manifest::parse(&toml)?,
+                ));
+            }
+        }
+
+        anyhow::bail!("Failed to find ambient.toml in project");
+    }
+    let (project_path, manifest) =
+        rt.block_on(get_new_project_path_and_manifest(project_path, assets))?;
+    let build_path = build_path.unwrap_or_else(|| project_path.url.push("build").unwrap());
+    Ok((project_path, manifest, build_path))
+}
+
+fn build_project(
+    rt: &tokio::runtime::Runtime,
+    project: &ProjectCli,
+    project_path: &Path,
+    assets: &AssetCache,
+) -> anyhow::Result<(ProjectPath, Option<AbsAssetUrl>)> {
+    rt.block_on(async {
+        let build_path = project_path.join("build");
+        // The build step uses its own semantic to ensure that there is
+        // no contamination, so that the built project can use its own
+        // semantic based on the flat hierarchy.
+        let mut semantic = ambient_project_semantic::Semantic::new().await?;
+        let primary_ember_scope_id = shared::ember::add(None, &mut semantic, project_path).await?;
+
+        let manifest = semantic
+            .items
+            .get(primary_ember_scope_id)?
+            .manifest
+            .clone()
+            .context("no manifest for scope")?;
+
+        let build_config = ambient_build::BuildConfiguration {
+            build_path: build_path.clone(),
+            assets: assets.clone(),
+            semantic: &mut semantic,
+            optimize: project.release,
+            clean_build: project.clean_build,
+            build_wasm_only: project.build_wasm_only,
+        };
+
+        let project_name = manifest
+            .ember
+            .name
+            .as_deref()
+            .unwrap_or_else(|| manifest.ember.id.as_str());
+
+        tracing::info!("Building project {:?}", project_name);
+
+        let output_path = ambient_build::build(build_config, primary_ember_scope_id)
+            .await
+            .context("Failed to build project")?;
+
+        anyhow::Ok((
+            ProjectPath::new_local(output_path)?,
+            Some(AbsAssetUrl::from_file_path(build_path)),
+        ))
+    })
+}
+
+fn server_run_cmd(
+    host: &cli::HostCli,
+    project_path: ProjectPath,
+    rt: &tokio::runtime::Runtime,
+    runtime: &tokio::runtime::Handle,
+    assets: &AssetCache,
+    cli: &Cli,
+    build_path: AbsAssetUrl,
+    manifest: ambient_project::Manifest,
+) -> anyhow::Result<ResolvedAddr> {
+    let crypto = if let (Some(cert_file), Some(key_file)) = (&host.cert, &host.key) {
+        let raw_cert = std::fs::read(cert_file).context("Failed to read certificate file")?;
+        let cert_chain = if raw_cert.starts_with(b"-----BEGIN CERTIFICATE-----") {
+            rustls_pemfile::certs(&mut raw_cert.as_slice())
+                .context("Failed to parse certificate file")?
+        } else {
+            vec![raw_cert]
+        };
+        let raw_key = std::fs::read(key_file).context("Failed to read certificate key")?;
+        let key = if raw_key.starts_with(b"-----BEGIN ") {
+            rustls_pemfile::read_all(&mut raw_key.as_slice())
+                .context("Failed to parse certificate key")?
+                .into_iter()
+                .find_map(|item| match item {
+                    rustls_pemfile::Item::RSAKey(key) => Some(key),
+                    rustls_pemfile::Item::PKCS8Key(key) => Some(key),
+                    rustls_pemfile::Item::ECKey(key) => Some(key),
+                    _ => None,
+                })
+                .ok_or_else(|| anyhow::anyhow!("No private key found"))?
+        } else {
+            raw_key
+        };
+        ambient_network::native::server::Crypto { cert_chain, key }
+    } else {
+        #[cfg(feature = "no_bundled_certs")]
+        {
+            anyhow::bail!("--cert and --key are required without bundled certs.");
+        }
+        #[cfg(not(feature = "no_bundled_certs"))]
+        {
+            tracing::info!("Using bundled certificate and key");
+            ambient_network::native::server::Crypto {
+                cert_chain: vec![CERT.to_vec()],
+                key: CERT_KEY.to_vec(),
+            }
+        }
+    };
+    let working_directory = project_path
+        .fs_path
+        .clone()
+        .unwrap_or(std::env::current_dir()?);
+    let addr = rt.block_on(server::start(
+        runtime,
+        assets.clone(),
+        cli.clone(),
+        working_directory,
+        project_path.url.clone(),
+        build_path,
+        manifest,
+        crypto,
+    ));
+    Ok(ResolvedAddr::localhost_with_port(addr.port()))
+}
+
+fn client_run_cmd(
+    run: &cli::RunCli,
+    rt: &tokio::runtime::Runtime,
+    assets: AssetCache,
+    server_addr: ResolvedAddr,
+    original_project_path: ProjectPath,
+) -> anyhow::Result<()> {
+    // Hey! listen, it is time to setup audio
+    let audio_stream = if !run.mute_audio {
+        log::info!("Creating audio stream");
+        match AudioStream::new().context("Failed to initialize audio stream") {
+            Ok(v) => Some(v),
+            Err(err) => {
+                log::error!("Failed to initialize audio stream: {err}");
+                None
+            }
+        }
+    } else {
+        log::info!("Audio is disabled");
+        None
+    };
+
+    let mixer = if run.mute_audio {
+        None
+    } else {
+        audio_stream.as_ref().map(|v| v.mixer().clone())
+    };
+
+    // If we have run parameters, start a client and join a server
+    let exit_status = rt.block_on(client::run(
+        assets,
+        server_addr,
+        run,
+        original_project_path.fs_path,
+        mixer,
+    ));
+
+    if exit_status == ExitStatus::FAILURE {
+        bail!("client::run failed with {exit_status:?}");
+    }
+
+    Ok(())
+}
+
+fn new_project_cmd(
+    project_path: &ProjectPath,
+    name: &Option<String>,
+    api_path: &Option<String>,
+) -> anyhow::Result<()> {
+    if let Some(path) = &project_path.fs_path {
+        if let Err(err) = cli::new_project::new_project(path, name.as_deref(), api_path.as_deref())
+        {
+            eprintln!("Failed to create project: {err:?}");
+        }
+    } else {
+        eprintln!("Cannot create project in a remote directory.");
+    }
+    Ok(())
+}
+
+fn assets_cmd(rt: &tokio::runtime::Runtime, command: &AssetCommand) -> anyhow::Result<()> {
+    rt.block_on(async {
+        match command {
+            AssetCommand::MigratePipelinesToml(opt) => {
+                let path = ProjectPath::new_local(opt.path.clone())?;
+                ambient_build::migrate::toml::process(path.fs_path.unwrap())
+                    .await
+                    .context("Failed to migrate pipelines")?;
+            }
+            AssetCommand::Import(opt) => match opt.path.extension() {
+                Some(ext) => {
+                    if ext == "wav" || ext == "mp3" || ext == "ogg" {
+                        let convert = opt.convert_audio;
+                        ambient_build::pipelines::import_audio(opt.path.clone(), convert)
+                            .context("failed to import audio")?;
+                    } else if ext == "fbx" || ext == "glb" || ext == "gltf" || ext == "obj" {
+                        let collider_from_model = opt.collider_from_model;
+                        ambient_build::pipelines::import_model(
+                            opt.path.clone(),
+                            collider_from_model,
+                        )
+                        .context("failed to import models")?;
+                    } else if ext == "jpg" || ext == "png" || ext == "gif" || ext == "webp" {
+                        // TODO: import textures API may change, so this is just a placeholder
+                        todo!();
+                    } else {
+                        bail!("Unsupported file type");
+                    }
+                }
+                None => bail!("Unknown file type"),
+            },
+        }
+
+        Ok(())
+    })
 }
 
 fn setup_logging() -> anyhow::Result<()> {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -66,7 +66,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     if let Commands::Assets { command } = &cli.command {
-        return assets_cmd(&rt, command);
+        return rt.block_on(assets_cmd(command));
     }
 
     // Build the project if required. Note that this only runs if the project is local.
@@ -78,7 +78,7 @@ fn main() -> anyhow::Result<()> {
         .filter(|p| !p.no_build)
         .zip(project_path.fs_path.as_deref())
     {
-        build_project(&rt, project, project_path, &assets)?
+        rt.block_on(build_project(project, project_path, &assets))?
     } else {
         (project_path.clone(), None)
     };
@@ -98,42 +98,16 @@ fn main() -> anyhow::Result<()> {
         ..
     } = &cli.command
     {
-        // TODO: use the build path instead of the project path for deploys
-        let (project_path, manifest, _build_path) =
-            retrieve_project_path_and_manifest(&rt, project_path, &assets, build_path)?;
-
-        return rt.block_on(async {
-            let Some(project_fs_path) = &project_path.fs_path else {
-                anyhow::bail!("Can only deploy a local project");
-            };
-            let deployment_id = ambient_deploy::deploy(
-                runtime,
-                api_server,
-                token,
-                project_fs_path,
-                &manifest,
-                *force_upload,
-            )
-            .await?;
-            log::info!(
-                "Assets deployed successfully. Deployment id: {}. Deploy url: https://assets.ambient.run/{}",
-                deployment_id,
-                deployment_id,
-            );
-            if *ensure_running {
-                let spec = ambient_cloud_client::ServerSpec::new_with_deployment(deployment_id)
-                    .with_context(context.clone());
-                let server = ambient_cloud_client::ensure_server_running(
-                    &assets,
-                    api_server,
-                    token.into(),
-                    spec,
-                )
-                .await?;
-                log::info!("Deployed ember is running at {}", server.host);
-            }
-            Ok(())
-        });
+        return rt.block_on(deploy_cli(
+            &project_path,
+            &assets,
+            build_path.as_ref(),
+            token,
+            api_server,
+            *force_upload,
+            *ensure_running,
+            context,
+        ));
     }
 
     // Otherwise, either connect to a server or host one
@@ -163,19 +137,19 @@ fn main() -> anyhow::Result<()> {
             ResolvedAddr::localhost_with_port(QUIC_INTERFACE_PORT)
         }
     } else if let Some(host) = &cli.host() {
-        let (project_path, manifest, build_path) =
-            retrieve_project_path_and_manifest(&rt, project_path, &assets, build_path)?;
+        let (project_path, manifest, build_path) = rt.block_on(
+            retrieve_project_path_and_manifest(&project_path, &assets, build_path.as_ref()),
+        )?;
 
-        server_run_cmd(
+        rt.block_on(server_run_cmd(
             host,
             project_path,
-            &rt,
             runtime,
             &assets,
             &cli,
             build_path,
             manifest,
-        )?
+        ))?
     } else {
         unreachable!()
     };
@@ -194,18 +168,54 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn retrieve_project_path_and_manifest(
-    rt: &tokio::runtime::Runtime,
-    project_path: ProjectPath,
+async fn deploy_cli(
+    project_path: &ProjectPath,
     assets: &AssetCache,
-    build_path: Option<AbsAssetUrl>,
+    build_path: Option<&AbsAssetUrl>,
+    token: &str,
+    api_server: &str,
+    force_upload: bool,
+    ensure_running: bool,
+    context: &str,
+) -> Result<(), anyhow::Error> {
+    let (project_path, manifest, _build_path) =
+        retrieve_project_path_and_manifest(project_path, assets, build_path).await?;
+
+    let Some(project_fs_path) = &project_path.fs_path else {
+            anyhow::bail!("Can only deploy a local project");
+        };
+
+    let deployment_id =
+        ambient_deploy::deploy(api_server, token, project_fs_path, &manifest, force_upload).await?;
+
+    log::info!(
+        "Assets deployed successfully. Deployment id: {}. Deploy url: https://assets.ambient.run/{}",
+        deployment_id,
+        deployment_id,
+    );
+
+    if ensure_running {
+        let spec = ambient_cloud_client::ServerSpec::new_with_deployment(deployment_id)
+            .with_context(context.to_string());
+        let server =
+            ambient_cloud_client::ensure_server_running(assets, api_server, token.into(), spec)
+                .await?;
+        log::info!("Deployed ember is running at {}", server.host);
+    }
+    Ok(())
+}
+
+async fn retrieve_project_path_and_manifest(
+    project_path: &ProjectPath,
+    assets: &AssetCache,
+    build_path: Option<&AbsAssetUrl>,
 ) -> anyhow::Result<(ProjectPath, ambient_project::Manifest, AbsAssetUrl)> {
     // Read the project manifest from the project path (which may have been updated by the build step)
     // We attempt both the root and build/ as `ambient.toml` is in the former for local builds,
     // and in the latter for deployed builds. This will likely be improved if/when deployments
     // no longer have their own build directory.
     async fn get_new_project_path_and_manifest(
-        project_path: ProjectPath,
+        project_path: &ProjectPath,
         assets: &AssetCache,
     ) -> anyhow::Result<(ProjectPath, ambient_project::Manifest)> {
         let paths = [project_path.url.clone(), project_path.push("build")];
@@ -221,65 +231,63 @@ fn retrieve_project_path_and_manifest(
 
         anyhow::bail!("Failed to find ambient.toml in project");
     }
-    let (project_path, manifest) =
-        rt.block_on(get_new_project_path_and_manifest(project_path, assets))?;
-    let build_path = build_path.unwrap_or_else(|| project_path.url.push("build").unwrap());
+
+    let (project_path, manifest) = get_new_project_path_and_manifest(project_path, assets).await?;
+    let build_path = build_path
+        .cloned()
+        .unwrap_or_else(|| project_path.url.push("build").unwrap());
     Ok((project_path, manifest, build_path))
 }
 
-fn build_project(
-    rt: &tokio::runtime::Runtime,
+async fn build_project(
     project: &ProjectCli,
     project_path: &Path,
     assets: &AssetCache,
 ) -> anyhow::Result<(ProjectPath, Option<AbsAssetUrl>)> {
-    rt.block_on(async {
-        let build_path = project_path.join("build");
-        // The build step uses its own semantic to ensure that there is
-        // no contamination, so that the built project can use its own
-        // semantic based on the flat hierarchy.
-        let mut semantic = ambient_project_semantic::Semantic::new().await?;
-        let primary_ember_scope_id = shared::ember::add(None, &mut semantic, project_path).await?;
+    let build_path = project_path.join("build");
+    // The build step uses its own semantic to ensure that there is
+    // no contamination, so that the built project can use its own
+    // semantic based on the flat hierarchy.
+    let mut semantic = ambient_project_semantic::Semantic::new().await?;
+    let primary_ember_scope_id = shared::ember::add(None, &mut semantic, project_path).await?;
 
-        let manifest = semantic
-            .items
-            .get(primary_ember_scope_id)?
-            .manifest
-            .clone()
-            .context("no manifest for scope")?;
+    let manifest = semantic
+        .items
+        .get(primary_ember_scope_id)?
+        .manifest
+        .clone()
+        .context("no manifest for scope")?;
 
-        let build_config = ambient_build::BuildConfiguration {
-            build_path: build_path.clone(),
-            assets: assets.clone(),
-            semantic: &mut semantic,
-            optimize: project.release,
-            clean_build: project.clean_build,
-            build_wasm_only: project.build_wasm_only,
-        };
+    let build_config = ambient_build::BuildConfiguration {
+        build_path: build_path.clone(),
+        assets: assets.clone(),
+        semantic: &mut semantic,
+        optimize: project.release,
+        clean_build: project.clean_build,
+        build_wasm_only: project.build_wasm_only,
+    };
 
-        let project_name = manifest
-            .ember
-            .name
-            .as_deref()
-            .unwrap_or_else(|| manifest.ember.id.as_str());
+    let project_name = manifest
+        .ember
+        .name
+        .as_deref()
+        .unwrap_or_else(|| manifest.ember.id.as_str());
 
-        tracing::info!("Building project {:?}", project_name);
+    tracing::info!("Building project {:?}", project_name);
 
-        let output_path = ambient_build::build(build_config, primary_ember_scope_id)
-            .await
-            .context("Failed to build project")?;
+    let output_path = ambient_build::build(build_config, primary_ember_scope_id)
+        .await
+        .context("Failed to build project")?;
 
-        anyhow::Ok((
-            ProjectPath::new_local(output_path)?,
-            Some(AbsAssetUrl::from_file_path(build_path)),
-        ))
-    })
+    anyhow::Ok((
+        ProjectPath::new_local(output_path)?,
+        Some(AbsAssetUrl::from_file_path(build_path)),
+    ))
 }
 
-fn server_run_cmd(
+async fn server_run_cmd(
     host: &cli::HostCli,
     project_path: ProjectPath,
-    rt: &tokio::runtime::Runtime,
     runtime: &tokio::runtime::Handle,
     assets: &AssetCache,
     cli: &Cli,
@@ -324,11 +332,13 @@ fn server_run_cmd(
             }
         }
     };
+
     let working_directory = project_path
         .fs_path
         .clone()
         .unwrap_or(std::env::current_dir()?);
-    let addr = rt.block_on(server::start(
+
+    let addr = server::start(
         runtime,
         assets.clone(),
         cli.clone(),
@@ -337,7 +347,9 @@ fn server_run_cmd(
         build_path,
         manifest,
         crypto,
-    ));
+    )
+    .await;
+
     Ok(ResolvedAddr::localhost_with_port(addr.port()))
 }
 
@@ -401,41 +413,36 @@ fn new_project_cmd(
     Ok(())
 }
 
-fn assets_cmd(rt: &tokio::runtime::Runtime, command: &AssetCommand) -> anyhow::Result<()> {
-    rt.block_on(async {
-        match command {
-            AssetCommand::MigratePipelinesToml(opt) => {
-                let path = ProjectPath::new_local(opt.path.clone())?;
-                ambient_build::migrate::toml::process(path.fs_path.unwrap())
-                    .await
-                    .context("Failed to migrate pipelines")?;
-            }
-            AssetCommand::Import(opt) => match opt.path.extension() {
-                Some(ext) => {
-                    if ext == "wav" || ext == "mp3" || ext == "ogg" {
-                        let convert = opt.convert_audio;
-                        ambient_build::pipelines::import_audio(opt.path.clone(), convert)
-                            .context("failed to import audio")?;
-                    } else if ext == "fbx" || ext == "glb" || ext == "gltf" || ext == "obj" {
-                        let collider_from_model = opt.collider_from_model;
-                        ambient_build::pipelines::import_model(
-                            opt.path.clone(),
-                            collider_from_model,
-                        )
-                        .context("failed to import models")?;
-                    } else if ext == "jpg" || ext == "png" || ext == "gif" || ext == "webp" {
-                        // TODO: import textures API may change, so this is just a placeholder
-                        todo!();
-                    } else {
-                        bail!("Unsupported file type");
-                    }
-                }
-                None => bail!("Unknown file type"),
-            },
+async fn assets_cmd(command: &AssetCommand) -> anyhow::Result<()> {
+    match command {
+        AssetCommand::MigratePipelinesToml(opt) => {
+            let path = ProjectPath::new_local(opt.path.clone())?;
+            ambient_build::migrate::toml::process(path.fs_path.unwrap())
+                .await
+                .context("Failed to migrate pipelines")?;
         }
+        AssetCommand::Import(opt) => match opt.path.extension() {
+            Some(ext) => {
+                if ext == "wav" || ext == "mp3" || ext == "ogg" {
+                    let convert = opt.convert_audio;
+                    ambient_build::pipelines::import_audio(opt.path.clone(), convert)
+                        .context("failed to import audio")?;
+                } else if ext == "fbx" || ext == "glb" || ext == "gltf" || ext == "obj" {
+                    let collider_from_model = opt.collider_from_model;
+                    ambient_build::pipelines::import_model(opt.path.clone(), collider_from_model)
+                        .context("failed to import models")?;
+                } else if ext == "jpg" || ext == "png" || ext == "gif" || ext == "webp" {
+                    // TODO: import textures API may change, so this is just a placeholder
+                    todo!();
+                } else {
+                    bail!("Unsupported file type");
+                }
+            }
+            None => bail!("Unknown file type"),
+        },
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 fn setup_logging() -> anyhow::Result<()> {

--- a/app/src/shared/certs.rs
+++ b/app/src/shared/certs.rs
@@ -1,0 +1,5 @@
+#[cfg(not(feature = "no_bundled_certs"))]
+pub const CERT: &[u8] = include_bytes!("../../../localhost.crt");
+
+#[cfg(not(feature = "no_bundled_certs"))]
+pub const CERT_KEY: &[u8] = include_bytes!("../../../localhost.key");

--- a/app/src/shared/mod.rs
+++ b/app/src/shared/mod.rs
@@ -1,6 +1,7 @@
 use ambient_network::server;
 use ambient_rpc::RpcRegistry;
 
+pub mod certs;
 pub mod components;
 pub mod ember;
 

--- a/campfire/src/golden_images/mod.rs
+++ b/campfire/src/golden_images/mod.rs
@@ -189,6 +189,7 @@ fn update_tests(i: usize, ambient_path: &str, name: &str) -> (String, Vec<String
         quic_port,
         "--http-interface-port".to_string(),
         http_port,
+        "--mute-audio".to_string(),
         "golden-image-update".to_string(),
         // Todo: Ideally this waiting should be unnecessary, because
         // we only care about rendering the first frame of the test,
@@ -218,6 +219,7 @@ fn check_tests(i: usize, ambient_path: &str, name: &str) -> (String, Vec<String>
         quic_port,
         "--http-interface-port".to_string(),
         http_port,
+        "--mute-audio".to_string(),
         "golden-image-check".to_string(),
         // Todo: See notes on --wait-seconds from above.
         "--timeout-seconds".to_string(),

--- a/crates/deploy/src/lib.rs
+++ b/crates/deploy/src/lib.rs
@@ -33,7 +33,6 @@ const REQUIRED_FILES: &[&str] = &["build/ambient.toml"];
 /// This takes the path to an Ambient ember and deploys it. An Ambient ember is expected to
 /// be already built.
 pub async fn deploy(
-    runtime: &tokio::runtime::Handle,
     api_server: &str,
     auth_token: &str,
     path: impl AsRef<Path>,
@@ -74,7 +73,7 @@ pub async fn deploy(
     let (file_request_tx, file_request_rx) = flume::unbounded::<FileRequest>();
     let (deploy_asset_request_tx, deploy_asset_request_rx) =
         flume::bounded::<DeployAssetRequest>(16);
-    let handle = runtime.spawn(process_file_requests(
+    let handle = tokio::task::spawn(process_file_requests(
         file_request_rx,
         deploy_asset_request_tx,
         ember_id.clone(),


### PR DESCRIPTION
As suggested by @ten3roberts - breaking up the Ambient native `main` so that it's easier to see what each command does. This fixes #683.

To-do:
- Clean up the resulting functions (I just went at it with R-A to get the loose outline of it in place)
- See if we can unify this with the web