### PR TITLE
Mod manager

### DIFF
--- a/campfire/src/golden_images/mod.rs
+++ b/campfire/src/golden_images/mod.rs
@@ -57,7 +57,7 @@ pub async fn main(gi: &GoldenImages) -> anyhow::Result<()> {
     let tests = if let Mode::Update = gi.mode {
         // The base path is stripped as `get_all_packages` returns
         // paths relative to the current working directory.
-        get_all_packages(true, false)?
+        get_all_packages(true, false, false)?
             .into_iter()
             .map(|p| {
                 p.strip_prefix(TEST_BASE_PATH)

--- a/campfire/src/package.rs
+++ b/campfire/src/package.rs
@@ -13,6 +13,8 @@ pub enum Package {
     Clean,
     /// Run an package
     Run(Run),
+    /// List all packages
+    List,
     /// Run all the packages in order
     RunAll(RunParams),
     /// Check all the packages
@@ -53,6 +55,7 @@ pub fn main(args: &Package) -> anyhow::Result<()> {
     match args {
         Package::Clean => clean(),
         Package::Run(args) => run(args),
+        Package::List => list(),
         Package::RunAll(params) => run_all(params),
         Package::CheckAll => check_all(),
         Package::BuildAll => build_all(),
@@ -63,37 +66,9 @@ pub fn main(args: &Package) -> anyhow::Result<()> {
     }
 }
 
-pub fn build_all() -> anyhow::Result<()> {
-    let package_paths = get_all_packages(true, true)?;
-
-    for path in &package_paths {
-        run_ambient(&["build", &path.to_string_lossy(), "--clean-build"], true)?;
-    }
-
-    Ok(())
-}
-
-pub fn deploy_all(token: &str, include_examples: bool) -> anyhow::Result<()> {
-    let paths = get_all_packages(include_examples, false)?;
-    let paths = paths.iter().map(|p| p.to_string_lossy()).collect_vec();
-
-    let mut args = vec!["deploy"];
-    for (idx, path) in paths.iter().enumerate() {
-        if idx != 0 {
-            args.push("--extra-packages");
-        }
-        args.push(path);
-    }
-    args.push("--token");
-    args.push(token);
-    args.push("--clean-build");
-
-    run_ambient(&args, true)
-}
-
 pub fn clean() -> anyhow::Result<()> {
     log::info!("Cleaning examples...");
-    for path in get_all_packages(true, true)? {
+    for path in get_all_packages(true, true, true)? {
         let build_path = path.join("build");
         if !build_path.exists() {
             continue;
@@ -109,7 +84,7 @@ pub fn clean() -> anyhow::Result<()> {
 pub fn run(args: &Run) -> anyhow::Result<()> {
     let Run { package, params } = args;
 
-    let path = get_all_packages(true, true)?
+    let path = get_all_packages(true, true, false)?
         .into_iter()
         .find(|p| p.ends_with(package))
         .ok_or_else(|| anyhow::anyhow!("no example found with name {}", package))?;
@@ -118,8 +93,16 @@ pub fn run(args: &Run) -> anyhow::Result<()> {
     run_package(&path, params)
 }
 
+fn list() -> anyhow::Result<()> {
+    for path in get_all_packages(true, true, true)? {
+        println!("{}", path.display());
+    }
+
+    Ok(())
+}
+
 fn run_all(params: &RunParams) -> anyhow::Result<()> {
-    for path in get_all_packages(true, true)? {
+    for path in get_all_packages(true, true, false)? {
         log::info!("Running example {} (params: {params:?})...", path.display());
         run_package(&path, params)?;
     }
@@ -160,6 +143,34 @@ fn check_all() -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn build_all() -> anyhow::Result<()> {
+    let package_paths = get_all_packages(true, true, true)?;
+
+    for path in &package_paths {
+        run_ambient(&["build", &path.to_string_lossy(), "--clean-build"], true)?;
+    }
+
+    Ok(())
+}
+
+pub fn deploy_all(token: &str, include_examples: bool) -> anyhow::Result<()> {
+    let paths = get_all_packages(include_examples, false, true)?;
+    let paths = paths.iter().map(|p| p.to_string_lossy()).collect_vec();
+
+    let mut args = vec!["deploy"];
+    for (idx, path) in paths.iter().enumerate() {
+        if idx != 0 {
+            args.push("--extra-packages");
+        }
+        args.push(path);
+    }
+    args.push("--token");
+    args.push(token);
+    args.push("--clean-build");
+
+    run_ambient(&args, true)
+}
+
 fn run_package(path: &Path, params: &RunParams) -> anyhow::Result<()> {
     let mut args = vec!["run"];
     let path = path.to_string_lossy();
@@ -173,11 +184,22 @@ fn run_package(path: &Path, params: &RunParams) -> anyhow::Result<()> {
 pub fn get_all_packages(
     include_examples: bool,
     include_testcases: bool,
+    include_mods: bool,
 ) -> anyhow::Result<Vec<PathBuf>> {
     let mut package_paths = vec![];
     for category in all_directories_in(Path::new("guest/rust/packages"))? {
         for package in all_directories_in(&category.path())? {
-            package_paths.push(package.path());
+            let package_path = package.path();
+            package_paths.push(package_path.clone());
+
+            if include_mods {
+                let mods_path = package_path.join("mods");
+                if mods_path.is_dir() {
+                    for mod_path in all_directories_in(&mods_path)? {
+                        package_paths.push(mod_path.path());
+                    }
+                }
+            }
         }
     }
     if include_examples {

--- a/guest/rust/.gitignore
+++ b/guest/rust/.gitignore
@@ -4,6 +4,7 @@ examples/*/*/build
 examples/*/*/target
 
 packages/*/*/build
+packages/*/*/mods/*/build
 
 testcases/*/.cargo
 testcases/*/.gitignore

--- a/guest/rust/Cargo.lock
+++ b/guest/rust/Cargo.lock
@@ -2383,6 +2383,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tangent"
+version = "0.0.1"
+dependencies = [
+ "ambient_api",
+]
+
+[[package]]
 name = "tangent_core"
 version = "0.0.1"
 dependencies = [

--- a/guest/rust/Cargo.lock
+++ b/guest/rust/Cargo.lock
@@ -1678,6 +1678,7 @@ dependencies = [
  "ambient_api",
  "ambient_package",
  "serde",
+ "serde_json",
  "toml 0.7.6",
 ]
 

--- a/guest/rust/Cargo.toml
+++ b/guest/rust/Cargo.toml
@@ -72,13 +72,16 @@ members = [
     "packages/tools/package_manager",
 
     # Packages (games)
+    "packages/games/tangent",
     "packages/games/tangent/core",
     "packages/games/tangent/mods/*",
+
     "packages/games/minigolf",
     "packages/games/music_sequencer",
     "packages/games/pong",
     "packages/games/tictactoe",
     "packages/games/arkanoid",
+
     "packages/games/afps/core/*",
     "packages/games/afps/mods/*",
 ]

--- a/guest/rust/packages/games/tangent/Cargo.toml
+++ b/guest/rust/packages/games/tangent/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tangent"
+
+edition = "2021"
+publish = false
+version = "0.0.1"
+
+[dependencies]
+ambient_api = { workspace = true }
+
+[[bin]]
+name = "tangent_server"
+path = "src/server.rs"
+required-features = ["server"]
+
+[features]
+client = ["ambient_api/client"]
+server = ["ambient_api/server"]

--- a/guest/rust/packages/games/tangent/ambient.toml
+++ b/guest/rust/packages/games/tangent/ambient.toml
@@ -5,6 +5,6 @@ version = "0.0.1"
 content = { type = "Playable" }
 
 [dependencies]
-tangent_core = { path = "core", deployment = "6ohn5Rwwqy8FuFGe4AYgZi" }
-hide_cursor = { path = "../../std/hide_cursor", deployment = "72i9rwwm8taOeSqEYXnuQN" }
-package_manager = { path = "../../tools/package_manager", deployment = "2mGVCqCbJiOIANR4owPWPF" }
+tangent_core = { path = "core", deployment = "3Cr1inzxA7I9S0uGcygsDb" }
+hide_cursor = { path = "../../std/hide_cursor", deployment = "1o9AEWIWxauVgzUsW6x7Fb" }
+package_manager = { path = "../../tools/package_manager", deployment = "4hTFWZ5hiN5sTDAnQ6s1BN" }

--- a/guest/rust/packages/games/tangent/ambient.toml
+++ b/guest/rust/packages/games/tangent/ambient.toml
@@ -5,6 +5,6 @@ version = "0.0.1"
 content = { type = "Playable" }
 
 [dependencies]
-tangent_core = { path = "core", deployment = "5bTrM5ALilFYHrX4LkRxwN" }
+tangent_core = { path = "core", deployment = "3fkpE2Oakmtww5Yksg9aZv" }
 hide_cursor = { path = "../../std/hide_cursor", deployment = "4jy6aSt8bVKwPVjXwWCiq4" }
-package_manager = { path = "../../tools/package_manager", deployment = "FLZfgOfDlm10XUlP60rXI" }
+package_manager = { path = "../../tools/package_manager", deployment = "2j2oBSzO03NIixBDlEGeVT" }

--- a/guest/rust/packages/games/tangent/ambient.toml
+++ b/guest/rust/packages/games/tangent/ambient.toml
@@ -5,6 +5,6 @@ version = "0.0.1"
 content = { type = "Playable" }
 
 [dependencies]
-tangent_core = { path = "core", deployment = "3Cr1inzxA7I9S0uGcygsDb" }
-hide_cursor = { path = "../../std/hide_cursor", deployment = "1o9AEWIWxauVgzUsW6x7Fb" }
-package_manager = { path = "../../tools/package_manager", deployment = "4hTFWZ5hiN5sTDAnQ6s1BN" }
+tangent_core = { path = "core", deployment = "5bTrM5ALilFYHrX4LkRxwN" }
+hide_cursor = { path = "../../std/hide_cursor", deployment = "4jy6aSt8bVKwPVjXwWCiq4" }
+package_manager = { path = "../../tools/package_manager", deployment = "FLZfgOfDlm10XUlP60rXI" }

--- a/guest/rust/packages/games/tangent/ambient.toml
+++ b/guest/rust/packages/games/tangent/ambient.toml
@@ -6,6 +6,5 @@ content = { type = "Playable" }
 
 [dependencies]
 tangent_core = { path = "core", deployment = "6ohn5Rwwqy8FuFGe4AYgZi" }
-tangent_scene = { path = "mods/scene", deployment = "7Mq34Y8E6M0xDZvT8oKUpe" }
 hide_cursor = { path = "../../std/hide_cursor", deployment = "72i9rwwm8taOeSqEYXnuQN" }
 package_manager = { path = "../../tools/package_manager", deployment = "2mGVCqCbJiOIANR4owPWPF" }

--- a/guest/rust/packages/games/tangent/core/ambient.toml
+++ b/guest/rust/packages/games/tangent/core/ambient.toml
@@ -13,4 +13,4 @@ debug_messages = { type = { type = "Vec", element_type = "String" }, name = "Deb
 ] }
 
 [dependencies]
-tangent_schema = { path = "../schema" , deployment = "6aJ3qf6AHkUgyarfXphwsJ" }
+tangent_schema = { path = "../schema" , deployment = "2jl5QKVM6D65U9B3tTK8zt" }

--- a/guest/rust/packages/games/tangent/core/ambient.toml
+++ b/guest/rust/packages/games/tangent/core/ambient.toml
@@ -13,4 +13,4 @@ debug_messages = { type = { type = "Vec", element_type = "String" }, name = "Deb
 ] }
 
 [dependencies]
-tangent_schema = { path = "../schema" , deployment = "2jl5QKVM6D65U9B3tTK8zt" }
+tangent_schema = { path = "../schema" , deployment = "1TPATbTfhDSITewj4eCfJQ" }

--- a/guest/rust/packages/games/tangent/core/src/client.rs
+++ b/guest/rust/packages/games/tangent/core/src/client.rs
@@ -124,28 +124,30 @@ pub fn main() {
         let kph = speed_kph(vehicle_linear_velocity, vehicle_rotation);
         entity::set_component(camera_id, fovy(), 0.9 + (kph.abs() / 300.0).clamp(0.0, 1.0));
 
-        let input = input::get();
-        let direction = {
-            let mut direction = Vec2::ZERO;
-            if input.keys.contains(&KeyCode::W) {
-                direction.y += 1.;
+        if input::is_game_focused() {
+            let input = input::get();
+            let direction = {
+                let mut direction = Vec2::ZERO;
+                if input.keys.contains(&KeyCode::W) {
+                    direction.y += 1.;
+                }
+                if input.keys.contains(&KeyCode::S) {
+                    direction.y -= 1.;
+                }
+                if input.keys.contains(&KeyCode::A) {
+                    direction.x -= 1.;
+                }
+                if input.keys.contains(&KeyCode::D) {
+                    direction.x += 1.;
+                }
+                direction
+            };
+            Input {
+                direction,
+                jump: input.keys.contains(&KeyCode::Space),
             }
-            if input.keys.contains(&KeyCode::S) {
-                direction.y -= 1.;
-            }
-            if input.keys.contains(&KeyCode::A) {
-                direction.x -= 1.;
-            }
-            if input.keys.contains(&KeyCode::D) {
-                direction.x += 1.;
-            }
-            direction
-        };
-        Input {
-            direction,
-            jump: input.keys.contains(&KeyCode::Space),
+            .send_server_unreliable();
         }
-        .send_server_unreliable();
     });
 
     if RENDER_DEBUG {

--- a/guest/rust/packages/games/tangent/mods/scene/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/scene/ambient.toml
@@ -5,4 +5,4 @@ version = "0.0.1"
 content = { type = "Mod", for_playables = ["tangent"] }
 
 [dependencies]
-tangent_schema = { deployment = "2jl5QKVM6D65U9B3tTK8zt" }
+tangent_schema = { deployment = "1TPATbTfhDSITewj4eCfJQ" }

--- a/guest/rust/packages/games/tangent/mods/scene/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/scene/ambient.toml
@@ -5,4 +5,4 @@ version = "0.0.1"
 content = { type = "Mod", for_playables = ["tangent"] }
 
 [dependencies]
-tangent_schema = { deployment = "6aJ3qf6AHkUgyarfXphwsJ" }
+tangent_schema = { deployment = "2jl5QKVM6D65U9B3tTK8zt" }

--- a/guest/rust/packages/games/tangent/mods/scene/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/scene/ambient.toml
@@ -2,7 +2,7 @@
 id = "tangent_scene"
 name = "Tangent Scene"
 version = "0.0.1"
-content = { type = "Asset", models = true, code = true }
+content = { type = "Mod", for_playables = ["tangent"] }
 
 [dependencies]
-tangent_schema = { path = "../../schema" , deployment = "6aJ3qf6AHkUgyarfXphwsJ" }
+tangent_schema = { deployment = "6aJ3qf6AHkUgyarfXphwsJ" }

--- a/guest/rust/packages/games/tangent/src/server.rs
+++ b/guest/rust/packages/games/tangent/src/server.rs
@@ -1,0 +1,11 @@
+use ambient_api::prelude::*;
+use packages::package_manager;
+
+#[main]
+fn main() {
+    entity::add_component(
+        package_manager::entity(),
+        package_manager::components::mod_manager_for(),
+        packages::this::entity(),
+    );
+}

--- a/guest/rust/packages/tools/package_manager/Cargo.toml
+++ b/guest/rust/packages/tools/package_manager/Cargo.toml
@@ -10,6 +10,7 @@ ambient_api = { workspace = true }
 ambient_package = { workspace = true }
 toml = "0.7"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [[bin]]
 name = "package_manager_client"

--- a/guest/rust/packages/tools/package_manager/ambient.toml
+++ b/guest/rust/packages/tools/package_manager/ambient.toml
@@ -4,6 +4,12 @@ name = "Package Manager"
 version = "0.0.1"
 content = { type = "Tool" }
 
+[components.mod_manager_for]
+name = "Mod Manager For"
+description = "Package config component. Attach this component to this package's entity to make it a mod manager for the given package."
+type = "EntityId"
+attributes = ["Networked", "Debuggable"]
+
 [messages.PackageLoad.fields]
 url = "String"
 
@@ -47,4 +53,4 @@ packages = { container_type = "Vec", element_type = "String" }
 error = { container_type = "Option", element_type = "String" }
 
 [dependencies]
-editor_schema = { path = "../../schemas/editor", deployment = "pmZjq6Wcr1luBrsbkR141" }
+editor_schema = { path = "../../schemas/editor", deployment = "gqDEh5MyO0TAYzAzRHxbm" }

--- a/guest/rust/packages/tools/package_manager/ambient.toml
+++ b/guest/rust/packages/tools/package_manager/ambient.toml
@@ -34,5 +34,17 @@ id = "EntityId"
 description = "Shows the package load view"
 [messages.PackageLoadShow.fields]
 
+[messages.PackageRemoteRequest]
+description = "Requests all relevant remote packages"
+[messages.PackageRemoteRequest.fields]
+
+[messages.PackageRemoteResponse]
+description = "Response to a remote package request"
+[messages.PackageRemoteResponse.fields]
+# It would be nice to send structured types here
+# https://github.com/AmbientRun/Ambient/issues/790
+packages = { container_type = "Vec", element_type = "String" }
+error = { container_type = "Option", element_type = "String" }
+
 [dependencies]
 editor_schema = { path = "../../schemas/editor", deployment = "pmZjq6Wcr1luBrsbkR141" }

--- a/guest/rust/packages/tools/package_manager/ambient.toml
+++ b/guest/rust/packages/tools/package_manager/ambient.toml
@@ -53,4 +53,4 @@ packages = { container_type = "Vec", element_type = "String" }
 error = { container_type = "Option", element_type = "String" }
 
 [dependencies]
-editor_schema = { path = "../../schemas/editor", deployment = "gqDEh5MyO0TAYzAzRHxbm" }
+editor_schema = { path = "../../schemas/editor", deployment = "NCtVbEsZzOTybL5etYjHH" }

--- a/guest/rust/packages/tools/package_manager/src/client/package_manager.rs
+++ b/guest/rust/packages/tools/package_manager/src/client/package_manager.rs
@@ -2,18 +2,27 @@ use std::fmt;
 
 use ambient_api::{
     core::{
-        package::{components::description, concepts::Package},
+        package::{components::description, concepts::Package as PackageConcept},
         rect::components::background_color,
         text::{components::font_style, types::FontStyle},
     },
-    element::{use_module_message, use_query, use_spawn},
+    element::{use_effect, use_module_message, use_query, use_spawn, use_state},
     prelude::*,
     ui::ImageFromUrl,
 };
 
-use crate::packages::this::{
-    assets,
-    messages::{PackageLoadShow, PackageSetEnabled, PackageShow},
+use crate::{
+    packages::{
+        self,
+        this::{
+            assets,
+            messages::{
+                PackageLoadShow, PackageRemoteRequest, PackageRemoteResponse, PackageSetEnabled,
+                PackageShow,
+            },
+        },
+    },
+    shared::PackageJson,
 };
 
 use super::use_hotkey_toggle;
@@ -57,12 +66,7 @@ fn PackageManagerInner(hooks: &mut Hooks) -> Element {
 
     Tabs::new()
         .with_tab(ListTab::Local, || PackagesLocal::el())
-        .with_tab(ListTab::Remote, || {
-            Button::new("Load package", |_| {
-                PackageLoadShow.send_local(crate::packages::this::entity())
-            })
-            .el()
-        })
+        .with_tab(ListTab::Remote, || PackagesRemote::el())
         .el()
         .with(space_between_items(), 4.0)
         .with_margin_even(STREET)
@@ -70,7 +74,7 @@ fn PackageManagerInner(hooks: &mut Hooks) -> Element {
 
 #[element_component]
 fn PackagesLocal(hooks: &mut Hooks) -> Element {
-    let packages = use_query(hooks, Package::as_query());
+    let packages = use_query(hooks, PackageConcept::as_query());
 
     let display_packages: Vec<_> = packages
         .into_iter()
@@ -78,8 +82,10 @@ fn PackagesLocal(hooks: &mut Hooks) -> Element {
             let description = entity::get_component(id, description());
 
             DisplayPackage {
-                source: DisplayPackageSource::Local { id },
-                enabled: package.enabled,
+                source: DisplayPackageSource::Local {
+                    id,
+                    enabled: package.enabled,
+                },
                 name: package.name,
                 version: package.version,
                 authors: package.authors,
@@ -91,10 +97,79 @@ fn PackagesLocal(hooks: &mut Hooks) -> Element {
     PackageList::el(display_packages)
 }
 
+#[element_component]
+fn PackagesRemote(hooks: &mut Hooks) -> Element {
+    #[derive(Clone, Debug)]
+    enum PackagesState {
+        Loading,
+        Loaded(Vec<DisplayPackage>),
+        Error(String),
+    }
+    let (packages, set_packages) = use_state(hooks, PackagesState::Loading);
+
+    use_effect(hooks, (), move |_, _| {
+        PackageRemoteRequest::default().send_server_reliable();
+        |_| {}
+    });
+
+    use_module_message::<PackageRemoteResponse>(hooks, move |_, ctx, msg| {
+        if !ctx.server() {
+            return;
+        }
+
+        if let Some(error) = &msg.error {
+            set_packages(PackagesState::Error(error.to_string()));
+            return;
+        }
+
+        let packages_json = msg
+            .packages
+            .iter()
+            .map(|p| serde_json::from_str::<PackageJson>(p))
+            .collect::<Result<Vec<_>, _>>();
+
+        match packages_json {
+            Ok(packages_json) => set_packages(PackagesState::Loaded(
+                packages_json
+                    .into_iter()
+                    .map(|package| DisplayPackage {
+                        source: DisplayPackageSource::Remote {
+                            url: package.url.clone(),
+                        },
+                        name: package.name,
+                        version: package.version,
+                        authors: package.authors,
+                        description: package.description,
+                    })
+                    .collect(),
+            )),
+            Err(error) => {
+                set_packages(PackagesState::Error(format!(
+                    "Failed to parse packages: {}",
+                    error
+                )));
+                return;
+            }
+        };
+    });
+
+    FlowColumn::el([
+        match packages {
+            PackagesState::Loading => Text::el("Loading..."),
+            PackagesState::Loaded(packages) => PackageList::el(packages),
+            PackagesState::Error(error) => Text::el(error),
+        },
+        Button::new("Load package from URL", |_| {
+            PackageLoadShow.send_local(crate::packages::this::entity())
+        })
+        .el(),
+    ])
+    .with(space_between_items(), 8.0)
+}
+
 #[derive(Clone, Debug)]
 struct DisplayPackage {
     source: DisplayPackageSource,
-    enabled: bool,
     name: String,
     version: String,
     authors: Vec<String>,
@@ -103,7 +178,7 @@ struct DisplayPackage {
 
 #[derive(Clone, Debug)]
 enum DisplayPackageSource {
-    Local { id: EntityId },
+    Local { id: EntityId, enabled: bool },
     Remote { url: String },
 }
 
@@ -112,64 +187,72 @@ fn PackageList(_hooks: &mut Hooks, packages: Vec<DisplayPackage>) -> Element {
     let mut packages = packages;
     packages.sort_by_key(|package| package.name.clone());
 
-    FlowColumn::el(packages.into_iter().map(|package| {
-        with_rect(FlowRow::el([
-            ImageFromUrl {
-                url: assets::url("construction.png"),
-            }
+    FlowColumn::el(packages.into_iter().map(|package| Package::el(package)))
+        .with(space_between_items(), 8.0)
+        .with(min_width(), 400.0)
+}
+
+#[element_component]
+fn Package(_hooks: &mut Hooks, package: DisplayPackage) -> Element {
+    fn button(text: impl Into<String>, action: impl Fn() + Send + Sync + 'static) -> Element {
+        Button::new(text.into(), move |_| action())
+            .style(ButtonStyle::Inline)
             .el()
-            .with(width(), 64.0)
-            .with(height(), 64.0),
-            FlowColumn::el([
-                FlowRow::el([
-                    Text::el(package.name).with(font_style(), FontStyle::Bold),
-                    Text::el(package.version),
-                    Text::el("by"),
-                    Text::el(if package.authors.is_empty() {
-                        "No authors specified".to_string()
-                    } else {
-                        package.authors.join(", ")
-                    })
-                    .with(font_style(), FontStyle::Italic),
-                ])
-                .with(space_between_items(), 4.0),
-                Text::el(package.description.as_deref().unwrap_or("No description")),
-                match &package.source {
-                    DisplayPackageSource::Local { id } => {
-                        let id = *id;
-                        FlowRow::el([
-                            Button::new(
-                                if package.enabled { "Disable" } else { "Enable" },
-                                move |_| {
-                                    PackageSetEnabled {
-                                        id,
-                                        enabled: !package.enabled,
-                                    }
-                                    .send_server_reliable();
-                                },
-                            )
-                            .style(ButtonStyle::Inline)
-                            .el(),
-                            Button::new("View", move |_| {
-                                PackageShow { id }.send_local(crate::packages::this::entity())
-                            })
-                            .style(ButtonStyle::Inline)
-                            .el(),
-                        ])
-                        .with(space_between_items(), 8.0)
-                    }
-                    _ => Element::new(),
-                },
+    }
+
+    with_rect(FlowRow::el([
+        // Image (ideally, this would be the package icon)
+        ImageFromUrl {
+            url: assets::url("construction.png"),
+        }
+        .el()
+        .with(width(), 64.0)
+        .with(height(), 64.0),
+        // Contents
+        FlowColumn::el([
+            // Header
+            FlowRow::el([
+                Text::el(package.name).with(font_style(), FontStyle::Bold),
+                Text::el(package.version),
+                Text::el("by"),
+                Text::el(if package.authors.is_empty() {
+                    "No authors specified".to_string()
+                } else {
+                    package.authors.join(", ")
+                })
+                .with(font_style(), FontStyle::Italic),
             ])
             .with(space_between_items(), 4.0),
-        ]))
-        .with(space_between_items(), 8.0)
-        .with(background_color(), vec4(0., 0., 0., 0.5))
-        .with(fit_horizontal(), Fit::Parent)
-        .with_padding_even(8.0)
-    }))
+            // Description
+            Text::el(package.description.as_deref().unwrap_or("No description")),
+            // Buttons
+            match &package.source {
+                DisplayPackageSource::Local { id, enabled } => {
+                    let id = *id;
+                    let enabled = *enabled;
+                    FlowRow::el([
+                        button(if enabled { "Disable" } else { "Enable" }, move || {
+                            PackageSetEnabled {
+                                id,
+                                enabled: !enabled,
+                            }
+                            .send_server_reliable();
+                        }),
+                        button("View", move || {
+                            PackageShow { id }.send_local(crate::packages::this::entity())
+                        }),
+                    ])
+                    .with(space_between_items(), 8.0)
+                }
+                _ => Element::new(),
+            },
+        ])
+        .with(space_between_items(), 4.0),
+    ]))
     .with(space_between_items(), 8.0)
-    .with(min_width(), 400.0)
+    .with(background_color(), vec4(0., 0., 0., 0.5))
+    .with(fit_horizontal(), Fit::Parent)
+    .with_padding_even(8.0)
 }
 
 // TODO: is there a way to share this?

--- a/guest/rust/packages/tools/package_manager/src/client/package_manager.rs
+++ b/guest/rust/packages/tools/package_manager/src/client/package_manager.rs
@@ -3,7 +3,6 @@ use std::{collections::HashSet, fmt};
 use ambient_api::{
     core::{
         package::{
-            self,
             components::{description, id, is_package},
             concepts::Package as PackageConcept,
         },
@@ -161,7 +160,7 @@ fn use_remote_packages(hooks: &mut Hooks) -> PackagesState {
     let (remote_packages, set_remote_packages) = use_state(hooks, PackagesState::Loading);
 
     use_effect(hooks, (), move |_, _| {
-        PackageRemoteRequest::default().send_server_reliable();
+        PackageRemoteRequest.send_server_reliable();
         |_| {}
     });
 
@@ -188,7 +187,6 @@ fn use_remote_packages(hooks: &mut Hooks) -> PackagesState {
                     "Failed to parse packages: {}",
                     error
                 )));
-                return;
             }
         };
     });
@@ -251,7 +249,7 @@ fn PackageList(_hooks: &mut Hooks, packages: Vec<DisplayPackage>) -> Element {
     let mut packages = packages;
     packages.sort_by_key(|package| package.name.clone());
 
-    FlowColumn::el(packages.into_iter().map(|package| Package::el(package)))
+    FlowColumn::el(packages.into_iter().map(Package::el))
         .with(space_between_items(), 8.0)
         .with(min_width(), 400.0)
 }

--- a/guest/rust/packages/tools/package_manager/src/client/package_manager.rs
+++ b/guest/rust/packages/tools/package_manager/src/client/package_manager.rs
@@ -1,21 +1,16 @@
-use crate::ambient_element::use_module_message;
-use crate::ambient_element::use_spawn;
 use ambient_api::{
     core::{
-        package::components::{
-            authors, client_modules, description, enabled, is_package, name, server_modules,
-            version,
-        },
+        package::{components::description, concepts::Package},
         text::{components::font_style, types::FontStyle},
     },
-    element::use_query,
+    element::{use_module_message, use_query, use_spawn},
     prelude::*,
     ui::ImageFromUrl,
 };
 
 use crate::packages::this::{
     assets,
-    messages::{PackageLoadShow, PackageSetEnabled, PackageShow, WasmReload},
+    messages::{PackageLoadShow, PackageSetEnabled, PackageShow},
 };
 
 use super::use_hotkey_toggle;
@@ -38,114 +33,104 @@ pub fn PackageManager(hooks: &mut Hooks) -> Element {
 
 #[element_component]
 fn PackageManagerInner(hooks: &mut Hooks) -> Element {
-    let packages = use_query(
-        hooks,
-        (
-            is_package(),
-            enabled(),
-            name(),
-            version(),
-            authors(),
-            client_modules(),
-            server_modules(),
-        ),
-    );
+    let packages = use_query(hooks, Package::as_query());
 
-    struct Package {
-        enabled: bool,
-        name: String,
-        version: String,
-        authors: Vec<String>,
-        description: Option<String>,
-        client_modules: Vec<EntityId>,
-        server_modules: Vec<EntityId>,
-    }
-
-    let mut packages: Vec<_> = packages
+    let display_packages: Vec<_> = packages
         .into_iter()
-        .map(
-            |(id, (_, enabled, name, version, authors, client_modules, server_modules))| {
-                let description = entity::get_component(id, description());
+        .map(|(id, package)| {
+            let description = entity::get_component(id, description());
 
-                (
-                    id,
-                    Package {
-                        enabled,
-                        name,
-                        version,
-                        authors,
-                        description,
-                        client_modules,
-                        server_modules,
-                    },
-                )
-            },
-        )
+            DisplayPackage {
+                source: DisplayPackageSource::Local { id },
+                enabled: package.enabled,
+                name: package.name,
+                version: package.version,
+                authors: package.authors,
+                description,
+            }
+        })
         .collect();
-    packages.sort_by_key(|(_, package)| package.name.clone());
 
-    FlowColumn::el(Iterator::chain(
-        [Button::new("Load package", |_| {
+    FlowColumn::el([
+        Button::new("Load package", |_| {
             PackageLoadShow.send_local(crate::packages::this::entity())
         })
-        .el()]
-        .into_iter(),
-        packages.into_iter().map(|(id, package)| {
-            FlowRow::el([
-                ImageFromUrl {
-                    url: assets::url("construction.png"),
-                }
-                .el()
-                .with(width(), 48.0)
-                .with(height(), 48.0),
-                FlowColumn::el([
-                    Checkbox::new(package.enabled, move |value| {
-                        PackageSetEnabled { id, enabled: value }.send_server_reliable();
-                    })
-                    .el(),
-                    Button::new(FontAwesomeIcon::el(0xf2f1, true), {
-                        let modules: Vec<_> = package
-                            .client_modules
-                            .iter()
-                            .chain(package.server_modules.iter())
-                            .copied()
-                            .collect();
-                        move |_| {
-                            for &id in &modules {
-                                WasmReload::new(id).send_server_reliable();
-                            }
-                        }
-                    })
-                    .style(ButtonStyle::Flat)
-                    .el(),
-                ]),
-                FlowColumn::el([
-                    FlowRow::el([
-                        Text::el(package.name).with(font_style(), FontStyle::Bold),
-                        Text::el(package.version),
-                        Text::el("by"),
-                        Text::el(if package.authors.is_empty() {
-                            "No authors specified".to_string()
-                        } else {
-                            package.authors.join(", ")
-                        })
-                        .with(font_style(), FontStyle::Italic),
-                    ])
-                    .with(space_between_items(), 4.0),
-                    Text::el(package.description.as_deref().unwrap_or("No description")),
-                    Button::new("View", move |_| {
-                        PackageShow { id }.send_local(crate::packages::this::entity())
-                    })
-                    .style(ButtonStyle::Flat)
-                    .el(),
-                ])
-                .with(space_between_items(), 8.0),
-            ])
-            .with(space_between_items(), 8.0)
-        }),
-    ))
+        .el(),
+        PackageList::el(display_packages),
+    ])
     .with(space_between_items(), 4.0)
     .with_margin_even(STREET)
+}
+
+#[derive(Clone, Debug)]
+struct DisplayPackage {
+    source: DisplayPackageSource,
+    enabled: bool,
+    name: String,
+    version: String,
+    authors: Vec<String>,
+    description: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+enum DisplayPackageSource {
+    Local { id: EntityId },
+    Remote { url: String },
+}
+
+#[element_component]
+fn PackageList(_hooks: &mut Hooks, packages: Vec<DisplayPackage>) -> Element {
+    let mut packages = packages;
+    packages.sort_by_key(|package| package.name.clone());
+
+    FlowColumn::el(packages.into_iter().map(|package| {
+        FlowRow::el([
+            ImageFromUrl {
+                url: assets::url("construction.png"),
+            }
+            .el()
+            .with(width(), 48.0)
+            .with(height(), 48.0),
+            match &package.source {
+                DisplayPackageSource::Local { id } => {
+                    let id = *id;
+                    FlowColumn::el([Checkbox::new(package.enabled, move |value| {
+                        PackageSetEnabled { id, enabled: value }.send_server_reliable();
+                    })
+                    .el()])
+                }
+                _ => Element::new(),
+            },
+            FlowColumn::el([
+                FlowRow::el([
+                    Text::el(package.name).with(font_style(), FontStyle::Bold),
+                    Text::el(package.version),
+                    Text::el("by"),
+                    Text::el(if package.authors.is_empty() {
+                        "No authors specified".to_string()
+                    } else {
+                        package.authors.join(", ")
+                    })
+                    .with(font_style(), FontStyle::Italic),
+                ])
+                .with(space_between_items(), 4.0),
+                Text::el(package.description.as_deref().unwrap_or("No description")),
+                match &package.source {
+                    DisplayPackageSource::Local { id } => {
+                        let id = *id;
+                        Button::new("View", move |_| {
+                            PackageShow { id }.send_local(crate::packages::this::entity())
+                        })
+                        .style(ButtonStyle::Flat)
+                        .el()
+                    }
+                    _ => Element::new(),
+                },
+            ])
+            .with(space_between_items(), 8.0),
+        ])
+        .with(space_between_items(), 8.0)
+    }))
 }
 
 // TODO: is there a way to share this?

--- a/guest/rust/packages/tools/package_manager/src/server/package_manager.rs
+++ b/guest/rust/packages/tools/package_manager/src/server/package_manager.rs
@@ -50,7 +50,7 @@ async fn process_request() -> anyhow::Result<PackageRemoteResponse> {
     .and_then(|id| entity::get_component(id, ambient_api::core::package::components::id()));
 
     let mut api_url = "https://api.ambient.run/packages/list".to_string();
-    if let Some(id) = &mod_manager_for {
+    if let Some(_id) = &mod_manager_for {
         // TODO: use for_playables filtering when available
         api_url.push_str("?content_contains=Mod");
     }

--- a/guest/rust/packages/tools/package_manager/src/server/package_manager.rs
+++ b/guest/rust/packages/tools/package_manager/src/server/package_manager.rs
@@ -1,9 +1,74 @@
-use ambient_api::{core::package::components::enabled, prelude::*};
+use std::collections::HashSet;
 
-use crate::packages::this::messages::PackageSetEnabled;
+use ambient_api::{anyhow, core::package::components::enabled, prelude::*};
+use ambient_package::Manifest;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    packages::this::messages::{PackageRemoteRequest, PackageRemoteResponse, PackageSetEnabled},
+    shared::PackageJson,
+};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct PackageListApiJson {
+    name: String,
+    latest_deployment: String,
+    content: Vec<String>,
+}
 
 pub fn main() {
     PackageSetEnabled::subscribe(|_, msg| {
         entity::set_component(msg.id, enabled(), msg.enabled);
     });
+
+    PackageRemoteRequest::subscribe(|ctx, _| {
+        let Some(user_id) = ctx.client_user_id() else {
+            return;
+        };
+
+        run_async(async move {
+            match process_request().await {
+                Ok(msg) => msg,
+                Err(err) => PackageRemoteResponse {
+                    packages: vec![],
+                    error: Some(err.to_string()),
+                },
+            }
+            .send_client_targeted_reliable(user_id)
+        });
+    });
+}
+
+async fn process_request() -> anyhow::Result<PackageRemoteResponse> {
+    let mut api_packages: Vec<PackageListApiJson> =
+        serde_json::from_slice(&http::get("https://api.ambient.run/packages/list").await?)?;
+
+    let ignore_content_types: HashSet<&str> = HashSet::from_iter(["Schema", "Playable"]);
+    api_packages.retain(|pkg| {
+        HashSet::from_iter(pkg.content.iter().map(|s| s.as_str()))
+            .is_disjoint(&ignore_content_types)
+    });
+
+    let mut packages_json = vec![];
+    for api_package in api_packages {
+        let url = format!(
+            "https://assets.ambient.run/{}/ambient.toml",
+            api_package.latest_deployment
+        );
+
+        let manifest: Manifest = toml::from_str(std::str::from_utf8(&http::get(&url).await?)?)?;
+
+        packages_json.push(serde_json::to_string(&PackageJson {
+            name: manifest.package.name,
+            url,
+            version: manifest.package.version.to_string(),
+            authors: manifest.package.authors,
+            description: manifest.package.description,
+        })?);
+    }
+
+    Ok(PackageRemoteResponse {
+        packages: packages_json,
+        error: None,
+    })
 }

--- a/guest/rust/packages/tools/package_manager/src/server/package_manager.rs
+++ b/guest/rust/packages/tools/package_manager/src/server/package_manager.rs
@@ -59,8 +59,9 @@ async fn process_request() -> anyhow::Result<PackageRemoteResponse> {
         let manifest: Manifest = toml::from_str(std::str::from_utf8(&http::get(&url).await?)?)?;
 
         packages_json.push(serde_json::to_string(&PackageJson {
-            name: manifest.package.name,
             url,
+            name: manifest.package.name,
+            id: manifest.package.id.to_string(),
             version: manifest.package.version.to_string(),
             authors: manifest.package.authors,
             description: manifest.package.description,

--- a/guest/rust/packages/tools/package_manager/src/shared.rs
+++ b/guest/rust/packages/tools/package_manager/src/shared.rs
@@ -1,1 +1,11 @@
+use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize)]
+pub struct PackageJson {
+    // TODO: don't let people submit their own custom URLs to the backend
+    pub url: String,
+    pub name: String,
+    pub version: String,
+    pub authors: Vec<String>,
+    pub description: Option<String>,
+}

--- a/guest/rust/packages/tools/package_manager/src/shared.rs
+++ b/guest/rust/packages/tools/package_manager/src/shared.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PackageJson {
     // TODO: don't let people submit their own custom URLs to the backend
     pub url: String,
+    pub id: String,
     pub name: String,
     pub version: String,
     pub authors: Vec<String>,

--- a/shared_crates/ui/src/tabs.rs
+++ b/shared_crates/ui/src/tabs.rs
@@ -3,12 +3,14 @@ use std::fmt::Debug;
 
 use ambient_cb::{cb, Cb};
 use ambient_element::{to_owned, use_state, Element, ElementComponent, ElementComponentExt, Hooks};
-use ambient_guest_bridge::{core::layout::components::space_between_items, ecs::ComponentValue};
+use ambient_guest_bridge::core::layout::components::{padding, space_between_items};
+use glam::vec4;
 
 use crate::{
-    button::Button,
+    button::{Button, ButtonStyle},
     default_theme::STREET,
     layout::{FlowColumn, FlowRow},
+    UIExt,
 };
 
 #[derive(Clone, Debug)]
@@ -38,12 +40,13 @@ impl<T: ToString + PartialEq + Clone + Debug + Sync + Send + 'static> ElementCom
                         move |_| on_change.0(tab.clone())
                     })
                     .toggled(tab == value)
+                    .style(ButtonStyle::Card)
                     .el()
+                    .with(padding(), vec4(0.0, STREET, 0.0, STREET))
                 })
                 .collect(),
         )
         .el()
-        .with(space_between_items(), STREET)
     }
 }
 

--- a/shared_crates/ui/src/tabs.rs
+++ b/shared_crates/ui/src/tabs.rs
@@ -71,9 +71,8 @@ impl<T: ToString + PartialEq + Default + Clone + Debug + Sync + Send + 'static> 
         self
     }
 }
-impl<
-        T: ToString + PartialEq + Default + ComponentValue + Clone + Debug + Sync + Send + 'static,
-    > ElementComponent for Tabs<T>
+impl<T: ToString + PartialEq + Default + Clone + Debug + Sync + Send + 'static> ElementComponent
+    for Tabs<T>
 {
     fn render(self: Box<Self>, hooks: &mut Hooks) -> Element {
         let (value, set_value) = use_state(hooks, T::default());

--- a/shared_crates/ui/src/tabs.rs
+++ b/shared_crates/ui/src/tabs.rs
@@ -10,7 +10,6 @@ use crate::{
     button::{Button, ButtonStyle},
     default_theme::STREET,
     layout::{FlowColumn, FlowRow},
-    UIExt,
 };
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Revises the package manager to act double-duty as a mod manager by specifying the `mod_manager_for` component on its package entity.

There are a few TODOs, but it works without fixing them:

- Filter what's relevant to us using the API, not by grabbing all of it and filtering there
- Add `content` and `playable_for` to the package components so we can figure out if a local package is relevant without having to ask the server about it

Notably, this does not make any changes to Ambient (outside of making Campfire deploy mods) - this should mean it's compatible with today's nightly.