### PR TITLE
Launch.json + distributing docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
 - [Animations](reference/animations.md)
 - [Audio](reference/audio.md)
 - [UI](reference/ui.md)
+- [Distributing](reference/distributing.md)
 - [Terminology](reference/terminology.md)
 - [Common pitfalls](reference/common_pitfalls.md)
 - [FAQ](reference/faq.md)

--- a/docs/src/reference/distributing.md
+++ b/docs/src/reference/distributing.md
@@ -1,0 +1,16 @@
+# Distributing your game
+
+It's possible to distribute a native desktop version of your game by following these steps:
+
+First, create a `launch.json`, like this:
+
+```json
+{
+    "args": ["run", "https://assets.ambient.run/1QI2Kc6xKnzantTL0bjiOQ"]
+}
+```
+
+The address should point to a deployment of your game. `ambient deploy` can be used to deploy your game, and will give you an address back.
+
+Then package the `launch.json` together with the `ambient.exe` binary. The `ambient.exe` can be renamed to your liking (i.e. `my_game.exe`).
+This can then be deployed to any platform that expects native desktop apps, such as Steam and Epic games.


### PR DESCRIPTION
This makes it possible to set cli args with a `launch.json` file (which makes it possible to create native desktop distributions of a game).