### PR TITLE
feat: add url helpers

### DIFF
--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -69,7 +69,7 @@ pub enum Commands {
         #[arg(long)]
         extra_packages: Vec<PathBuf>,
         /// API server endpoint
-        #[arg(long, default_value = "https://api.ambient.run")]
+        #[arg(long, default_value = ambient_shared_types::urls::API_URL)]
         api_server: String,
         /// Authentication token
         #[arg(short, long)]

--- a/crates/deploy/src/lib.rs
+++ b/crates/deploy/src/lib.rs
@@ -38,7 +38,7 @@ pub async fn deploy(
     auth_token: &str,
     path: impl AsRef<Path>,
     force_upload: bool,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<(String, Manifest)> {
     let manifest =
         Manifest::parse(&tokio::fs::read_to_string(path.as_ref().join("ambient.toml")).await?)?;
 
@@ -155,7 +155,10 @@ pub async fn deploy(
     handle.await??;
 
     // this should have arrived in Finished message from the server
-    deployment.ok_or_else(|| anyhow::anyhow!("No deployment id returned from deploy"))
+    Ok((
+        deployment.ok_or_else(|| anyhow::anyhow!("No deployment id returned from deploy"))?,
+        manifest,
+    ))
 }
 
 // Get all files from "build" and EXTRA_FILES_FROM_PACKAGE_ROOT

--- a/guest/rust/Cargo.lock
+++ b/guest/rust/Cargo.lock
@@ -1677,6 +1677,7 @@ version = "0.0.1"
 dependencies = [
  "ambient_api",
  "ambient_package",
+ "ambient_shared_types",
  "serde",
  "serde_json",
  "toml 0.7.6",

--- a/guest/rust/packages/tools/package_manager/Cargo.toml
+++ b/guest/rust/packages/tools/package_manager/Cargo.toml
@@ -8,6 +8,8 @@ version = "0.0.1"
 [dependencies]
 ambient_api = { workspace = true }
 ambient_package = { workspace = true }
+ambient_shared_types = { workspace = true }
+
 toml = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/guest/rust/packages/tools/package_manager/src/server/package_load.rs
+++ b/guest/rust/packages/tools/package_manager/src/server/package_load.rs
@@ -9,7 +9,7 @@ pub fn main() {
         };
         let maybe_url = msg.url.strip_suffix('/').unwrap_or(&msg.url).to_owned();
         let url = if !maybe_url.contains("http") {
-            format!("https://assets.ambient.run/{maybe_url}")
+            ambient_shared_types::urls::deployment_url(&maybe_url)
         } else {
             maybe_url
         };

--- a/shared_crates/package/src/manifest.rs
+++ b/shared_crates/package/src/manifest.rs
@@ -181,7 +181,7 @@ impl Dependency {
         if let Some(url) = self.url.clone() {
             Some(url)
         } else if let Some(deployment) = self.deployment.as_ref() {
-            Url::parse(&format!("https://assets.ambient.run/{deployment}")).ok()
+            Url::parse(&ambient_shared_types::urls::deployment_url(&deployment)).ok()
         } else {
             None
         }

--- a/shared_crates/shared_types/src/lib.rs
+++ b/shared_crates/shared_types/src/lib.rs
@@ -5,6 +5,7 @@ mod procedurals;
 pub use crate::procedurals::*;
 
 pub mod asset;
+pub mod urls;
 
 /// A mapping from enum names to Rust types. Instantiate this with a macro that takes `$(($value:ident, $type:ty)),*`.
 #[macro_export]

--- a/shared_crates/shared_types/src/urls.rs
+++ b/shared_crates/shared_types/src/urls.rs
@@ -1,0 +1,105 @@
+pub const AMBIENT_WEB_APP_URL: &str = "https://ambient-733e7.web.app";
+pub const ASSETS_URL: &str = "https://assets.ambient.run";
+pub const API_URL: &str = "https://api.ambient.run";
+
+/// The URL for a deployed package on the website.
+///
+/// What the user would visit to play this package on the website.
+pub fn web_package_url(package_id: &str, deployment_id: Option<&str>) -> String {
+    let mut output = format!("{AMBIENT_WEB_APP_URL}/packages/{package_id}");
+    if let Some(deployment_id) = deployment_id {
+        output.push_str(&format!("/deployments/{deployment_id}"));
+    }
+    output
+}
+
+/// The URL for a deployed package on the asset server.
+///
+/// What the user would use to run this package, or to get its assets.
+pub fn deployment_url(deployment_id: &str) -> String {
+    format!("{ASSETS_URL}/{deployment_id}")
+}
+
+/// The URL for a ensure-running server for a deployed package.
+///
+/// When connecting to this URL, a server will be started if one is not already running.
+pub fn ensure_running_url(deployment_id: &str) -> String {
+    format!("{API_URL}/servers/ensure-running?deployment_id={deployment_id}")
+}
+
+/// Replicated from `AmbientFbSchema::DbPackageContent`
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PackageContent {
+    Playable,
+    Example,
+    NotExample,
+    Asset,
+    Models,
+    Animations,
+    Textures,
+    Materials,
+    Fonts,
+    Code,
+    Schema,
+    Audio,
+    Other,
+    Tool,
+    Mod,
+}
+
+#[derive(Default, Copy, Clone)]
+pub struct PackageListParams<'a> {
+    /// ISO8601 date string
+    pub created_after: Option<&'a str>,
+    /// ISO8601 date string
+    pub updated_after: Option<&'a str>,
+    /// NOTE: This does not URI-encode the name (yet)
+    pub name: Option<&'a str>,
+    pub content_contains: &'a [PackageContent],
+    pub owner_id: Option<&'a str>,
+    pub for_playable: Option<&'a str>,
+}
+
+/// Endpoint to get a list of packages. Filters can be supplied as necessary.
+pub fn package_list_url(params: PackageListParams) -> String {
+    let url = format!("{API_URL}/packages/list");
+
+    let mut segments = vec![];
+    if let Some(created_after) = params.created_after {
+        segments.push(format!("created_after={}", created_after));
+    }
+
+    if let Some(updated_after) = params.updated_after {
+        segments.push(format!("updated_after={}", updated_after));
+    }
+
+    if let Some(name) = params.name {
+        segments.push(format!("name={}", name));
+    }
+
+    if !params.content_contains.is_empty() {
+        segments.push(format!(
+            "content_contains={}",
+            params
+                .content_contains
+                .iter()
+                .map(|content| format!("{:?}", content))
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+    }
+
+    if let Some(owner_id) = params.owner_id {
+        segments.push(format!("owner_id={}", owner_id));
+    }
+
+    if let Some(for_playable) = params.for_playable {
+        segments.push(format!("for_playable={}", for_playable));
+    }
+
+    if segments.is_empty() {
+        url
+    } else {
+        format!("{url}?{}", segments.join("&"))
+    }
+}


### PR DESCRIPTION
Adds URL helpers to reduce duplication and to help with moving the URLs when required.

Also fixes:
- web URL in deployment
- using the proper API request for package manager