### PR TITLE
Fix excessive rebuilds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,6 @@ dependencies = [
  "clap 4.4.2",
  "convert_case 0.6.0",
  "env_logger 0.10.0",
- "git-version",
  "glam 0.24.1",
  "image",
  "image_hasher",
@@ -702,6 +701,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient_git_rev"
+version = "0.3.0-dev"
+
+[[package]]
 name = "ambient_gizmos"
 version = "0.3.0-dev"
 dependencies = [
@@ -938,6 +941,7 @@ dependencies = [
  "ambient_cb",
  "ambient_color",
  "ambient_friendly_id",
+ "ambient_git_rev",
  "ambient_math",
  "ambient_shared_types",
  "ambient_sys",
@@ -948,7 +952,6 @@ dependencies = [
  "convert_case 0.6.0",
  "data-encoding",
  "futures",
- "git-version",
  "glam 0.24.1",
  "log",
  "mikktspace",
@@ -3690,28 +3693,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-version"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
-dependencies = [
- "git-version-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "git-version-macro"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "glam"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6093,12 +6074,6 @@ dependencies = [
  "once_cell",
  "toml_edit",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,6 @@ toml = { version = "0.7.4", features = ["preserve_order"] }
 percent-encoding = "2.2.0"
 indoc = "2.0"
 cargo_toml = "0.15.0"
-git-version = "0.3.5"
 toml_edit = "0.19.3"
 arboard = "3.2.0"
 noise = { version = "0.7.0", default-features = false }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -64,7 +64,6 @@ tracing = { workspace = true }
 image_hasher = { workspace = true }
 toml_edit = { workspace = true }
 rpassword = { workspace = true }
-git-version = { workspace = true }
 sentry = { workspace = true }
 sentry-rust-minidump = { workspace = true }
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -20,9 +20,6 @@ use serde::Deserialize;
 use server::{ServerHandle, QUIC_INTERFACE_PORT};
 use std::path::{Path, PathBuf};
 
-pub const GIT_VERSION: &str = git_version::git_version!();
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
 fn main() -> anyhow::Result<()> {
     let rt = ambient_sys::task::make_native_multithreaded_runtime()?;
 
@@ -361,10 +358,11 @@ fn init_sentry(sentry_dsn: &String) -> sentry::ClientInitGuard {
         std::process::exit(1);
     }));
 
+    let version = ambient_native_std::ambient_version();
     sentry::init((
         sentry_dsn.to_owned(),
         sentry::ClientOptions {
-            release: Some(format!("{VERSION}_{GIT_VERSION}").into()),
+            release: Some(format!("{}_{}", version.version, version.revision).into()),
             ..Default::default()
         },
     ))

--- a/crates/git_rev/Cargo.toml
+++ b/crates/git_rev/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ambient_git_rev"
+version = { workspace = true }
+rust-version = { workspace = true }
+edition = "2021"
+description = "Ambient git revision helper. Host-only."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/AmbientRun/Ambient"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/git_rev/README.md
+++ b/crates/git_rev/README.md
@@ -1,0 +1,3 @@
+# Ambient git revision
+
+Tiny helper crate to get the current git revision.

--- a/crates/git_rev/build.rs
+++ b/crates/git_rev/build.rs
@@ -1,0 +1,36 @@
+fn git_rev(len: usize) -> String {
+    std::str::from_utf8(
+        &std::process::Command::new("git")
+            .args(["rev-parse", &format!("--short={}", len), "HEAD"])
+            .output()
+            .expect("Failed to call `git rev-parse ...`")
+            .stdout,
+    )
+    .expect("Invalid git revision encoding")
+    .trim()
+    .to_string()
+}
+
+fn git_dir() -> String {
+    std::str::from_utf8(
+        &std::process::Command::new("git")
+            .args(["rev-parse", "--git-dir"])
+            .output()
+            .expect("Failed to call `git rev-parse --git-dir`")
+            .stdout,
+    )
+    .expect("Invalid path encoding")
+    .trim()
+    .to_string()
+}
+
+fn main() {
+    println!("cargo:rustc-env=REV_FULL={}", git_rev(40));
+    println!("cargo:rustc-env=REV_10={}", git_rev(10));
+    // This is a hack to get cargo to rebuild when the git log changes
+    // Also generating the path here so it's platform independent (include_bytes! expects a platform-specific path!)
+    println!(
+        "cargo:rustc-env=GIT_LOG_HEAD={}",
+        std::path::Path::new(&git_dir()).join("logs/HEAD").display()
+    );
+}

--- a/crates/git_rev/src/lib.rs
+++ b/crates/git_rev/src/lib.rs
@@ -1,0 +1,32 @@
+pub const REV_FULL: &str = env!("REV_FULL");
+pub const REV_10: &str = env!("REV_10");
+
+// This is a hack to get cargo to rebuild when the git log changes
+// Also generating the path in build.rs so it's platform independent (include_bytes! expects a platform-specific path!)
+const _JUST_DEP: &[u8] = include_bytes!(env!("GIT_LOG_HEAD"));
+
+#[test]
+fn test_git_rev_10() {
+    let revision = String::from_utf8(
+        std::process::Command::new("git")
+            .args(["rev-parse", "--short=10", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .expect("Invalid encoding");
+    assert_eq!(REV_10, revision.trim());
+}
+
+#[test]
+fn test_git_rev_full() {
+    let revision = String::from_utf8(
+        std::process::Command::new("git")
+            .args(["rev-parse", "--short=40", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .expect("Invalid encoding");
+    assert_eq!(REV_FULL, revision.trim());
+}

--- a/crates/native_std/Cargo.toml
+++ b/crates/native_std/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/AmbientRun/Ambient"
 [dependencies]
 ambient_asset_cache = { path = "../asset_cache/", optional = true, version = "0.3.0-dev" }
 ambient_sys = { path = "../sys", version = "0.3.0-dev" }
+ambient_git_rev = { path = "../git_rev", version = "0.3.0-dev" }
 
 ambient_cb = { path = "../../libs/cb", version = "0.3.0-dev" }
 ambient_color = { path = "../../libs/color", version = "0.3.0-dev" }
@@ -24,7 +25,6 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 ulid = { workspace = true }
 mikktspace = { workspace = true }
-git-version = { workspace = true }
 
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }


### PR DESCRIPTION
https://github.com/AmbientRun/Ambient/issues/835

This works almost like the git-version macro, the main difference being: it keeps only the `.git/logs/HEAD` as a dependency for rebuilds while git-version also tracks `.git/index`.