### PR TITLE
fix(web): semantic packages

### DIFF
--- a/crates/network/src/diff_serialization.rs
+++ b/crates/network/src/diff_serialization.rs
@@ -547,7 +547,9 @@ impl<'a, 'de> serde::de::Visitor<'de> for NetworkedComponentDescVisitor<'a> {
                 let component = with_component_registry(|r| r.get_by_path(path));
                 match component {
                     Some(desc) => Ok(desc),
-                    None => Err(serde::de::Error::custom(format!("No such component: {v}"))),
+                    None => Err(serde::de::Error::custom(format!(
+                        "Encountered unknown networked component: {v} {path:?}"
+                    ))),
                 }
             }
             None => Err(serde::de::Error::custom(format!(

--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "ambient_layout",
  "ambient_native_std",
  "ambient_network",
+ "ambient_package_semantic_native",
  "ambient_primitives",
  "ambient_renderer",
  "ambient_rpc",

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -30,6 +30,7 @@ ambient_ecs_editor = { path = "../crates/ecs_editor" }
 ambient_debugger = { path = "../crates/debugger" }
 ambient_primitives = { path = "../crates/primitives" }
 ambient_client_shared = { path = "../crates/client_shared/" }
+ambient_package_semantic_native = { path = "../crates/package_semantic_native/" }
 
 url = "2.3"
 anyhow = "1.0"

--- a/web/client/Cargo.toml
+++ b/web/client/Cargo.toml
@@ -33,6 +33,7 @@ ambient_layout = { workspace = true }
 ambient_debugger = { workspace = true }
 ambient_primitives = { workspace = true }
 ambient_client_shared = { workspace = true }
+ambient_package_semantic_native = { workspace = true }
 
 url = { workspace = true }
 anyhow = { workspace = true }

--- a/web/client/src/lib.rs
+++ b/web/client/src/lib.rs
@@ -36,6 +36,7 @@ pub fn init_ambient(logging: bool, panic: bool) {
     ambient_world_audio::init_components();
     ambient_wasm::shared::init_all_components();
     ambient_primitives::init_components();
+    ambient_package_semantic_native::init_components();
 }
 
 #[wasm_bindgen]

--- a/web/www/src/main.ts
+++ b/web/www/src/main.ts
@@ -91,6 +91,6 @@ import("ambient_web")
       return;
     }
 
-    ambient.start(target, "https://api.ambient.run/servers/ensure-running?package_id=ambient_example_asset_loading");
+    ambient.start(target, "https://127.0.0.1:9000");
     // setupAudio();
   });


### PR DESCRIPTION
Fixes `Error: no such component: 336` seen on the web client