### PR TITLE
feat(campfire): replace OpenSSL with Rust deps

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,5 +19,4 @@ rustflags = ["--cfg=web_sys_unstable_apis"]
 [alias]
 cf = "run --package campfire --"
 campfire = "run --package campfire --"
-campfire-ssl = "run --package campfire --features openssl --"
 campfire-slim = "run --package campfire --no-default-features --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bcder"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf16bec990f8ea25cab661199904ef452fcf11f565c404ce6cffbdf3f8cbbc47"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2195,7 @@ dependencies = [
  "anyhow",
  "cargo_toml",
  "clap 4.4.2",
+ "data-encoding",
  "dunce",
  "flume 0.11.0",
  "futures",
@@ -2190,16 +2207,18 @@ dependencies = [
  "nix 0.26.4",
  "notify",
  "num_cpus",
- "openssl",
  "rustdoc-json",
  "rustdoc-types",
  "serde",
  "serde_json",
+ "sha2",
  "simplelog",
+ "spki",
  "tokio",
  "toml 0.7.8",
  "toml_edit",
  "which",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -2604,6 +2623,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,6 +2733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2954,6 +2988,16 @@ checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
  "uuid",
+]
+
+[[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -5797,15 +5841,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "300.1.3+3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5813,7 +5848,6 @@ checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5919,6 +5953,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64 0.21.4",
+ "serde",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -7185,6 +7229,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
+name = "sha2"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7216,6 +7271,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 
 [[package]]
 name = "simba"
@@ -7368,6 +7429,16 @@ checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
 dependencies = [
  "bitflags 1.3.2",
  "num-traits",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -9950,6 +10021,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-certificate"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5d27c90840e84503cf44364de338794d5d5680bdd1da6272d13f80b0769ee0"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem",
+ "ring",
+ "signature",
+ "spki",
+ "thiserror",
+]
+
+[[package]]
 name = "xattr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9993,6 +10082,12 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zune-inflate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ tonic = { version = "0.9", features = ["gzip", "tls", "tls-roots"] }
 md-5 = "0.10"
 pollster = "0.3.0"
 rpassword = "7.2"
+sha2 = "0.10"
 
 cfg-if = "1.0"
 

--- a/campfire/Cargo.toml
+++ b/campfire/Cargo.toml
@@ -13,6 +13,8 @@ serde_json = { workspace = true }
 toml_edit = { workspace = true }
 itertools = { workspace = true }
 toml = { workspace = true }
+sha2 = { workspace = true }
+data-encoding = { workspace = true }
 
 which = "4.4"
 rustdoc-json = "0.8.0"
@@ -25,18 +27,17 @@ tokio = { version = "1.0", features = ["fs", "rt", "process", "time"] }
 futures = "0.3"
 num_cpus = "1.15.0"
 home = "0.5"
+x509-certificate = "0.21.0"
+spki = "0.7"
+
 notify = { version = "6.0", optional = true }
 flume = { version = "0.11", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
-openssl = { version = "0.10", features = ["vendored"], optional = true }
 dunce = "1.0"
 
 [target.'cfg(target_os="linux")'.dependencies]
 nix = "0.26"
-
-[target.'cfg(not(target_os="windows"))'.dependencies]
-openssl = { version = "0.10", optional = true }
 
 [features]
 default = ["serve"]

--- a/campfire/src/web/mod.rs
+++ b/campfire/src/web/mod.rs
@@ -2,7 +2,6 @@ use clap::Subcommand;
 
 use self::build::BuildOptions;
 
-#[cfg(feature = "openssl")]
 mod browser;
 mod build;
 #[cfg(feature = "serve")]
@@ -27,16 +26,7 @@ pub async fn run(command: Web) -> anyhow::Result<()> {
             Ok(())
         }
         Web::Check(args) => args.check().await,
-        Web::OpenBrowser => {
-            #[cfg(feature = "openssl")]
-            {
-                browser::open().await
-            }
-            #[cfg(not(feature = "openssl"))]
-            {
-                anyhow::bail!("The `openssl` feature must be enabled to use this command")
-            }
-        }
+        Web::OpenBrowser => browser::open().await,
         #[cfg(feature = "serve")]
         Web::Serve(args) => args.run().await,
     }

--- a/recipes.json
+++ b/recipes.json
@@ -244,7 +244,7 @@
     }
   },
   "open-browser": {
-    "cmd": "cargo run -p campfire --features openssl -- web open-browser"
+    "cmd": "cargo cf web open-browser"
   },
   "build web": {
     "cmd": "cargo cf web build"

--- a/web/README.md
+++ b/web/README.md
@@ -27,10 +27,10 @@ Whenever a file changes the client will automatically rebuild and the changes wi
 
 **Note**: Skip this section if you are connecting to a hosted Package.
 
-If using self-signed certificates, you need to toll Chrome to trust it.
+If using self-signed certificates, you need to tell Chrome to trust it.
 
 ```sh
-cargo run -p campfire --features openssl -- web open-browser
+cargo cf web open-browser
 ```
 
 **Note**: If you are on mac **make sure you close any existing Chrome instances using `Quit`**


### PR DESCRIPTION
Really didn't want to go through the hassle of getting OpenSSL to work on Windows, so I just replaced the logic with Rust equivalents. My Chrome starts up and connects to my 127.0.0.1 server OK. Need to test on the other platforms.