### PR TITLE
Fix #803 child collision volumes

### DIFF
--- a/crates/physics/src/physx.rs
+++ b/crates/physics/src/physx.rs
@@ -195,6 +195,7 @@ pub fn sync_ecs_physics() -> SystemGroup {
                         let is_kinematic = world.has_component(id, kinematic());
                         let (_scale, rot, pos) = localworld.to_scale_rotation_translation();
                         if let Ok(body) = world.get(id, rigid_dynamic()) {
+                            //                            println!("child physx is dynamic {:?} ", id);
                             let pose = PxTransform::new(pos, rot);
                             if is_kinematic {
                                 body.set_kinematic_target(&pose);
@@ -204,8 +205,10 @@ pub fn sync_ecs_physics() -> SystemGroup {
                                 body.set_angular_velocity(Vec3::ZERO, true);
                             }
                         } else if let Ok(body) = world.get(id, rigid_static()) {
+                            //                            println!("child physx is static {:?} ", id);
                             body.set_global_pose(&PxTransform::new(pos, rot), true);
                         } else if let Ok(shape) = world.get_ref(id, physics_shape()) {
+                            //                            println!("child physx has a shape? {:?} ", id);
                             let actor = shape.get_actor().unwrap();
                             let pose = PxTransform::new(pos, rot);
                             if !is_kinematic {

--- a/crates/physics/src/physx.rs
+++ b/crates/physics/src/physx.rs
@@ -5,7 +5,7 @@ use ambient_core::{
     transform::{local_to_world, rotation, scale, translation},
 };
 use ambient_ecs::{
-    components, ensure_has_component, parent, query, FnSystem, QueryState, Resource, SystemGroup,
+    components, ensure_has_component, query, FnSystem, QueryState, Resource, SystemGroup,
 };
 use ambient_native_std::asset_cache::SyncAssetKey;
 use glam::{EulerRot, Quat, Vec3};
@@ -277,18 +277,9 @@ pub fn sync_ecs_physics() -> SystemGroup {
             .to_system(|q, world, qs, _| {
                 let delta_time = *world.resource(delta_time());
                 for (id, (body, pos, rot, lvel, avel)) in q.collect_cloned(world, qs) {
-                    let mut h_pos = pos;
-                    let mut h_rot = rot;
-                    let is_child = world.has_component(id, parent());
-                    if is_child {
-                        let localworld = world.get(id, local_to_world()).unwrap();
-                        h_pos = localworld.transform_point3(Vec3::ZERO);
-                        h_rot = Quat::from_mat4(&localworld);
-                        println!("updating velocities for rigit dynamic child {:?} ", id)
-                    }
                     let avel = avel * delta_time;
-                    let new_pos = h_pos + lvel * delta_time;
-                    let new_rot = h_rot * Quat::from_euler(EulerRot::XYZ, avel.x, avel.y, avel.z);
+                    let new_pos = pos + lvel * delta_time;
+                    let new_rot = rot * Quat::from_euler(EulerRot::XYZ, avel.x, avel.y, avel.z);
                     let pos_changed = vec3_changed(pos, new_pos);
                     let rot_changed = quat_changed(rot, new_rot);
                     if pos_changed {

--- a/crates/physics/src/physx.rs
+++ b/crates/physics/src/physx.rs
@@ -153,8 +153,6 @@ pub fn sync_ecs_physics() -> SystemGroup {
                     for (id, &localworld) in q.iter(world, Some(&mut *qs)) {
                         let is_kinematic = world.has_component(id, kinematic());
                         let (_scale, rot, pos) = localworld.to_scale_rotation_translation();
-                        // let pos = localworld.transform_point3(Vec3::ZERO);
-                        // let rot = Quat::from_mat4(&localworld);
                         if let Ok(body) = world.get(id, rigid_dynamic()) {
                             let pose = PxTransform::new(pos, rot);
                             if is_kinematic {

--- a/crates/physics/src/physx.rs
+++ b/crates/physics/src/physx.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use ambient_core::{
     delta_time,
-    transform::{local_to_world, rotation, scale, translation},
+    transform::{local_to_parent, local_to_world, rotation, scale, translation},
 };
 use ambient_ecs::{
     components, ensure_has_component, query, FnSystem, QueryState, Resource, SystemGroup,
@@ -103,8 +103,10 @@ pub fn sync_ecs_physics() -> SystemGroup {
     // Though they have rotation and translation those values may not update
     // the parents will and local_to_world.changed() will need to be updated
     let hiearchy_transform_qs = Arc::new(Mutex::new(QueryState::new()));
-    let hiearchy_transform_q = query(local_to_world().changed()).incl(physics_shape());
-    let hiearchy_transform_q2 = translation_rotation_q.query.clone();
+    let hiearchy_transform_q = query(local_to_world().changed())
+        .incl(physics_shape())
+        .incl(local_to_parent());
+    let hiearchy_transform_q2 = hiearchy_transform_q.query.clone();
 
     let translation_character_qs = Arc::new(Mutex::new(QueryState::new()));
     let translation_character_q =


### PR DESCRIPTION
This PR addresses #803

This PR adds a new query to the physx system to update entities that have `physics_shape` components and their `local_to_world` changes. This covers the case where an entity is the child of a hierarchy and has a physics collider attached. The child entities may not change its `translation` or `rotation` components but its parents will and the child needs to update its collider state accordingly.

Heres an example gif with a `visualize_collider` component. The collider is generate from the asset pipeline and the ship model is a child of a parent entity that handles all the movement and rotation.
![collider](https://github.com/AmbientRun/Ambient/assets/126209/403efd24-2b19-40ee-9214-ffe10ada011c)

I need feedback and guidance on this. I basically copied this from the `query((translation().changed(), rotation().changed())).incl(physics_shape());` query implementation. Let me know any thoughts on how to improve.



