### PR TITLE
Change CI cache to cargo-cache

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -36,9 +36,8 @@ jobs:
             libcairo-dev libgtk2.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev xorg-dev ninja-build libxcb-render0-dev clang nodejs
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: main
+      - name: Rust cache
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
       - name: Build
         run: cargo build --workspace --release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,7 @@ jobs:
           sudo apt-get install --no-install-recommends -y tree libasound2-dev libglib2.0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libcairo-dev libgtk2.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev xorg-dev ninja-build libxcb-render0-dev
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: clippy
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
       - name: Run clippy
         uses: actions-rs/cargo@v1
         with:
@@ -44,13 +42,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: wasm32-unknown-unknown
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: clippy-web
-          workspaces: |
-            .
-            web
       - name: Run clippy
         working-directory: web
         run: cargo clippy --workspace
@@ -76,9 +67,8 @@ jobs:
           sudo apt-get update
           sudo apt install -y libxcb-xfixes0-dev vulkan-validationlayers-dev mesa-vulkan-drivers libasound2-dev
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: main
+      - name: Rust cache
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
       - uses: taiki-e/install-action@cargo-nextest
       - name: Run tests
         uses: actions-rs/cargo@v1
@@ -111,6 +101,10 @@ jobs:
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
+      - name: Rust cache
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
+        with:
+            cargo-target-dir: "web"
 
       - name: "Build campfire"
         uses: actions-rs/cargo@v1
@@ -155,9 +149,8 @@ jobs:
             libcairo-dev libgtk2.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev xorg-dev ninja-build libxcb-render0-dev clang nodejs
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: main
+      - name: Rust cache
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
       - name: Build
         run: cargo build --workspace --release
         env:
@@ -183,10 +176,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - name: Rust cache
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
         with:
-          key: guest-rust
-          workspaces: guest/rust
+            cargo-target-dir: "guest/rust"
       - name: Build guest/rust
         run: cd guest/rust && cargo build --workspace
 
@@ -199,6 +192,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: rustup target add --toolchain stable wasm32-wasi
+      - name: Rust cache
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
       - name: Download ambient executable
         uses: actions/download-artifact@v3
         with:
@@ -234,6 +229,8 @@ jobs:
     steps:
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/checkout@v3
+      - name: Rust cache
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
       - name: Download ambient executable
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -21,9 +21,8 @@ jobs:
             libcairo-dev libgtk2.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev xorg-dev ninja-build libxcb-render0-dev
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: main
+      - name: Rust cache
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
       - name: Build
         run: cargo build --workspace --release
         env:
@@ -73,6 +72,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown,wasm32-wasi
+      - name: Rust cache
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
       - name: Fetch ambient executable artifact from cache
         uses: actions/cache/restore@v3
         with:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -23,6 +23,9 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
 
+      - name: Rust cache
+        uses: Leafwing-Studios/cargo-cache@v1.1.0
+
       - name: "Build campfire"
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
At least until https://github.com/Swatinem/rust-cache/issues/167 is addressed

Note that there's no need to switch caches between main and test configurations because cargo cache already handles cache fallbacks with restore-keys