### PR TITLE
fix(campfire): build on linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,4 +19,5 @@ rustflags = ["--cfg=web_sys_unstable_apis"]
 [alias]
 cf = "run --package campfire --"
 campfire = "run --package campfire --"
+campfire-ssl = "run --package campfire --features openssl --"
 campfire-slim = "run --package campfire --no-default-features --"


### PR DESCRIPTION
It was after I did this that I realised Chrome stable on Linux doesn't support WebGPU, which meant this wasn't of much use anyway (without switching to canary + adding some flags). Oh well.