### PR TITLE
Add path to 1.0 document

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -31,6 +31,7 @@
 - [Terminology](reference/terminology.md)
 - [Common pitfalls](reference/common_pitfalls.md)
 - [FAQ](reference/faq.md)
+- [The path to 1.0](reference/path_to_1.0.md)
 - [Changelog](reference/changelog.md)
 
 # Runtime internals

--- a/docs/src/reference/path_to_1.0.md
+++ b/docs/src/reference/path_to_1.0.md
@@ -1,0 +1,24 @@
+# The path to 1.0
+
+The development of Ambient can be split up into two rough periods; pre-1.0 and post-1.0.
+
+Pre-1.0, which we're currently in, involves heavy iterations on the API and services. This
+is a period where we experiment with things, where we take big and wide decisions, and where
+we're not afraid to throw things out when we find better ways of doing things. During this
+period you can expect fairly frequent breaking changes to the API and services. Very little
+effort will be put into maintaining backwards compability.
+
+Post-1.0 this will reverse. After 1.0 we will strive to maintain maximum backwards compability,
+and very rarely introduce breaking changes. In the post 1.0 era you should expect much greater
+long-term stability, and you should be able to trust that what you build will work for as long
+as you're using Ambient as a service.
+
+So when will we reach 1.0? These are the rough things that we think need to be completed before
+we can do that:
+
+- [ ] Guest side programmable graphics (user shaders)
+- [ ] Performance roundup; we should take one big last look at how api's are structured to figure
+  out if there are any broad sweeping changes we need to make to maximize performance
+- [ ] One at least medium sized game needs to have been built with the API, to work out the worst kinks
+
+Once those things are in place, we'll set a date for the 1.0.


### PR DESCRIPTION
@Pombal @philpax @pierd @ten3roberts @chaosprint @droqen let's discuss this here. I just laid out an idea for a rough outline in the doc here. I think we should try to commit to a list of accomplishable things that lead to 1.0; of course if we discover things along the way we might need to revise that list, but at least it'll give us a roadmap to what's needed.

Also, post-1.0 doesn't mean we stop iterating; it just means it will be _heavier_ to make big, bread changes because we'll have to maintain more backwards compatibility and support for people to migrate. I.e. there will be lots of things that won't be "done" in time for 1.0, but if we wait for everything to be "done" we'll never be able to start providing a stable version.