### PR TITLE
Add `as_module_message` for Ambient-defined messages

### DIFF
--- a/crates/ecs/src/generated.rs
+++ b/crates/ecs/src/generated.rs
@@ -1008,7 +1008,7 @@ mod raw {
         pub mod messages {
             use crate::{Entity, EntityId};
             use ambient_package_rt::message_serde::{
-                Message, MessageSerde, MessageSerdeError, RuntimeMessage,
+                Message, MessageSerde, MessageSerdeError, ModuleMessage, RuntimeMessage,
             };
             use glam::{Mat4, Quat, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4};
             #[derive(Clone, Debug)]

--- a/crates/wasm/src/server/mod.rs
+++ b/crates/wasm/src/server/mod.rs
@@ -1,4 +1,4 @@
-use crate::shared::{self, message::RuntimeMessageExt};
+use crate::shared::{self, message::MessageExt};
 use ambient_ecs::{generated::messages, query, EntityId, FnSystem, SystemGroup, World};
 use ambient_network::server::{ForkingEvent, ShutdownEvent};
 use std::{path::PathBuf, sync::Arc};

--- a/crates/wasm/src/shared/message.rs
+++ b/crates/wasm/src/shared/message.rs
@@ -122,10 +122,10 @@ pub(super) fn run(
     }
 }
 
-pub trait RuntimeMessageExt {
+pub trait MessageExt {
     fn run(self, world: &mut World, module_id: Option<EntityId>) -> anyhow::Result<()>;
 }
-impl<T: ambient_ecs::RuntimeMessage> RuntimeMessageExt for T {
+impl<T: ambient_ecs::Message> MessageExt for T {
     fn run(self, world: &mut World, module_id: Option<EntityId>) -> anyhow::Result<()> {
         run(
             world,

--- a/crates/wasm/src/shared/mod.rs
+++ b/crates/wasm/src/shared/mod.rs
@@ -70,7 +70,7 @@ mod internal_wit {
 #[cfg(feature = "wit")]
 use self::internal_wit::preopened_dir;
 use self::message::Source;
-use crate::shared::message::{RuntimeMessageExt, Target};
+use crate::shared::message::{MessageExt, Target};
 
 pub fn init_all_components() {
     internal::init_components();

--- a/shared_crates/package/src/message.rs
+++ b/shared_crates/package/src/message.rs
@@ -7,6 +7,11 @@ use crate::{ComponentType, SnakeCaseIdentifier};
 pub struct Message {
     pub description: Option<String>,
     pub fields: IndexMap<SnakeCaseIdentifier, ComponentType>,
+    /// When set, will generate a `ModuleMessage` instead of a `RuntimeMessage`.
+    ///
+    /// Only applicable to messages defined in the `ambient_core` schema. Intentionally undocumented.
+    #[serde(default)]
+    pub as_module_message: bool,
 }
 
 #[cfg(test)]

--- a/shared_crates/package_macro_common/src/messages.rs
+++ b/shared_crates/package_macro_common/src/messages.rs
@@ -71,11 +71,12 @@ pub fn generate(
                 quote! {}
             };
 
-            let message_impl = if message.data().source == ItemSource::Ambient {
-                quote! { RuntimeMessage }
-            } else {
-                quote! { ModuleMessage }
-            };
+            let message_impl =
+                if message.data().source != ItemSource::Ambient || message.as_module_message {
+                    quote! { ModuleMessage }
+                } else {
+                    quote! { RuntimeMessage }
+                };
 
             let struct_definition = if message.fields.is_empty() {
                 quote! {

--- a/shared_crates/package_macro_common/src/messages.rs
+++ b/shared_crates/package_macro_common/src/messages.rs
@@ -131,7 +131,7 @@ pub fn generate(
 
     let inner = match context {
         Context::Host => quote! {
-            use ambient_package_rt::message_serde::{Message, MessageSerde, MessageSerdeError, RuntimeMessage};
+            use ambient_package_rt::message_serde::{Message, MessageSerde, MessageSerdeError, RuntimeMessage, ModuleMessage};
             use glam::{Vec2, Vec3, Vec4, UVec2, UVec3, UVec4, Mat4, Quat};
             use crate::{EntityId, Entity};
             #(#messages)*

--- a/shared_crates/package_rt/src/message_serde.rs
+++ b/shared_crates/package_rt/src/message_serde.rs
@@ -368,3 +368,6 @@ pub trait Message: Sized {
 
 /// Implemented on all messages that come from the runtime.
 pub trait RuntimeMessage: Message {}
+
+/// Implemented on all messages that can be sent between packages.
+pub trait ModuleMessage: Message {}

--- a/shared_crates/package_semantic/src/message.rs
+++ b/shared_crates/package_semantic/src/message.rs
@@ -13,6 +13,7 @@ pub struct Message {
 
     pub description: Option<String>,
     pub fields: IndexMap<SnakeCaseIdentifier, ResolvableItemId<Type>>,
+    pub as_module_message: bool,
 }
 
 impl Item for Message {
@@ -80,6 +81,7 @@ impl Message {
                 .iter()
                 .map(|(k, v)| (k.clone(), ResolvableItemId::Unresolved(v.clone())))
                 .collect(),
+            as_module_message: value.as_module_message,
         }
     }
 }


### PR DESCRIPTION
Some messages, while sent by the runtime, need to be able to be sent by packages, too. This primarily concerns the UI.

To enable this, I've added `as_module_message` as a field for messages in packages, so that you can set `as_module_message = true` and both the host and the guest will generate them as `ModuleMessage`s instead.