### PR TITLE
Update Ambient version in manifests

### DIFF
--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -74,7 +74,9 @@ jobs:
           # switch back to the main branch version
           version_majminpat=$(echo ${tag} | sed -E -e 's/^v([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
           version=${version_majminpat}-dev
-          cargo cf release update-version ${version}
+          # We do not update the Ambient versions of the packages to ensure that the nightly that they were deployed with
+          # remains active + accurate
+          cargo cf release update-version ${version} --no-package-ambient-version-update
           git commit -a -m "Revert version back to ${version}"
 
           git push --set-upstream origin ${branch}

--- a/campfire/src/install.rs
+++ b/campfire/src/install.rs
@@ -64,6 +64,7 @@ fn install_version(suffix: &str, args: &[&str]) -> anyhow::Result<()> {
 }
 
 #[allow(unused_mut)]
+#[allow(clippy::let_and_return)]
 fn ambient_executable_name(suffix: &str) -> String {
     let mut name = if suffix.is_empty() {
         "ambient".to_string()

--- a/campfire/src/package.rs
+++ b/campfire/src/package.rs
@@ -101,10 +101,10 @@ pub fn serve(args: &Run) -> anyhow::Result<()> {
 }
 
 fn find_package(package: &String) -> anyhow::Result<PathBuf> {
-    Ok(get_all_packages(true, true, false)?
+    get_all_packages(true, true, false)?
         .into_iter()
         .find(|p| p.ends_with(package))
-        .ok_or_else(|| anyhow::anyhow!("no example found with name {}", package))?)
+        .ok_or_else(|| anyhow::anyhow!("no example found with name {}", package))
 }
 
 fn list() -> anyhow::Result<()> {

--- a/campfire/src/release.rs
+++ b/campfire/src/release.rs
@@ -150,7 +150,7 @@ fn update_version(
     // This must be done first, before we mutate anything, to ensure that it's in a consistent state
     let all_publishable_crates = get_all_publishable_crates()?;
 
-    if !dbg!(no_package_ambient_version_update) {
+    if !no_package_ambient_version_update {
         fn add_ambient_version(toml: &mut toml_edit::Document, new_version: &str) {
             toml["package"]["ambient_version"] = toml_edit::value(new_version);
         }

--- a/campfire/src/web/browser.rs
+++ b/campfire/src/web/browser.rs
@@ -9,7 +9,7 @@ pub async fn open() -> anyhow::Result<()> {
         .await
         .context("Failed to read certificate file")?;
 
-    let der = X509Certificate::from_der(&cert_file).context("Failed to deserialize certificate")?;
+    let der = X509Certificate::from_der(cert_file).context("Failed to deserialize certificate")?;
 
     let pubkey = der.to_public_key_der().expect("Failed to get public key");
 

--- a/guest/rust/examples/assets/basic_model/ambient.toml
+++ b/guest/rust/examples/assets/basic_model/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/basic_model"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 orbit_camera = { path = "../../../packages/std/orbit_camera" , deployment = "5FW32mbhXcqn3Mtp2DsUvU" }

--- a/guest/rust/examples/assets/generate_pipeline/ambient.toml
+++ b/guest/rust/examples/assets/generate_pipeline/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/basic_model"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 orbit_camera = { path = "../../../packages/std/orbit_camera" , deployment = "5FW32mbhXcqn3Mtp2DsUvU" }

--- a/guest/rust/examples/assets/material_overriding/ambient.toml
+++ b/guest/rust/examples/assets/material_overriding/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/material_overriding"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.is_the_best]
 type = "Bool"

--- a/guest/rust/examples/assets/unity/ambient.toml
+++ b/guest/rust/examples/assets/unity/ambient.toml
@@ -4,3 +4,4 @@ name = "Unity"
 description = "Load and spawn a Unity prefab"
 version = "0.0.1"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/basics/input/ambient.toml
+++ b/guest/rust/examples/basics/input/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/input"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/basics/multiplayer/ambient.toml
+++ b/guest/rust/examples/basics/multiplayer/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/multiplayer"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/basics/primitives/ambient.toml
+++ b/guest/rust/examples/basics/primitives/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/primitives"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 orbit_camera = { path = "../../../packages/std/orbit_camera" , deployment = "5FW32mbhXcqn3Mtp2DsUvU" }

--- a/guest/rust/examples/basics/skinmesh/ambient.toml
+++ b/guest/rust/examples/basics/skinmesh/ambient.toml
@@ -5,6 +5,7 @@ description = "Render a character model, with animations."
 version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/skinmesh"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [messages]
 SetController = { name = "Set controller", description = "Sets the animation controller.", fields = { value = "U32" } }

--- a/guest/rust/examples/controllers/first_person_camera/ambient.toml
+++ b/guest/rust/examples/controllers/first_person_camera/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/first_person_camera"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 
 [dependencies]

--- a/guest/rust/examples/controllers/third_person_camera/ambient.toml
+++ b/guest/rust/examples/controllers/third_person_camera/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/third_person_camera"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 base_assets = { path = "../../../packages/std/base_assets", deployment = "2TUw8gb8vEm19jklIUKnyO" }

--- a/guest/rust/examples/intermediate/async/ambient.toml
+++ b/guest/rust/examples/intermediate/async/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/async"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/intermediate/clientside/ambient.toml
+++ b/guest/rust/examples/intermediate/clientside/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/clientside"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 grid_side_length = { name = "Grid Side Length", description = "The length of a grid side, ignoring the centre (i.e. if this is 10, the total axis length is 21)", type = "I32", attributes = [

--- a/guest/rust/examples/intermediate/dependencies/ambient.toml
+++ b/guest/rust/examples/intermediate/dependencies/ambient.toml
@@ -4,6 +4,7 @@ name = "Dependencies"
 description = "Break your project up into packages."
 version = "0.0.1"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 deps_assets = { path = "deps/assets" , deployment = "1esTfW4Soql4RpisyV0VNJ" }

--- a/guest/rust/examples/intermediate/messaging/ambient.toml
+++ b/guest/rust/examples/intermediate/messaging/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/messaging"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [messages.Hello]
 name = "Hello"

--- a/guest/rust/examples/intermediate/screen_ray/ambient.toml
+++ b/guest/rust/examples/intermediate/screen_ray/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/screen_ray"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [messages.Input.fields]
 ray_origin = "Vec3"

--- a/guest/rust/examples/physics/basics/ambient.toml
+++ b/guest/rust/examples/physics/basics/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/physics/basics"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [messages.Bonk]
 description = "Collision between two objects."

--- a/guest/rust/examples/rendering/decals/ambient.toml
+++ b/guest/rust/examples/rendering/decals/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/decals"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 orbit_camera = { path = "../../../packages/std/orbit_camera" , deployment = "5FW32mbhXcqn3Mtp2DsUvU" }

--- a/guest/rust/examples/rendering/fog/ambient.toml
+++ b/guest/rust/examples/rendering/fog/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/fog"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 orbit_camera = { path = "../../../packages/std/orbit_camera" , deployment = "5FW32mbhXcqn3Mtp2DsUvU" }

--- a/guest/rust/examples/rendering/image/ambient.toml
+++ b/guest/rust/examples/rendering/image/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/image"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/rendering/instancing/ambient.toml
+++ b/guest/rust/examples/rendering/instancing/ambient.toml
@@ -4,6 +4,7 @@ name = "Instancing"
 description = "Render lots of objects with a single draw call."
 version = "0.0.1"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 instance_index = { type = "Uvec3", name = "Instance Index" }

--- a/guest/rust/examples/rendering/procedural_generation/ambient.toml
+++ b/guest/rust/examples/rendering/procedural_generation/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/procedural_generation"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 rotating_sun = { type = "Bool", name = "Rotating sun", description = "Whether or not rotate the sun automatically" }

--- a/guest/rust/examples/rendering/raw_text/ambient.toml
+++ b/guest/rust/examples/rendering/raw_text/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/raw_text"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/rendering/samplers/ambient.toml
+++ b/guest/rust/examples/rendering/samplers/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/samplers"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 orbit_camera = { path = "../../../packages/std/orbit_camera" , deployment = "5FW32mbhXcqn3Mtp2DsUvU" }

--- a/guest/rust/examples/rendering/sun/ambient.toml
+++ b/guest/rust/examples/rendering/sun/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/sun"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 orbit_camera = { path = "../../../packages/std/orbit_camera" , deployment = "5FW32mbhXcqn3Mtp2DsUvU" }

--- a/guest/rust/examples/rendering/transparency/ambient.toml
+++ b/guest/rust/examples/rendering/transparency/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/basics/transparency"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 orbit_camera = { path = "../../../packages/std/orbit_camera" , deployment = "5FW32mbhXcqn3Mtp2DsUvU" }

--- a/guest/rust/examples/ui/audio_ctrl/ambient.toml
+++ b/guest/rust/examples/ui/audio_ctrl/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/audio_ctrl"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/auto_editor/ambient.toml
+++ b/guest/rust/examples/ui/auto_editor/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/auto_editor"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/button/ambient.toml
+++ b/guest/rust/examples/ui/button/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/button"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/clock/ambient.toml
+++ b/guest/rust/examples/ui/clock/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/clock"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/counter/ambient.toml
+++ b/guest/rust/examples/ui/counter/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/counter"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/dock_layout/ambient.toml
+++ b/guest/rust/examples/ui/dock_layout/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/dock_layout"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/editors/ambient.toml
+++ b/guest/rust/examples/ui/editors/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/editors"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/flow_layout/ambient.toml
+++ b/guest/rust/examples/ui/flow_layout/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/flow_layout"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/image/ambient.toml
+++ b/guest/rust/examples/ui/image/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/image"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/rect/ambient.toml
+++ b/guest/rust/examples/ui/rect/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/rect"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/screens/ambient.toml
+++ b/guest/rust/examples/ui/screens/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/screens"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/scroll/ambient.toml
+++ b/guest/rust/examples/ui/scroll/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/scroll"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/slider/ambient.toml
+++ b/guest/rust/examples/ui/slider/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/slider"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/text/ambient.toml
+++ b/guest/rust/examples/ui/text/ambient.toml
@@ -6,3 +6,4 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/text"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/examples/ui/todo/ambient.toml
+++ b/guest/rust/examples/ui/todo/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/examples/ui/todo"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [messages.NewItem]
 description = "Add a new todo item"

--- a/guest/rust/packages/assets/kenney_digital_audio/ambient.toml
+++ b/guest/rust/packages/assets/kenney_digital_audio/ambient.toml
@@ -5,3 +5,4 @@ authors = ["Kenney"]
 description = "https://www.kenney.nl/assets/digital-audio for Ambient. (Uploaded by Ambient, not Kenney.)"
 version = "0.0.1"
 content = { type = "Asset", audio = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/packages/assets/kenney_impact_sounds/ambient.toml
+++ b/guest/rust/packages/assets/kenney_impact_sounds/ambient.toml
@@ -5,3 +5,4 @@ authors = ["Kenney"]
 description = "https://www.kenney.nl/assets/impact-sounds for Ambient. (Uploaded by Ambient, not Kenney.)"
 version = "0.0.1"
 content = { type = "Asset", audio = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/packages/assets/kenney_space_kit/ambient.toml
+++ b/guest/rust/packages/assets/kenney_space_kit/ambient.toml
@@ -5,3 +5,4 @@ authors = ["Kenney"]
 description = "https://www.kenney.nl/assets/space-kit for Ambient. (Uploaded by Ambient, not Kenney.)"
 version = "0.0.1"
 content = { type = "Asset", models = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/packages/games/afps/ambient.toml
+++ b/guest/rust/packages/games/afps/ambient.toml
@@ -3,6 +3,7 @@ id = "afps"
 name = "afps"
 version = "0.0.1"
 content = { type = "Playable" }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 character_animation = { path = "../../std/character_animation", deployment = "6HS1Mf3o535O4retxpytgH" }

--- a/guest/rust/packages/games/afps/mods/scene/ambient.toml
+++ b/guest/rust/packages/games/afps/mods/scene/ambient.toml
@@ -3,6 +3,7 @@ id = "afps_scene"
 name = "AFPS Scene"
 version = "0.0.1"
 content = { type = "Asset", models = true, code = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 afps_schema = { path = "../../schema", deployment = "2eD1KcHctO5dBLheldSqbA" }

--- a/guest/rust/packages/games/afps/mods/spraypaint/ambient.toml
+++ b/guest/rust/packages/games/afps/mods/spraypaint/ambient.toml
@@ -3,6 +3,7 @@ id = "afps_spraypaint"
 name = "AFPS Spraypaint"
 version = "0.0.1"
 content = { type = "Asset", models = true, textures = true, code = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 claymore = { type = "EntityId" }

--- a/guest/rust/packages/games/afps/mods/world_latency/ambient.toml
+++ b/guest/rust/packages/games/afps/mods/world_latency/ambient.toml
@@ -4,6 +4,7 @@ name = "AFPS World Latency"
 description = "World latency is a simple utility that displays the relative latency # of world streamed from the server as seen by all players in the world."
 version = "0.0.1"
 content = { type = "Tool" }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 server_frame = { type = "U64", description = "Current server frame number", attributes = [

--- a/guest/rust/packages/games/afps/mods/zombie/ambient.toml
+++ b/guest/rust/packages/games/afps/mods/zombie/ambient.toml
@@ -3,6 +3,7 @@ id = "afps_zombie"
 name = "AFPS Zombie"
 version = "0.0.1"
 content = { type = "Asset", models = true, animations = true, code = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 is_zombie = { type = "Empty", attributes = ["Networked", "Debuggable"] }

--- a/guest/rust/packages/games/arkanoid/ambient.toml
+++ b/guest/rust/packages/games/arkanoid/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/packages/games/arkanoid"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 player_movement_direction = { type = "F32", name = "Player Movement Direction", description = "Direction of player movement" }

--- a/guest/rust/packages/games/minigolf/ambient.toml
+++ b/guest/rust/packages/games/minigolf/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/packages/games/minigolf"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 hide_cursor = { path = "../../std/hide_cursor", deployment = "A8CV3CgLgnnNNSsr2m9kL" }

--- a/guest/rust/packages/games/music_sequencer/ambient.toml
+++ b/guest/rust/packages/games/music_sequencer/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/packages/games/music_sequencer"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [messages.Click]
 description = "Select or deselect a note."

--- a/guest/rust/packages/games/pong/ambient.toml
+++ b/guest/rust/packages/games/pong/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/packages/games/pong"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 player_movement_direction = { type = "F32", name = "Player Movement Direction", description = "Direction of player movement" }

--- a/guest/rust/packages/games/tangent/ambient.toml
+++ b/guest/rust/packages/games/tangent/ambient.toml
@@ -3,6 +3,7 @@ id = "tangent"
 name = "Tangent"
 version = "0.1.0"
 content = { type = "Playable" }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_core = { path = "core", deployment = "7P1TaRdM8ZLcZtEayeRATd" }

--- a/guest/rust/packages/games/tangent/mods/camera_follow/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/camera_follow/ambient.toml
@@ -3,6 +3,7 @@ id = "tangent_camera_follow"
 name = "Tangent Camera: Follow"
 version = "0.1.0"
 content = { type = "Mod", for_playables = ["tangent"] }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_schema = { path = "../../schema", deployment = "1MdfsKM0PneOuY19MlhaOw" }

--- a/guest/rust/packages/games/tangent/mods/camera_topdown/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/camera_topdown/ambient.toml
@@ -3,6 +3,7 @@ id = "tangent_camera_topdown"
 name = "Tangent Camera: Top-down"
 version = "0.1.0"
 content = { type = "Mod", for_playables = ["tangent"] }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_schema = { path = "../../schema", deployment = "1MdfsKM0PneOuY19MlhaOw" }

--- a/guest/rust/packages/games/tangent/mods/class_assault/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/class_assault/ambient.toml
@@ -3,6 +3,7 @@ id = "ob731abrl0d51ihp3zgx1e8qtdiv7f12"
 name = "Tangent Class: Assault"
 version = "0.1.0"
 content = { type = "Mod", for_playables = ["tangent"] }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_schema = { path = "../../schema", deployment = "1MdfsKM0PneOuY19MlhaOw" }

--- a/guest/rust/packages/games/tangent/mods/class_scout/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/class_scout/ambient.toml
@@ -3,6 +3,7 @@ id = "haq3c8ra5r7u3mhaynqqdvtcmgb6l54p"
 name = "Tangent Class: Scout"
 version = "0.1.0"
 content = { type = "Mod", for_playables = ["tangent"] }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_schema = { path = "../../schema", deployment = "1MdfsKM0PneOuY19MlhaOw" }

--- a/guest/rust/packages/games/tangent/mods/class_tank/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/class_tank/ambient.toml
@@ -3,6 +3,7 @@ id = "o0j4qyxwhcf9vukzslsvhrkj2sv5mf4x"
 name = "Tangent Class: Tank"
 version = "0.1.0"
 content = { type = "Mod", for_playables = ["tangent"] }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_schema = { path = "../../schema", deployment = "1MdfsKM0PneOuY19MlhaOw" }

--- a/guest/rust/packages/games/tangent/mods/gun_laser/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/gun_laser/ambient.toml
@@ -3,6 +3,7 @@ id = "uojjsmn9xs1pj3xzz16rprjot0kk3p2o"
 name = "Tangent Gun: Laser"
 version = "0.1.0"
 content = { type = "Mod", for_playables = ["tangent"] }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_schema = { path = "../../schema", deployment = "1MdfsKM0PneOuY19MlhaOw" }

--- a/guest/rust/packages/games/tangent/mods/level_cubicide/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/level_cubicide/ambient.toml
@@ -3,6 +3,7 @@ id = "tangent_level_cubicide"
 name = "Tangent Level: Cubicide"
 version = "0.1.0"
 content = { type = "Mod", for_playables = ["tangent"] }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_schema = { path = "../../schema", deployment = "1MdfsKM0PneOuY19MlhaOw" }

--- a/guest/rust/packages/games/tangent/mods/pickup_health/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/pickup_health/ambient.toml
@@ -3,6 +3,7 @@ id = "tangent_pickup_health"
 name = "Tangent Pickup: Health"
 version = "0.1.0"
 content = { type = "Mod", for_playables = ["tangent"] }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_schema = { path = "../../schema", deployment = "1MdfsKM0PneOuY19MlhaOw" }

--- a/guest/rust/packages/games/tangent/mods/ui_class_selection/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/ui_class_selection/ambient.toml
@@ -3,6 +3,7 @@ id = "tangent_ui_class_selection"
 name = "Tangent UI: Class Selection"
 version = "0.1.0"
 content = { type = "Mod", for_playables = ["tangent"] }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_schema = { path = "../../schema", deployment = "1MdfsKM0PneOuY19MlhaOw" }

--- a/guest/rust/packages/games/tangent/mods/ui_holohud/ambient.toml
+++ b/guest/rust/packages/games/tangent/mods/ui_holohud/ambient.toml
@@ -3,6 +3,7 @@ id = "tangent_ui_holohud"
 name = "Tangent HUD: Hologram"
 version = "0.1.0"
 content = { type = "Mod", for_playables = ["tangent"] }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 tangent_schema = { path = "../../schema", deployment = "1MdfsKM0PneOuY19MlhaOw" }

--- a/guest/rust/packages/games/tictactoe/ambient.toml
+++ b/guest/rust/packages/games/tictactoe/ambient.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/packages/games/tictactoe"
 type = "Game"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 cells = { type = { type = "Vec", element_type = "EntityId" }, name = "Cells", description = "The cells in the game", attributes = [

--- a/guest/rust/packages/schemas/editor/ambient.toml
+++ b/guest/rust/packages/schemas/editor/ambient.toml
@@ -4,6 +4,7 @@ name = "Editor Schema"
 version = "0.0.1"
 description = "Schema for the editor."
 content = { type = "Asset", schema = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 # Player components

--- a/guest/rust/packages/schemas/unit/ambient.toml
+++ b/guest/rust/packages/schemas/unit/ambient.toml
@@ -4,6 +4,7 @@ name = "Unit"
 description = "Schema for units in games"
 version = "0.0.1"
 content = { type = "Asset", schema = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 run_direction = { type = "Vec2", attributes = ["Debuggable", "Networked"] }

--- a/guest/rust/packages/std/base_assets/ambient.toml
+++ b/guest/rust/packages/std/base_assets/ambient.toml
@@ -3,3 +3,4 @@ id = "base_assets"
 name = "base_assets"
 version = "0.0.1"
 content = { type = "Asset", models = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/packages/std/character_animation/ambient.toml
+++ b/guest/rust/packages/std/character_animation/ambient.toml
@@ -3,6 +3,7 @@ id = "character_animation"
 name = "Character animation"
 version = "0.0.1"
 content = { type = "Asset", animations = true, code = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 unit_schema = { path = "../../schemas/unit", deployment = "5KKf99BrahlrYHLEMMj6OU" }

--- a/guest/rust/packages/std/character_movement/ambient.toml
+++ b/guest/rust/packages/std/character_movement/ambient.toml
@@ -3,6 +3,7 @@ id = "character_movement"
 name = "character_movement"
 version = "0.0.1"
 content = { type = "Asset", code = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 unit_schema = { path = "../../schemas/unit", deployment = "5KKf99BrahlrYHLEMMj6OU" }

--- a/guest/rust/packages/std/fps_controller/ambient.toml
+++ b/guest/rust/packages/std/fps_controller/ambient.toml
@@ -3,6 +3,7 @@ id = "fps_controller"
 name = "fps_controller"
 version = "0.0.1"
 content = { type = "Asset", code = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 unit_schema = { path = "../../schemas/unit", deployment = "5KKf99BrahlrYHLEMMj6OU" }

--- a/guest/rust/packages/std/hide_cursor/ambient.toml
+++ b/guest/rust/packages/std/hide_cursor/ambient.toml
@@ -3,3 +3,4 @@ id = "hide_cursor"
 name = "hide_cursor"
 version = "0.0.1"
 content = { type = "Asset", code = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/guest/rust/packages/std/orbit_camera/ambient.toml
+++ b/guest/rust/packages/std/orbit_camera/ambient.toml
@@ -4,6 +4,7 @@ name = "Orbit Camera"
 description = "Implements a clientside-only orbit camera."
 version = "0.0.1"
 content = { type = "Asset", code = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components]
 is_orbit_camera = { type = "Empty", attributes = ["Debuggable", "Networked"] }

--- a/guest/rust/packages/tools/console/ambient.toml
+++ b/guest/rust/packages/tools/console/ambient.toml
@@ -3,6 +3,7 @@ id = "console"
 name = "Console"
 version = "0.0.1"
 content = { type = "Tool" }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [messages.ConsoleServerInput.fields]
 input = "String"

--- a/guest/rust/packages/tools/editor/ambient.toml
+++ b/guest/rust/packages/tools/editor/ambient.toml
@@ -3,6 +3,7 @@ id = "editor"
 name = "Editor"
 version = "0.0.1"
 content = { type = "Tool" }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [dependencies]
 editor_schema = { path = "../../schemas/editor" , deployment = "2VGI9Ugc9qr1n4HGsdSerK" }

--- a/guest/rust/packages/tools/package_manager/ambient.toml
+++ b/guest/rust/packages/tools/package_manager/ambient.toml
@@ -3,6 +3,7 @@ id = "package_manager"
 name = "Package Manager"
 version = "0.0.1"
 content = { type = "Tool" }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.mod_manager_for]
 name = "Mod Manager For"

--- a/guest/rust/testcases/588-prefab-despawn-panic/ambient.toml
+++ b/guest/rust/testcases/588-prefab-despawn-panic/ambient.toml
@@ -5,3 +5,4 @@ version = "0.0.1"
 description = "Reproduces https://github.com/AmbientRun/Ambient/issues/588"
 repository = "https://github.com/AmbientRun/Ambient/tree/main/guest/rust/testcases/588-prefab-despawn-panic"
 content = { type = "Playable", example = true }
+ambient_version = "0.3.0-nightly-2023-09-20"

--- a/schema/ambient.toml
+++ b/schema/ambient.toml
@@ -2,8 +2,9 @@
 id = "ambient_core"
 description = "Contains all core components for the Ambient runtime."
 name = "Core Components"
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
 content = { type = "Asset", schema = true }
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [includes]
 animation = "schema/animation.toml"

--- a/schema/schema/animation.toml
+++ b/schema/schema/animation.toml
@@ -3,7 +3,8 @@ id = "animation"
 name = "Animation"
 description = "Components relating to animations."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.is_animation_player]
 type = "Empty"

--- a/schema/schema/app_.toml
+++ b/schema/schema/app_.toml
@@ -3,7 +3,8 @@ id = "app"
 name = "App"
 description = "High-level state relevant to the application (including the in-development Editor)."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.cursor_position]
 type = "Vec2"

--- a/schema/schema/audio.toml
+++ b/schema/schema/audio.toml
@@ -3,7 +3,8 @@ id = "audio"
 name = "Audio"
 description = "Audio functionality and state."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.is_audio_player]
 type = "Empty"

--- a/schema/schema/camera.toml
+++ b/schema/schema/camera.toml
@@ -3,7 +3,8 @@ id = "camera"
 name = "Camera"
 description = "Camera matrices, types, parameters, and more."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.active_camera]
 type = "F32"

--- a/schema/schema/ecs.toml
+++ b/schema/schema/ecs.toml
@@ -3,7 +3,8 @@ id = "ecs"
 name = "Entity Component System"
 description = "Core components for the ECS and entities."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.dont_despawn_on_unload]
 type = "Empty"

--- a/schema/schema/hierarchy.toml
+++ b/schema/schema/hierarchy.toml
@@ -3,7 +3,8 @@ id = "hierarchy"
 name = "Hierarchy"
 description = "Parent/child relationships."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.parent]
 type = "EntityId"

--- a/schema/schema/input.toml
+++ b/schema/schema/input.toml
@@ -3,7 +3,8 @@ id = "input"
 name = "Input"
 description = "Mouse, keyboard and controller input."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.mouse_over_entity]
 type = "EntityId"

--- a/schema/schema/layout.toml
+++ b/schema/schema/layout.toml
@@ -3,7 +3,8 @@ id = "layout"
 name = "Layout"
 description = "Layout components such as flow, margins etc."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.align_horizontal]
 type = "Align"

--- a/schema/schema/model.toml
+++ b/schema/schema/model.toml
@@ -3,7 +3,8 @@ id = "model"
 name = "Model"
 description = "Information about models attached to entities."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.model_animatable]
 type = "Bool"

--- a/schema/schema/network.toml
+++ b/schema/schema/network.toml
@@ -3,7 +3,8 @@ id = "network"
 name = "Network"
 description = "Network-related state."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.is_remote_entity]
 type = "Empty"

--- a/schema/schema/package.toml
+++ b/schema/schema/package.toml
@@ -3,7 +3,8 @@ id = "package"
 name = "Package"
 description = "Package-related state and functionality."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [enums.PackageContent]
 description = "The content type of the package."

--- a/schema/schema/physics.toml
+++ b/schema/schema/physics.toml
@@ -3,7 +3,8 @@ id = "physics"
 name = "Physics"
 description = "Physics functionality and state."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.angular_velocity]
 type = "Vec3"

--- a/schema/schema/player.toml
+++ b/schema/schema/player.toml
@@ -3,7 +3,8 @@ id = "player"
 name = "Player"
 description = "Components that are attached to player entities."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.local_user_id]
 type = "String"

--- a/schema/schema/prefab.toml
+++ b/schema/schema/prefab.toml
@@ -3,7 +3,8 @@ id = "prefab"
 name = "Prefab"
 description = "Prefab-related state, including loading of prefabs."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.prefab_from_url]
 type = "String"

--- a/schema/schema/primitives.toml
+++ b/schema/schema/primitives.toml
@@ -3,7 +3,8 @@ id = "primitives"
 name = "Primitives"
 description = "Components that create primitive (in the geometric sense) objects from their attached entities."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.cube]
 type = "Empty"

--- a/schema/schema/procedurals.toml
+++ b/schema/schema/procedurals.toml
@@ -3,7 +3,8 @@ id = "procedurals"
 name = "Procedurals"
 description = "Procedural asset functionality and related."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.procedural_mesh]
 type = "ProceduralMeshHandle"

--- a/schema/schema/rect.toml
+++ b/schema/schema/rect.toml
@@ -3,7 +3,8 @@ id = "rect"
 name = "Rect"
 description = "Rounded corners rectangle rendering components, with an optional border."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.background_color]
 type = "Vec4"

--- a/schema/schema/rendering.toml
+++ b/schema/schema/rendering.toml
@@ -3,7 +3,8 @@ id = "rendering"
 name = "Rendering"
 description = "Rendering-related state, including global rendering parameters and per-entity state."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.cast_shadows]
 type = "Empty"

--- a/schema/schema/text.toml
+++ b/schema/schema/text.toml
@@ -3,7 +3,8 @@ id = "text"
 name = "Text"
 description = "Text rendering."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.font_family]
 type = "String"

--- a/schema/schema/transform.toml
+++ b/schema/schema/transform.toml
@@ -3,7 +3,8 @@ id = "transform"
 name = "Transform"
 description = "Entity transform state (including translation, rotation and scale), as well as other transformations for this entity."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.cylindrical_billboard_z]
 type = "Empty"

--- a/schema/schema/ui.toml
+++ b/schema/schema/ui.toml
@@ -3,7 +3,8 @@ id = "ui"
 name = "UI"
 description = "User interface components"
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.focus]
 type = "String"

--- a/schema/schema/wasm.toml
+++ b/schema/schema/wasm.toml
@@ -3,7 +3,8 @@ id = "wasm"
 name = "WASM"
 description = "State related to WASM functionality."
 content = { type = "Asset", schema = true }
-version = "0.3.0-dev"
+version = "0.3.0-nightly-2023-09-20"
+ambient_version = "0.3.0-nightly-2023-09-20"
 
 [components.is_module]
 name = "Is module"


### PR DESCRIPTION
Closes #887.

This makes Campfire update each manifest with the specified `ambient_version`, and adds a flag `--update-package-ambient-versions-only` that _only_ does this update so that it can be used as part of `deploy-packages` to update all of the ambient_versions of the packages after the initial reversion.

@pierd I could use your help with `deploy-packages.yml` - I was thinking that I'd insert a call to update-version --update-package-ambient-versions-only between these two:

```sh
cargo cf release update-version ${version}
git commit -a -m "Revert version back to ${version}"
```

so that it would look like


```sh
cargo cf release update-version ${version}
cargo cf release update-version ${deployed_version} --update-package-ambient-versions-only
git commit -a -m "Revert version back to ${version}"
```

but it occurs to me that there isn't necessarily an easy way to get the deployed version at that point. Can you think of a simple way, or is it easier to invert the flag and have it update everything *but* the ambient versions?