### PR TITLE
Ember content instead of categories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,13 +1245,11 @@ dependencies = [
  "convert_case 0.6.0",
  "indexmap 2.0.0",
  "once_cell",
- "parse-display",
  "paste",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "serde",
  "serde_json",
- "serde_with",
  "syn 1.0.109",
  "thiserror",
  "toml 0.7.4",
@@ -3014,41 +3012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "strsim 0.10.0",
- "syn 2.0.28",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
-dependencies = [
- "darling_core",
- "quote 1.0.32",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "dashmap"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4544,12 +4507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5989,32 +5946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-display"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6509d08722b53e8dafe97f2027b22ccbe3a5db83cb352931e9716b0aa44bc5c"
-dependencies = [
- "once_cell",
- "parse-display-derive",
- "regex",
-]
-
-[[package]]
-name = "parse-display-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68517892c8daf78da08c0db777fcc17e07f2f63ef70041718f8a7630ad84f341"
-dependencies = [
- "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "regex",
- "regex-syntax 0.7.4",
- "structmeta",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7283,35 +7214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1402f54f9a3b9e2efe71c1cea24e648acce55887983553eeb858cf3115acfd49"
-dependencies = [
- "base64 0.21.2",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.0.0",
- "serde",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9197f1ad0e3c173a0222d3c4404fb04c3afe87e962bcb327af73e8301fa203c7"
-dependencies = [
- "darling",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7631,29 +7533,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structmeta"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
-dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "structmeta-derive",
- "syn 2.0.28",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
-dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.28",
-]
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11.5"
 serde_json = "1.0"
 serde_path_to_error = "0.1"
-serde_with = "3.2.0"
 byteorder = "1.4.3"
 bincode = "1.3.3"
 lazy_static = "1.4.0"
@@ -158,7 +157,6 @@ tokio-stream = "0.1"
 tonic = { version = "0.9", features = ["gzip", "tls", "tls-roots"] }
 md-5 = "0.10"
 pollster = "0.3.0"
-parse-display = "0.8.2"
 
 cfg-if = "1.0"
 

--- a/app/src/cli/new_project_template/ambient.toml
+++ b/app/src/cli/new_project_template/ambient.toml
@@ -2,4 +2,4 @@
 id = "{{id}}"
 name = "{{name}}"
 version = "0.0.1"
-categories = ["game/other"]
+categories = ["app/game"]

--- a/app/src/cli/new_project_template/ambient.toml
+++ b/app/src/cli/new_project_template/ambient.toml
@@ -2,4 +2,4 @@
 id = "{{id}}"
 name = "{{name}}"
 version = "0.0.1"
-categories = ["app/game"]
+content = { type = "Playable" }

--- a/docs/src/reference/ember.md
+++ b/docs/src/reference/ember.md
@@ -97,14 +97,8 @@ The `ember` section contains metadata about the ember itself, such as its name a
 These are the valid categories for the ember catgories field:
 
 ```
-game/example
-game/fps
-game/survival
-game/simulation
-game/strategy
-game/sports
-game/racing
-game/other
+app/example
+app/game
 
 asset/model
 asset/texture

--- a/docs/src/reference/ember.md
+++ b/docs/src/reference/ember.md
@@ -90,24 +90,29 @@ The `ember` section contains metadata about the ember itself, such as its name a
 | `name`        | `String`              | _Optional_. A human-readable name for the ember.                                            |
 | `description` | `String`              | _Optional_. A human-readable description of the ember.                                      |
 | `version`     | `String`              | _Optional_. The ember's version, in `(major, minor, patch)` format. Semantically versioned. |
-| `categories`  | `Vec<Category>`       | _Optional_. A list of categories for this Ember.                                            |
+| `content`     | `EmberContent`        | _Optional_. A description of the content of this Ember. See below.                          |
 
-#### Category
+#### `EmberContent`
 
-These are the valid categories for the ember catgories field:
+These are the valid configurations for ember content:
 
+```toml
+# A Playable is anything that can be run as an application; i.e. games, examples, applications etc.
+content = { type = "Playable" }
+content = { type = "Playable", example = true } # example defaults to false
+
+# Assets are things you can use as a dependency in your project
+content = { type = "Asset", models = true, textures = false, audio = false, fonts = false, code = false } # models etc. default to false
+content = { type = "Asset", models = true } # Shorthand of above
+
+# Tools are things you can use to develop your project
+content = { type = "Tool" }
+
+# Mods are extension to Playables
+content = { type = "Mod", for_playables: ["i3terk32jw"] }
 ```
-app/example
-app/game
 
-asset/model
-asset/texture
-asset/audio
-asset/font
-asset/code
-asset/tool
-asset/mod
-```
+The default is `content = { type = "Playable" }`
 
 #### Example
 
@@ -126,6 +131,7 @@ description = "A sample ember that's the coolest thing ever."
 # Other formats are not accepted. This requirement may be relaxed later.
 # Optional, but required for deployments.
 version = "0.0.1"
+content = { type = "Asset", code = true }
 ```
 
 ### Build / `[build]`

--- a/guest/rust/Cargo.lock
+++ b/guest/rust/Cargo.lock
@@ -24,15 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
-name = "aho-corasick"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ambient_api"
 version = "0.3.0-dev"
 dependencies = [
@@ -60,7 +51,7 @@ dependencies = [
  "data-encoding",
  "futures",
  "glam",
- "indexmap 2.0.0",
+ "indexmap",
  "once_cell",
  "paste",
  "rand 0.8.5",
@@ -224,7 +215,7 @@ name = "ambient_example_editors"
 version = "0.3.0-dev"
 dependencies = [
  "ambient_api",
- "indexmap 2.0.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -468,13 +459,11 @@ version = "0.3.0-dev"
 dependencies = [
  "anyhow",
  "convert_case",
- "indexmap 2.0.0",
+ "indexmap",
  "once_cell",
- "parse-display",
  "proc-macro2",
  "quote",
  "serde",
- "serde_with",
  "syn 1.0.109",
  "thiserror",
  "toml 0.7.5",
@@ -519,7 +508,7 @@ dependencies = [
  "async-trait",
  "data-encoding",
  "glam",
- "indexmap 2.0.0",
+ "indexmap",
  "paste",
  "thiserror",
  "toml 0.7.5",
@@ -579,28 +568,13 @@ dependencies = [
  "convert_case",
  "futures",
  "glam",
- "indexmap 2.0.0",
+ "indexmap",
  "itertools",
  "parking_lot",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "tracing",
-]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -677,12 +651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,12 +661,6 @@ name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
-
-[[package]]
-name = "bumpalo"
-version = "3.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytemuck"
@@ -731,19 +693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "serde",
- "winapi",
-]
-
-[[package]]
 name = "code"
 version = "0.3.0-dev"
 dependencies = [
@@ -764,12 +713,6 @@ checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "crc32fast"
@@ -834,41 +777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.28",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,15 +797,6 @@ name = "dependencies"
 version = "0.3.0-dev"
 dependencies = [
  "ambient_api",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -970,12 +869,6 @@ checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
 dependencies = [
  "toml 0.5.11",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -1126,12 +1019,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -1158,39 +1045,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1223,23 +1081,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown",
  "serde",
 ]
 
@@ -1280,15 +1127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
 dependencies = [
  "rayon",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
-dependencies = [
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1532,32 +1370,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
-]
-
-[[package]]
-name = "parse-display"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6509d08722b53e8dafe97f2027b22ccbe3a5db83cb352931e9716b0aa44bc5c"
-dependencies = [
- "once_cell",
- "parse-display-derive",
- "regex",
-]
-
-[[package]]
-name = "parse-display-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68517892c8daf78da08c0db777fcc17e07f2f63ef70041718f8a7630ad84f341"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "regex",
- "regex-syntax",
- "structmeta",
- "syn 2.0.28",
 ]
 
 [[package]]
@@ -1849,35 +1661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,35 +1737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1402f54f9a3b9e2efe71c1cea24e648acce55887983553eeb858cf3115acfd49"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.0.0",
- "serde",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9197f1ad0e3c173a0222d3c4404fb04c3afe87e962bcb327af73e8301fa203c7"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,35 +1783,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b19b32ed6d899ab23174302ff105c1577e45a06b08d4fe0a9dd13ce804bbbf71"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structmeta"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive",
- "syn 2.0.28",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
 ]
 
 [[package]]
@@ -2136,34 +1861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
-dependencies = [
- "deranged",
- "itoa",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
-
-[[package]]
-name = "time-macros"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
-dependencies = [
- "time-core",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2224,7 +1921,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2246,7 +1943,7 @@ version = "0.19.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2367,60 +2064,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.28",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
 name = "wasm-encoder"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,7 +2079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51db59397fc650b5f2fc778e4a5c4456cd856bed7fc1ec15f8d3e28229dc463"
 dependencies = [
  "anyhow",
- "indexmap 2.0.0",
+ "indexmap",
  "serde",
  "serde_json",
  "spdx",
@@ -2450,7 +2093,7 @@ version = "0.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c956109dcb41436a39391139d9b6e2d0a5e0b158e1293ef352ec977e5e36c5"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap",
  "semver",
 ]
 
@@ -2481,15 +2124,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -2633,7 +2267,7 @@ checksum = "253bd426c532f1cae8c633c517c63719920535f3a7fada3589de40c5b734e393"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
- "indexmap 2.0.0",
+ "indexmap",
  "log",
  "wasm-encoder",
  "wasm-metadata",
@@ -2649,7 +2283,7 @@ checksum = "541efa2046e544de53a9da1e2f6299e63079840360c9e106f1f8275a97771318"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.0.0",
+ "indexmap",
  "log",
  "pulldown-cmark",
  "semver",

--- a/guest/rust/examples/basics/asset_loading/ambient.toml
+++ b/guest/rust/examples/basics/asset_loading/ambient.toml
@@ -5,7 +5,7 @@ description = "This shows how to load assets, and how to work with the asset pip
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/asset_loading"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [components.is_the_best]
 type = "Bool"

--- a/guest/rust/examples/basics/asset_loading/ambient.toml
+++ b/guest/rust/examples/basics/asset_loading/ambient.toml
@@ -5,7 +5,7 @@ description = "This shows how to load assets, and how to work with the asset pip
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/asset_loading"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [components.is_the_best]
 type = "Bool"

--- a/guest/rust/examples/basics/input/ambient.toml
+++ b/guest/rust/examples/basics/input/ambient.toml
@@ -5,4 +5,4 @@ description = "This show how to handle user keyboard and mouse input."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/input"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/basics/input/ambient.toml
+++ b/guest/rust/examples/basics/input/ambient.toml
@@ -5,4 +5,4 @@ description = "This show how to handle user keyboard and mouse input."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/input"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/basics/multiplayer/ambient.toml
+++ b/guest/rust/examples/basics/multiplayer/ambient.toml
@@ -4,4 +4,4 @@ name = "Multiplayer"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/multiplayer"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/basics/multiplayer/ambient.toml
+++ b/guest/rust/examples/basics/multiplayer/ambient.toml
@@ -4,4 +4,4 @@ name = "Multiplayer"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/multiplayer"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/basics/physics/ambient.toml
+++ b/guest/rust/examples/basics/physics/ambient.toml
@@ -4,7 +4,7 @@ name = "Physics"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/physics"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [messages.Bonk]
 description = "Collision between two objects."

--- a/guest/rust/examples/basics/physics/ambient.toml
+++ b/guest/rust/examples/basics/physics/ambient.toml
@@ -4,7 +4,7 @@ name = "Physics"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/physics"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [messages.Bonk]
 description = "Collision between two objects."

--- a/guest/rust/examples/basics/primitives/ambient.toml
+++ b/guest/rust/examples/basics/primitives/ambient.toml
@@ -4,4 +4,4 @@ name = "Primitives"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/primitives"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/basics/primitives/ambient.toml
+++ b/guest/rust/examples/basics/primitives/ambient.toml
@@ -4,4 +4,4 @@ name = "Primitives"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/primitives"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/basics/skinmesh/ambient.toml
+++ b/guest/rust/examples/basics/skinmesh/ambient.toml
@@ -4,7 +4,7 @@ name = "Skinmesh"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/skinmesh"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [messages]
 SetController = { name = "Set controller", description = "Sets the animation controller.", fields = { value = "U32" } }

--- a/guest/rust/examples/basics/skinmesh/ambient.toml
+++ b/guest/rust/examples/basics/skinmesh/ambient.toml
@@ -3,8 +3,7 @@ id = "ambient_example_skinmesh"
 name = "Skinmesh"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/skinmesh"
-type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [messages]
 SetController = { name = "Set controller", description = "Sets the animation controller.", fields = { value = "U32" } }

--- a/guest/rust/examples/controllers/first_person_camera/ambient.toml
+++ b/guest/rust/examples/controllers/first_person_camera/ambient.toml
@@ -5,7 +5,7 @@ description = "A simple FPS camera and input example."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/first_person_camera"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [components]
 ball_ref = { type = "EntityId", name = "Ball ref", description = "The ball entity.", attributes = [

--- a/guest/rust/examples/controllers/first_person_camera/ambient.toml
+++ b/guest/rust/examples/controllers/first_person_camera/ambient.toml
@@ -5,7 +5,7 @@ description = "A simple FPS camera and input example."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/first_person_camera"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [components]
 ball_ref = { type = "EntityId", name = "Ball ref", description = "The ball entity.", attributes = [

--- a/guest/rust/examples/controllers/third_person_camera/ambient.toml
+++ b/guest/rust/examples/controllers/third_person_camera/ambient.toml
@@ -4,7 +4,7 @@ name = "Third person camera"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/third_person_camera"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [components]
 player_camera_ref = { type = "EntityId", name = "Player camera ref", description = "The player's camera.", attributes = [

--- a/guest/rust/examples/controllers/third_person_camera/ambient.toml
+++ b/guest/rust/examples/controllers/third_person_camera/ambient.toml
@@ -4,7 +4,7 @@ name = "Third person camera"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/third_person_camera"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [components]
 player_camera_ref = { type = "EntityId", name = "Player camera ref", description = "The player's camera.", attributes = [

--- a/guest/rust/examples/games/arkanoid/ambient.toml
+++ b/guest/rust/examples/games/arkanoid/ambient.toml
@@ -4,7 +4,7 @@ name = "Arkanoid"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/games/arkanoid"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [components]
 player_movement_direction = { type = "F32", name = "Player Movement Direction", description = "Direction of player movement" }

--- a/guest/rust/examples/games/arkanoid/ambient.toml
+++ b/guest/rust/examples/games/arkanoid/ambient.toml
@@ -4,7 +4,7 @@ name = "Arkanoid"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/games/arkanoid"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [components]
 player_movement_direction = { type = "F32", name = "Player Movement Direction", description = "Direction of player movement" }

--- a/guest/rust/examples/games/minigolf/ambient.toml
+++ b/guest/rust/examples/games/minigolf/ambient.toml
@@ -4,7 +4,7 @@ name = "Minigolf"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/games/minigolf"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [components]
 next_player_hue = { type = "F32", name = "Next Player Hue", description = "Controls the hue (in degrees) to use for the next player's color.", attributes = [

--- a/guest/rust/examples/games/minigolf/ambient.toml
+++ b/guest/rust/examples/games/minigolf/ambient.toml
@@ -4,7 +4,7 @@ name = "Minigolf"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/games/minigolf"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [components]
 next_player_hue = { type = "F32", name = "Next Player Hue", description = "Controls the hue (in degrees) to use for the next player's color.", attributes = [

--- a/guest/rust/examples/games/music_sequencer/ambient.toml
+++ b/guest/rust/examples/games/music_sequencer/ambient.toml
@@ -4,7 +4,7 @@ name = "Music sequencer"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/games/music_sequencer"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [messages.Click]
 description = "Select or deselect a note."

--- a/guest/rust/examples/games/music_sequencer/ambient.toml
+++ b/guest/rust/examples/games/music_sequencer/ambient.toml
@@ -4,7 +4,7 @@ name = "Music sequencer"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/games/music_sequencer"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [messages.Click]
 description = "Select or deselect a note."

--- a/guest/rust/examples/games/pong/ambient.toml
+++ b/guest/rust/examples/games/pong/ambient.toml
@@ -4,7 +4,7 @@ name = "Pong"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/games/pong"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [components]
 player_movement_direction = { type = "F32", name = "Player Movement Direction", description = "Direction of player movement" }

--- a/guest/rust/examples/games/pong/ambient.toml
+++ b/guest/rust/examples/games/pong/ambient.toml
@@ -4,7 +4,7 @@ name = "Pong"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/games/pong"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [components]
 player_movement_direction = { type = "F32", name = "Player Movement Direction", description = "Direction of player movement" }

--- a/guest/rust/examples/games/tictactoe/ambient.toml
+++ b/guest/rust/examples/games/tictactoe/ambient.toml
@@ -4,7 +4,7 @@ name = "Tic Tac Toe"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/games/tictactoe"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [components]
 cells = { type = { type = "Vec", element_type = "EntityId" }, name = "Cells", description = "The cells in the game", attributes = [

--- a/guest/rust/examples/games/tictactoe/ambient.toml
+++ b/guest/rust/examples/games/tictactoe/ambient.toml
@@ -4,7 +4,7 @@ name = "Tic Tac Toe"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/games/tictactoe"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [components]
 cells = { type = { type = "Vec", element_type = "EntityId" }, name = "Cells", description = "The cells in the game", attributes = [

--- a/guest/rust/examples/intermediate/async/ambient.toml
+++ b/guest/rust/examples/intermediate/async/ambient.toml
@@ -5,4 +5,4 @@ description = "An example of using async/await in Ambient."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/async"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/intermediate/async/ambient.toml
+++ b/guest/rust/examples/intermediate/async/ambient.toml
@@ -5,4 +5,4 @@ description = "An example of using async/await in Ambient."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/async"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/intermediate/clientside/ambient.toml
+++ b/guest/rust/examples/intermediate/clientside/ambient.toml
@@ -5,7 +5,7 @@ description = "How to use client side code."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/clientside"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [components]
 grid_side_length = { name = "Grid Side Length", description = "The length of a grid side, ignoring the centre (i.e. if this is 10, the total axis length is 21)", type = "I32", attributes = [

--- a/guest/rust/examples/intermediate/clientside/ambient.toml
+++ b/guest/rust/examples/intermediate/clientside/ambient.toml
@@ -5,7 +5,7 @@ description = "How to use client side code."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/clientside"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [components]
 grid_side_length = { name = "Grid Side Length", description = "The length of a grid side, ignoring the centre (i.e. if this is 10, the total axis length is 21)", type = "I32", attributes = [

--- a/guest/rust/examples/intermediate/messaging/ambient.toml
+++ b/guest/rust/examples/intermediate/messaging/ambient.toml
@@ -5,7 +5,7 @@ description = "This shows how to Ambient message passing system works."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/messaging"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [messages.Hello]
 name = "Hello"

--- a/guest/rust/examples/intermediate/messaging/ambient.toml
+++ b/guest/rust/examples/intermediate/messaging/ambient.toml
@@ -5,7 +5,7 @@ description = "This shows how to Ambient message passing system works."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/messaging"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [messages.Hello]
 name = "Hello"

--- a/guest/rust/examples/intermediate/screen_ray/ambient.toml
+++ b/guest/rust/examples/intermediate/screen_ray/ambient.toml
@@ -4,7 +4,7 @@ name = "Screen Ray"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/screen_ray"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [messages.Input.fields]
 ray_origin = "Vec3"

--- a/guest/rust/examples/intermediate/screen_ray/ambient.toml
+++ b/guest/rust/examples/intermediate/screen_ray/ambient.toml
@@ -4,7 +4,7 @@ name = "Screen Ray"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/screen_ray"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [messages.Input.fields]
 ray_origin = "Vec3"

--- a/guest/rust/examples/rendering/decals/ambient.toml
+++ b/guest/rust/examples/rendering/decals/ambient.toml
@@ -5,4 +5,4 @@ description = "This shows how to render decals."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/decals"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/rendering/decals/ambient.toml
+++ b/guest/rust/examples/rendering/decals/ambient.toml
@@ -5,4 +5,4 @@ description = "This shows how to render decals."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/decals"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/rendering/fog/ambient.toml
+++ b/guest/rust/examples/rendering/fog/ambient.toml
@@ -5,4 +5,4 @@ description = "A simple example of fog and how to configure it."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/fog"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/rendering/fog/ambient.toml
+++ b/guest/rust/examples/rendering/fog/ambient.toml
@@ -5,4 +5,4 @@ description = "A simple example of fog and how to configure it."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/fog"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/rendering/image/ambient.toml
+++ b/guest/rust/examples/rendering/image/ambient.toml
@@ -5,4 +5,4 @@ description = "This shows how to load and display images in 3d."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/image"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/rendering/image/ambient.toml
+++ b/guest/rust/examples/rendering/image/ambient.toml
@@ -5,4 +5,4 @@ description = "This shows how to load and display images in 3d."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/image"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/rendering/procedural_generation/ambient.toml
+++ b/guest/rust/examples/rendering/procedural_generation/ambient.toml
@@ -4,7 +4,7 @@ name = "Procedural generation"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/procedural_generation"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [components]
 rotating_sun = { type = "Bool", name = "Rotating sun", description = "Whether or not rotate the sun automatically" }

--- a/guest/rust/examples/rendering/procedural_generation/ambient.toml
+++ b/guest/rust/examples/rendering/procedural_generation/ambient.toml
@@ -4,7 +4,7 @@ name = "Procedural generation"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/procedural_generation"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [components]
 rotating_sun = { type = "Bool", name = "Rotating sun", description = "Whether or not rotate the sun automatically" }

--- a/guest/rust/examples/rendering/raw_text/ambient.toml
+++ b/guest/rust/examples/rendering/raw_text/ambient.toml
@@ -4,4 +4,4 @@ name = "Raw Text"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/raw_text"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/rendering/raw_text/ambient.toml
+++ b/guest/rust/examples/rendering/raw_text/ambient.toml
@@ -4,4 +4,4 @@ name = "Raw Text"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/raw_text"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/rendering/samplers/ambient.toml
+++ b/guest/rust/examples/rendering/samplers/ambient.toml
@@ -4,4 +4,4 @@ name = "samplers"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/samplers"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/rendering/samplers/ambient.toml
+++ b/guest/rust/examples/rendering/samplers/ambient.toml
@@ -4,4 +4,4 @@ name = "samplers"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/samplers"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/rendering/sun/ambient.toml
+++ b/guest/rust/examples/rendering/sun/ambient.toml
@@ -4,4 +4,4 @@ name = "Sun"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/sun"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/rendering/sun/ambient.toml
+++ b/guest/rust/examples/rendering/sun/ambient.toml
@@ -4,4 +4,4 @@ name = "Sun"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/sun"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/rendering/transparency/ambient.toml
+++ b/guest/rust/examples/rendering/transparency/ambient.toml
@@ -4,4 +4,4 @@ name = "Transparency"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/transparency"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/rendering/transparency/ambient.toml
+++ b/guest/rust/examples/rendering/transparency/ambient.toml
@@ -4,4 +4,4 @@ name = "Transparency"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/transparency"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/audio_ctrl/ambient.toml
+++ b/guest/rust/examples/ui/audio_ctrl/ambient.toml
@@ -4,4 +4,4 @@ name = "Audio control"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/audio_ctrl"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/audio_ctrl/ambient.toml
+++ b/guest/rust/examples/ui/audio_ctrl/ambient.toml
@@ -4,4 +4,4 @@ name = "Audio control"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/audio_ctrl"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/auto_editor/ambient.toml
+++ b/guest/rust/examples/ui/auto_editor/ambient.toml
@@ -4,4 +4,4 @@ name = "Auto editor"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/auto_editor"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/auto_editor/ambient.toml
+++ b/guest/rust/examples/ui/auto_editor/ambient.toml
@@ -4,4 +4,4 @@ name = "Auto editor"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/auto_editor"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/button/ambient.toml
+++ b/guest/rust/examples/ui/button/ambient.toml
@@ -4,4 +4,4 @@ name = "Button"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/button"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/button/ambient.toml
+++ b/guest/rust/examples/ui/button/ambient.toml
@@ -4,4 +4,4 @@ name = "Button"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/button"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/clock/ambient.toml
+++ b/guest/rust/examples/ui/clock/ambient.toml
@@ -4,4 +4,4 @@ name = "clock"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/clock"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/clock/ambient.toml
+++ b/guest/rust/examples/ui/clock/ambient.toml
@@ -4,4 +4,4 @@ name = "clock"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/clock"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/counter/ambient.toml
+++ b/guest/rust/examples/ui/counter/ambient.toml
@@ -4,4 +4,4 @@ name = "Counter"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/counter"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/counter/ambient.toml
+++ b/guest/rust/examples/ui/counter/ambient.toml
@@ -4,4 +4,4 @@ name = "Counter"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/counter"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/dock_layout/ambient.toml
+++ b/guest/rust/examples/ui/dock_layout/ambient.toml
@@ -4,4 +4,4 @@ name = "Dock Layout"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/dock_layout"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/dock_layout/ambient.toml
+++ b/guest/rust/examples/ui/dock_layout/ambient.toml
@@ -4,4 +4,4 @@ name = "Dock Layout"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/dock_layout"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/editors/ambient.toml
+++ b/guest/rust/examples/ui/editors/ambient.toml
@@ -4,4 +4,4 @@ name = "Editors"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/editors"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/editors/ambient.toml
+++ b/guest/rust/examples/ui/editors/ambient.toml
@@ -4,4 +4,4 @@ name = "Editors"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/editors"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/flow_layout/ambient.toml
+++ b/guest/rust/examples/ui/flow_layout/ambient.toml
@@ -4,4 +4,4 @@ name = "Flow Layout"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/flow_layout"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/flow_layout/ambient.toml
+++ b/guest/rust/examples/ui/flow_layout/ambient.toml
@@ -4,4 +4,4 @@ name = "Flow Layout"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/flow_layout"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/image/ambient.toml
+++ b/guest/rust/examples/ui/image/ambient.toml
@@ -4,4 +4,4 @@ name = "Image"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/image"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/image/ambient.toml
+++ b/guest/rust/examples/ui/image/ambient.toml
@@ -4,4 +4,4 @@ name = "Image"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/image"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/rect/ambient.toml
+++ b/guest/rust/examples/ui/rect/ambient.toml
@@ -4,4 +4,4 @@ name = "Rect"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/rect"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/rect/ambient.toml
+++ b/guest/rust/examples/ui/rect/ambient.toml
@@ -4,4 +4,4 @@ name = "Rect"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/rect"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/screens/ambient.toml
+++ b/guest/rust/examples/ui/screens/ambient.toml
@@ -4,4 +4,4 @@ name = "Screens"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/screens"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/screens/ambient.toml
+++ b/guest/rust/examples/ui/screens/ambient.toml
@@ -4,4 +4,4 @@ name = "Screens"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/screens"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/scroll/ambient.toml
+++ b/guest/rust/examples/ui/scroll/ambient.toml
@@ -4,4 +4,4 @@ name = "Scroll"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/scroll"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/scroll/ambient.toml
+++ b/guest/rust/examples/ui/scroll/ambient.toml
@@ -4,4 +4,4 @@ name = "Scroll"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/scroll"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/slider/ambient.toml
+++ b/guest/rust/examples/ui/slider/ambient.toml
@@ -4,4 +4,4 @@ name = "Slider"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/slider"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/slider/ambient.toml
+++ b/guest/rust/examples/ui/slider/ambient.toml
@@ -4,4 +4,4 @@ name = "Slider"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/slider"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/text/ambient.toml
+++ b/guest/rust/examples/ui/text/ambient.toml
@@ -4,4 +4,4 @@ name = "Text"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/text"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }

--- a/guest/rust/examples/ui/text/ambient.toml
+++ b/guest/rust/examples/ui/text/ambient.toml
@@ -4,4 +4,4 @@ name = "Text"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/text"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]

--- a/guest/rust/examples/ui/todo/ambient.toml
+++ b/guest/rust/examples/ui/todo/ambient.toml
@@ -4,7 +4,7 @@ name = "todo"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/todo"
 type = "Game"
-categories = ["game/example"]
+categories = ["app/example"]
 
 [messages.NewItem]
 description = "Add a new todo item"

--- a/guest/rust/examples/ui/todo/ambient.toml
+++ b/guest/rust/examples/ui/todo/ambient.toml
@@ -4,7 +4,7 @@ name = "todo"
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/todo"
 type = "Game"
-categories = ["app/example"]
+content = { type = "Playable", example = true }
 
 [messages.NewItem]
 description = "Add a new todo item"

--- a/shared_crates/project/Cargo.toml
+++ b/shared_crates/project/Cargo.toml
@@ -19,8 +19,6 @@ thiserror = { workspace = true }
 indexmap = { workspace = true }
 convert_case = { workspace = true }
 once_cell = { workspace = true }
-parse-display = { workspace = true }
-serde_with = { workspace = true }
 
 [dev-dependencies]
 paste = { workspace = true }

--- a/shared_crates/project/src/manifest.rs
+++ b/shared_crates/project/src/manifest.rs
@@ -74,23 +74,17 @@ pub struct Ember {
 
 #[derive(Clone, Copy, Debug, PartialEq, Display, FromStr, SerializeDisplay, DeserializeFromStr)]
 pub enum Category {
-    #[display("game/{0}")]
-    Game(GameCategory),
+    #[display("app/{0}")]
+    App(AppCategory),
     #[display("asset/{0}")]
     Asset(AssetCategory),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Display, FromStr, SerializeDisplay, DeserializeFromStr)]
 #[display(style = "snake_case")]
-pub enum GameCategory {
+pub enum AppCategory {
     Example,
-    Fps,
-    Survival,
-    Simulation,
-    Strategy,
-    Sports,
-    Racing,
-    Other,
+    Game,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Display, FromStr, SerializeDisplay, DeserializeFromStr)]

--- a/shared_crates/project/src/manifest.rs
+++ b/shared_crates/project/src/manifest.rs
@@ -1,9 +1,7 @@
 use std::path::PathBuf;
 
 use indexmap::IndexMap;
-use parse_display::{Display, FromStr};
 use serde::{Deserialize, Serialize};
-use serde_with::{DeserializeFromStr, SerializeDisplay};
 use thiserror::Error;
 
 use crate::{
@@ -65,38 +63,44 @@ pub struct Ember {
     #[serde(default)]
     pub authors: Vec<String>,
     #[serde(default)]
-    pub categories: Vec<Category>,
+    pub content: EmberContent,
     #[serde(default)]
     pub includes: Vec<PathBuf>,
 }
 
 // ----- NOTE: Update docs/reference/ember.md when changing this ----
 
-#[derive(Clone, Copy, Debug, PartialEq, Display, FromStr, SerializeDisplay, DeserializeFromStr)]
-pub enum Category {
-    #[display("app/{0}")]
-    App(AppCategory),
-    #[display("asset/{0}")]
-    Asset(AssetCategory),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Display, FromStr, SerializeDisplay, DeserializeFromStr)]
-#[display(style = "snake_case")]
-pub enum AppCategory {
-    Example,
-    Game,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Display, FromStr, SerializeDisplay, DeserializeFromStr)]
-#[display(style = "snake_case")]
-pub enum AssetCategory {
-    Model,
-    Texture,
-    Audio,
-    Font,
-    Code,
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum EmberContent {
+    Playable {
+        #[serde(default)]
+        example: bool,
+    },
+    /// Assets are something that you can use as a dependency in your project
+    Asset {
+        #[serde(default)]
+        models: bool,
+        #[serde(default)]
+        textures: bool,
+        #[serde(default)]
+        audio: bool,
+        #[serde(default)]
+        fonts: bool,
+        #[serde(default)]
+        code: bool,
+    },
     Tool,
-    Mod,
+    Mod {
+        /// List of ember ids that this mod is applicable to
+        #[serde(default)]
+        for_playables: Vec<String>,
+    },
+}
+impl Default for EmberContent {
+    fn default() -> Self {
+        Self::Playable { example: false }
+    }
 }
 
 // -----------------------------------------------------------------


### PR DESCRIPTION
Realized categories can end up in weird states like "this is a tool and a playable game". This PR makes it so that embers describe their content instead, so that they can only be in "correct" states (i.e., either it's a playable experience, OR it's an asset you can depend on).