### PR TITLE
fix #831 - remove unwraps from world audio systems

### DIFF
--- a/campfire/src/install.rs
+++ b/campfire/src/install.rs
@@ -63,6 +63,7 @@ fn install_version(suffix: &str, args: &[&str]) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[allow(unused_mut)]
 fn ambient_executable_name(suffix: &str) -> String {
     let mut name = if suffix.is_empty() {
         "ambient".to_string()


### PR DESCRIPTION
This refactors the code to remove the unwraps by encoding assumptions and by early-exiting. I've also taken advantage of #845 to remove all of the children-sync code.