### PR TITLE
feat(app): simplify host flow

### DIFF
--- a/app/src/cli/client.rs
+++ b/app/src/cli/client.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use ambient_audio::AudioStream;
 use ambient_core::window::ExitStatus;
 use ambient_native_std::asset_cache::AssetCache;
@@ -6,14 +8,14 @@ use anyhow::Context;
 
 use crate::client;
 
-use super::{ProjectPath, RunCli};
+use super::RunCli;
 
 pub fn handle(
     run: &RunCli,
     rt: &tokio::runtime::Runtime,
     assets: AssetCache,
     server_addr: ResolvedAddr,
-    original_project_path: ProjectPath,
+    golden_image_output_dir: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     // Hey! listen, it is time to setup audio
     let audio_stream = if !run.mute_audio {
@@ -41,7 +43,7 @@ pub fn handle(
         assets,
         server_addr,
         run,
-        original_project_path.fs_path,
+        golden_image_output_dir,
         mixer,
     ));
 

--- a/app/src/cli/deploy.rs
+++ b/app/src/cli/deploy.rs
@@ -1,24 +1,20 @@
 use ambient_native_std::{asset_cache::AssetCache, asset_url::AbsAssetUrl};
 
-use crate::retrieve_project_path_and_manifest;
-
-use super::ProjectPath;
+use crate::retrieve_manifest;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn handle(
-    project_path: &ProjectPath,
+    built_project_path: &AbsAssetUrl,
     assets: &AssetCache,
-    build_path: Option<&AbsAssetUrl>,
     token: &str,
     api_server: &str,
     force_upload: bool,
     ensure_running: bool,
     context: &str,
 ) -> Result<(), anyhow::Error> {
-    let (project_path, manifest, _build_path) =
-        retrieve_project_path_and_manifest(project_path, assets, build_path).await?;
+    let manifest = retrieve_manifest(built_project_path, assets).await?;
 
-    let Some(project_fs_path) = &project_path.fs_path else {
+    let Some(project_fs_path) = built_project_path.to_file_path()? else {
         anyhow::bail!("Can only deploy a local project");
     };
 

--- a/app/src/cli/project_path.rs
+++ b/app/src/cli/project_path.rs
@@ -30,11 +30,6 @@ impl ProjectPath {
     pub fn is_remote(&self) -> bool {
         self.fs_path.is_none()
     }
-
-    // 'static to limit only to compile-time known paths
-    pub fn push(&self, path: &'static str) -> AbsAssetUrl {
-        self.url.push(path).unwrap()
-    }
 }
 
 impl TryFrom<Option<String>> for ProjectPath {
@@ -48,6 +43,11 @@ impl TryFrom<Option<String>> for ProjectPath {
                     || project_path.starts_with("file:/") =>
             {
                 let url = AbsAssetUrl::from_str(&project_path)?;
+                if url.extension().is_some() {
+                    anyhow::bail!("Project path must be a directory");
+                }
+
+                let url = url.as_directory();
                 if let Some(local) = url.to_file_path()? {
                     Self::new_local(local)
                 } else {

--- a/app/src/cli/server.rs
+++ b/app/src/cli/server.rs
@@ -5,47 +5,45 @@ use ambient_network::native::client::ResolvedAddr;
 use anyhow::Context;
 
 use crate::{
-    retrieve_project_path_and_manifest, server,
+    retrieve_manifest, server,
     shared::certs::{CERT, CERT_KEY},
 };
 
-use super::{HostCli, ProjectPath};
+use super::HostCli;
 
 pub async fn handle(
     host: &HostCli,
     view_asset_path: Option<PathBuf>,
-    project_path: ProjectPath,
-    build_path: Option<AbsAssetUrl>,
+    build_root_path: AbsAssetUrl,
+    main_ember_path: AbsAssetUrl,
     assets: &AssetCache,
 ) -> anyhow::Result<ResolvedAddr> {
-    let (project_path, manifest, build_path) =
-        retrieve_project_path_and_manifest(&project_path, assets, build_path.as_ref()).await?;
+    let manifest = retrieve_manifest(&main_ember_path, assets).await?;
+    let crypto = get_crypto(host)?;
 
-    let crypto = if let (Some(cert_file), Some(key_file)) = (&host.cert, &host.key) {
-        let raw_cert = std::fs::read(cert_file).context("Failed to read certificate file")?;
-        let cert_chain = if raw_cert.starts_with(b"-----BEGIN CERTIFICATE-----") {
-            rustls_pemfile::certs(&mut raw_cert.as_slice())
-                .context("Failed to parse certificate file")?
-        } else {
-            vec![raw_cert]
-        };
-        let raw_key = std::fs::read(key_file).context("Failed to read certificate key")?;
-        let key = if raw_key.starts_with(b"-----BEGIN ") {
-            rustls_pemfile::read_all(&mut raw_key.as_slice())
-                .context("Failed to parse certificate key")?
-                .into_iter()
-                .find_map(|item| match item {
-                    rustls_pemfile::Item::RSAKey(key) => Some(key),
-                    rustls_pemfile::Item::PKCS8Key(key) => Some(key),
-                    rustls_pemfile::Item::ECKey(key) => Some(key),
-                    _ => None,
-                })
-                .ok_or_else(|| anyhow::anyhow!("No private key found"))?
-        } else {
-            raw_key
-        };
-        ambient_network::native::server::Crypto { cert_chain, key }
-    } else {
+    let working_directory = main_ember_path
+        .to_file_path()?
+        .clone()
+        .unwrap_or(std::env::current_dir()?);
+
+    let addr = server::start(
+        assets.clone(),
+        host,
+        build_root_path,
+        main_ember_path,
+        view_asset_path,
+        working_directory,
+        manifest,
+        crypto,
+    )
+    .await;
+
+    Ok(ResolvedAddr::localhost_with_port(addr.port()))
+}
+
+fn get_crypto(host: &HostCli) -> anyhow::Result<ambient_network::native::server::Crypto> {
+    let Some((cert_file, key_file)) = host.cert.as_ref().zip(host.key.as_ref()) else {
+
         #[cfg(feature = "no_bundled_certs")]
         {
             anyhow::bail!("--cert and --key are required without bundled certs.");
@@ -53,29 +51,35 @@ pub async fn handle(
         #[cfg(not(feature = "no_bundled_certs"))]
         {
             tracing::info!("Using bundled certificate and key");
-            ambient_network::native::server::Crypto {
-                cert_chain: vec![CERT.to_vec()],
-                key: CERT_KEY.to_vec(),
-            }
+            return Ok(ambient_network::native::server::Crypto {
+                            cert_chain: vec![CERT.to_vec()],
+                            key: CERT_KEY.to_vec(),
+                        });
         }
     };
 
-    let working_directory = project_path
-        .fs_path
-        .clone()
-        .unwrap_or(std::env::current_dir()?);
+    let raw_cert = std::fs::read(cert_file).context("Failed to read certificate file")?;
+    let cert_chain = if raw_cert.starts_with(b"-----BEGIN CERTIFICATE-----") {
+        rustls_pemfile::certs(&mut raw_cert.as_slice())
+            .context("Failed to parse certificate file")?
+    } else {
+        vec![raw_cert]
+    };
+    let raw_key = std::fs::read(key_file).context("Failed to read certificate key")?;
+    let key = if raw_key.starts_with(b"-----BEGIN ") {
+        rustls_pemfile::read_all(&mut raw_key.as_slice())
+            .context("Failed to parse certificate key")?
+            .into_iter()
+            .find_map(|item| match item {
+                rustls_pemfile::Item::RSAKey(key) => Some(key),
+                rustls_pemfile::Item::PKCS8Key(key) => Some(key),
+                rustls_pemfile::Item::ECKey(key) => Some(key),
+                _ => None,
+            })
+            .ok_or_else(|| anyhow::anyhow!("No private key found"))?
+    } else {
+        raw_key
+    };
 
-    let addr = server::start(
-        assets.clone(),
-        host,
-        view_asset_path,
-        working_directory,
-        project_path.url.clone(),
-        build_path,
-        manifest,
-        crypto,
-    )
-    .await;
-
-    Ok(ResolvedAddr::localhost_with_port(addr.port()))
+    Ok(ambient_network::native::server::Crypto { cert_chain, key })
 }

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -40,10 +40,10 @@ pub mod wasm;
 pub async fn start(
     assets: AssetCache,
     host_cli: &HostCli,
+    build_root_path: AbsAssetUrl,
+    main_ember_path: AbsAssetUrl,
     view_asset_path: Option<PathBuf>,
     working_directory: PathBuf,
-    project_path: AbsAssetUrl,
-    build_path: AbsAssetUrl,
     manifest: ambient_project::Manifest,
     crypto: Crypto,
 ) -> SocketAddr {
@@ -55,7 +55,7 @@ pub async fn start(
             .proxy
             .clone()
             .unwrap_or("http://proxy.ambient.run/proxy".to_string()),
-        build_path: build_path.clone(),
+        build_path: build_root_path.clone(),
         pre_cache_assets: host_cli.proxy_pre_cache_assets,
         primary_ember_id: manifest.ember.id.to_string(),
     });
@@ -101,7 +101,7 @@ pub async fn start(
     };
 
     // here the key is inserted into the asset cache
-    if let Ok(Some(build_path_fs)) = build_path.to_file_path() {
+    if let Ok(Some(build_path_fs)) = build_root_path.to_file_path() {
         let key = format!("http://{public_host}:{http_interface_port}/content/");
         let base_url = AbsAssetUrl::from_str(&key).unwrap();
         ServerBaseUrlKey.insert(&assets, base_url.clone());
@@ -109,7 +109,7 @@ pub async fn start(
 
         start_http_interface(Some(&build_path_fs), http_interface_port);
     } else {
-        let base_url = build_path.clone();
+        let base_url = build_root_path.clone();
 
         ServerBaseUrlKey.insert(&assets, base_url.clone());
         ContentBaseUrlKey.insert(&assets, base_url);
@@ -161,7 +161,7 @@ pub async fn start(
             .unwrap();
 
         let mut semantic = ambient_project_semantic::Semantic::new().await.unwrap();
-        let primary_ember_scope_id = match project_path.to_file_path().unwrap() {
+        let primary_ember_scope_id = match main_ember_path.to_file_path().unwrap() {
             Some(local_path) => {
                 shared::ember::add(Some(&mut server_world), &mut semantic, &local_path)
                     .await
@@ -170,7 +170,7 @@ pub async fn start(
 
             None => {
                 let metadata = BuildMetadata::parse(
-                    &project_path
+                    &main_ember_path
                         .push(BuildMetadata::FILENAME)
                         .unwrap()
                         .download_string(&assets)
@@ -203,7 +203,7 @@ pub async fn start(
         }
 
         if let Some(asset_path) = view_asset_path {
-            let asset_path = build_path
+            let asset_path = main_ember_path
                 .push(asset_path.to_string_lossy())
                 .expect("FIXME")
                 .push("prefabs/main.json")

--- a/crates/deploy/src/lib.rs
+++ b/crates/deploy/src/lib.rs
@@ -28,7 +28,7 @@ use deploy_proto::{
 
 const CHUNK_SIZE: usize = 1024 * 1024 * 3; // 3MB
 const EXTRA_FILES_FROM_PROJECT_ROOT: &[&str] = &["screenshot.png", "README.md"];
-const REQUIRED_FILES: &[&str] = &["build/ambient.toml"];
+const REQUIRED_FILES: &[&str] = &["ambient.toml"];
 
 /// This takes the path to an Ambient ember and deploys it. An Ambient ember is expected to
 /// be already built.
@@ -164,7 +164,7 @@ fn collect_files_to_deploy(base_path: PathBuf) -> anyhow::Result<HashMap<String,
                     );
                     None
                 } else {
-                    Some((format!("build/{path}"), file_path))
+                    Some((path.to_string(), file_path))
                 }
             } else {
                 log::error!("Non-UTF-8 path: {:?}", file_path);


### PR DESCRIPTION
This removes the use of build/ for deployed embers, making the flow much simpler. For corresponding backend change, see api_server/v0.5.7.