### PR TITLE
Remove debug info to improve iteration times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,3 +213,7 @@ wasm-bindgen-shared = { git = "https://github.com/rustwasm/wasm-bindgen.git" }
 
 [profile.release]
 incremental = true
+
+[profile.dev]
+# Debug info slows down compile times and isn't heavily used
+debug = 0


### PR DESCRIPTION
The reasoning is that debug info slows down build times for everyone but isn't heavily used. It can be enabled on a need to basis. But if this will severaly impact some workflows, I'm happy to not to go ahead.