### PR TITLE
Misc fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,6 @@ dependencies = [
  "image_hasher",
  "log",
  "parking_lot",
- "rand 0.8.5",
  "rpassword",
  "rustls-pemfile",
  "rusty-hook",
@@ -429,6 +428,7 @@ dependencies = [
  "ambient_shared_types",
  "ambient_ui_native",
  "glam 0.24.1",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "image_hasher",
  "log",
  "parking_lot",
+ "rand 0.8.5",
  "rpassword",
  "rustls-pemfile",
  "rusty-hook",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -66,7 +66,6 @@ toml_edit = { workspace = true }
 rpassword = { workspace = true }
 sentry = { workspace = true }
 sentry-rust-minidump = { workspace = true }
-rand = { workspace = true }
 
 [dev-dependencies]
 glam = { workspace = true }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -66,6 +66,7 @@ toml_edit = { workspace = true }
 rpassword = { workspace = true }
 sentry = { workspace = true }
 sentry-rust-minidump = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 glam = { workspace = true }

--- a/app/src/client/mod.rs
+++ b/app/src/client/mod.rs
@@ -26,7 +26,6 @@ use ambient_settings::SettingsKey;
 use ambient_sys::time::Instant;
 use ambient_ui_native::{Dock, WindowSized};
 use glam::uvec2;
-use rand::seq::SliceRandom;
 
 use crate::{
     cli::{GoldenImageCommand, RunCli},
@@ -49,7 +48,7 @@ pub fn run(
     let user_id = match run.user_id.clone().or(settings.general.user_id) {
         Some(user_id) => user_id,
         None => {
-            let user_id = random_username();
+            let user_id = ambient_client_shared::util::random_username();
             log::warn!(
                 "No `user_id` found in settings, using random username: {:?}",
                 user_id
@@ -389,59 +388,5 @@ fn systems() -> SystemGroup {
             Box::new(wasm::systems()),
             Box::new(ambient_client_shared::player::systems_final()),
         ],
-    )
-}
-
-fn random_username() -> String {
-    const ADJECTIVES: &[&str] = &[
-        "Quirky",
-        "Sneaky",
-        "Witty",
-        "Curious",
-        "Grumpy",
-        "Silly",
-        "Mischievous",
-        "Goofy",
-        "Hasty",
-        "Awkward",
-        "Zany",
-        "Peculiar",
-        "Whimsical",
-        "Bumbling",
-        "Absurd",
-        "Oddball",
-        "Clumsy",
-        "Nutty",
-        "Haphazard",
-        "Eccentric",
-    ];
-
-    const ANIMALS: &[&str] = &[
-        "Penguin",
-        "Platypus",
-        "Lemur",
-        "Armadillo",
-        "Sloth",
-        "Ostrich",
-        "Tapir",
-        "Narwhal",
-        "Chameleon",
-        "Aardvark",
-        "Quokka",
-        "Wombat",
-        "Kakapo",
-        "Capybara",
-        "Mandrill",
-        "Axolotl",
-        "Blobfish",
-        "Echidna",
-        "Wallaby",
-    ];
-
-    let mut rng = rand::thread_rng();
-    format!(
-        "{}{}",
-        ADJECTIVES.choose(&mut rng).unwrap(),
-        ANIMALS.choose(&mut rng).unwrap()
     )
 }

--- a/app/src/client/mod.rs
+++ b/app/src/client/mod.rs
@@ -13,15 +13,20 @@ use ambient_element::{
     consume_context, element_component, use_effect, use_ref_with, use_spawn, use_state,
     use_state_with, Element, ElementComponentExt, Group, Hooks,
 };
-use ambient_native_std::{asset_cache::AssetCache, cb, friendly_id};
+use ambient_native_std::{
+    asset_cache::{AssetCache, SyncAssetKeyExt},
+    cb,
+};
 use ambient_network::{
     client::{client_network_stats, GameClientRenderTarget},
     hooks::use_remote_resource,
     native::client::{ClientView, ResolvedAddr},
 };
+use ambient_settings::SettingsKey;
 use ambient_sys::time::Instant;
 use ambient_ui_native::{Dock, WindowSized};
 use glam::uvec2;
+use rand::seq::SliceRandom;
 
 use crate::{
     cli::{GoldenImageCommand, RunCli},
@@ -39,10 +44,20 @@ pub fn run(
     golden_image_output_dir: Option<PathBuf>,
     mixer: Option<AudioMixer>,
 ) -> ExitStatus {
-    let user_id = run
-        .user_id
-        .clone()
-        .unwrap_or_else(|| format!("user_{}", friendly_id()));
+    let settings = SettingsKey.get(&assets);
+
+    let user_id = match run.user_id.clone().or(settings.general.user_id) {
+        Some(user_id) => user_id,
+        None => {
+            let user_id = random_username();
+            log::warn!(
+                "No `user_id` found in settings, using random username: {:?}",
+                user_id
+            );
+            user_id
+        }
+    };
+
     let headless = if run.headless {
         Some(uvec2(600, 600))
     } else {
@@ -374,5 +389,59 @@ fn systems() -> SystemGroup {
             Box::new(wasm::systems()),
             Box::new(ambient_client_shared::player::systems_final()),
         ],
+    )
+}
+
+fn random_username() -> String {
+    const ADJECTIVES: &[&str] = &[
+        "Quirky",
+        "Sneaky",
+        "Witty",
+        "Curious",
+        "Grumpy",
+        "Silly",
+        "Mischievous",
+        "Goofy",
+        "Hasty",
+        "Awkward",
+        "Zany",
+        "Peculiar",
+        "Whimsical",
+        "Bumbling",
+        "Absurd",
+        "Oddball",
+        "Clumsy",
+        "Nutty",
+        "Haphazard",
+        "Eccentric",
+    ];
+
+    const ANIMALS: &[&str] = &[
+        "Penguin",
+        "Platypus",
+        "Lemur",
+        "Armadillo",
+        "Sloth",
+        "Ostrich",
+        "Tapir",
+        "Narwhal",
+        "Chameleon",
+        "Aardvark",
+        "Quokka",
+        "Wombat",
+        "Kakapo",
+        "Capybara",
+        "Mandrill",
+        "Axolotl",
+        "Blobfish",
+        "Echidna",
+        "Wallaby",
+    ];
+
+    let mut rng = rand::thread_rng();
+    format!(
+        "{}{}",
+        ADJECTIVES.choose(&mut rng).unwrap(),
+        ANIMALS.choose(&mut rng).unwrap()
     )
 }

--- a/crates/client_shared/Cargo.toml
+++ b/crates/client_shared/Cargo.toml
@@ -19,3 +19,4 @@ ambient_debugger = { path = "../debugger/" , version = "0.3.0-dev" }
 ambient_ecs_editor = { path = "../ecs_editor/" , version = "0.3.0-dev" }
 
 glam = { workspace = true }
+rand = { workspace = true }

--- a/crates/client_shared/src/lib.rs
+++ b/crates/client_shared/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod game_view;
 pub mod player;
+pub mod util;

--- a/crates/client_shared/src/util.rs
+++ b/crates/client_shared/src/util.rs
@@ -1,0 +1,56 @@
+use rand::seq::SliceRandom;
+
+/// Generates an adjective-animal username.
+pub fn random_username() -> String {
+    const ADJECTIVES: &[&str] = &[
+        "Quirky",
+        "Sneaky",
+        "Witty",
+        "Curious",
+        "Grumpy",
+        "Silly",
+        "Mischievous",
+        "Goofy",
+        "Hasty",
+        "Awkward",
+        "Zany",
+        "Peculiar",
+        "Whimsical",
+        "Bumbling",
+        "Absurd",
+        "Oddball",
+        "Clumsy",
+        "Nutty",
+        "Haphazard",
+        "Eccentric",
+    ];
+
+    const ANIMALS: &[&str] = &[
+        "Penguin",
+        "Platypus",
+        "Lemur",
+        "Armadillo",
+        "Sloth",
+        "Ostrich",
+        "Tapir",
+        "Narwhal",
+        "Chameleon",
+        "Aardvark",
+        "Quokka",
+        "Wombat",
+        "Kakapo",
+        "Capybara",
+        "Mandrill",
+        "Axolotl",
+        "Blobfish",
+        "Echidna",
+        "Wallaby",
+    ];
+
+    let mut rng = rand::thread_rng();
+    format!(
+        "{}{}",
+        ADJECTIVES.choose(&mut rng).unwrap(),
+        ANIMALS.choose(&mut rng).unwrap()
+    )
+}

--- a/crates/settings/src/general.rs
+++ b/crates/settings/src/general.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug)]
 pub struct GeneralSettings {
+    pub user_id: Option<String>,
     pub api_token: Option<String>,
     pub sentry: Sentry,
 }

--- a/docs/src/tutorials/game/6_ui.md
+++ b/docs/src/tutorials/game/6_ui.md
@@ -9,7 +9,7 @@ Add the following to `client.rs`:
 ```rust
 #[element_component]
 fn PlayerPosition(hooks: &mut Hooks) -> Element {
-    let (pos, _) = use_entity_component(hooks, player::get_local(), translation());
+    let pos = use_entity_component(hooks, player::get_local(), translation());
     Text::el(format!("Player position: {}", pos.unwrap_or_default()))
 }
 ```

--- a/guest/rust/packages/games/afps/core/fpsui/src/client.rs
+++ b/guest/rust/packages/games/afps/core/fpsui/src/client.rs
@@ -25,7 +25,7 @@ pub fn main() {
 
 #[element_component]
 pub fn App(hooks: &mut Hooks) -> Element {
-    let (player_name, _) = use_entity_component(hooks, player::get_local(), player_name());
+    let player_name = use_entity_component(hooks, player::get_local(), player_name());
 
     if player_name.is_none() {
         JoinScreen::el()
@@ -121,7 +121,7 @@ fn Crosshair(hooks: &mut Hooks) -> Element {
 
 #[element_component]
 fn Hud(hooks: &mut Hooks) -> Element {
-    let (local_health, _) = use_entity_component(hooks, player::get_local(), health());
+    let local_health = use_entity_component(hooks, player::get_local(), health());
 
     WindowSized::el([Dock::el([Text::el(format!(
         "health: {:?}",

--- a/guest/rust/packages/games/tangent/core/src/client.rs
+++ b/guest/rust/packages/games/tangent/core/src/client.rs
@@ -213,7 +213,7 @@ fn handle_explosions() {
 
 #[element_component]
 fn CoreUI(_hooks: &mut Hooks) -> Element {
-    let vehicle_id = use_entity_component(_hooks, player::get_local(), pc::vehicle_ref()).0;
+    let vehicle_id = use_entity_component(_hooks, player::get_local(), pc::vehicle_ref());
 
     if let Some(vehicle_id) = vehicle_id {
         Crosshair::el(vehicle_id)
@@ -226,7 +226,6 @@ fn CoreUI(_hooks: &mut Hooks) -> Element {
 fn Crosshair(hooks: &mut Hooks, vehicle_id: EntityId) -> Element {
     let input_aim_direction =
         use_entity_component(hooks, player::get_local(), pc::input_aim_direction())
-            .0
             .unwrap_or_default();
 
     let Some(active_camera_id) = camera::get_active(None) else {

--- a/guest/rust/packages/games/tangent/mods/ui_class_selection/src/client.rs
+++ b/guest/rust/packages/games/tangent/mods/ui_class_selection/src/client.rs
@@ -20,9 +20,7 @@ pub fn main() {
 
 #[element_component]
 pub fn App(hooks: &mut Hooks) -> Element {
-    let has_class = use_entity_component(hooks, player::get_local(), pc::vehicle_class())
-        .0
-        .is_some();
+    let has_class = use_entity_component(hooks, player::get_local(), pc::vehicle_class()).is_some();
 
     let (toggle, set_toggle) = use_state(hooks, false);
     use_keyboard_input(hooks, {
@@ -50,8 +48,7 @@ pub fn App(hooks: &mut Hooks) -> Element {
 
 #[element_component]
 pub fn ClassSelection(hooks: &mut Hooks, hide: Cb<dyn Fn() + Send + Sync>) -> Element {
-    let (player_class_id, _) =
-        use_entity_component(hooks, player::get_local(), pc::vehicle_class());
+    let player_class_id = use_entity_component(hooks, player::get_local(), pc::vehicle_class());
 
     let mut classes = use_query(hooks, VehicleClass::as_query());
     classes.sort_by_key(|(_, c)| c.name.clone());

--- a/guest/rust/packages/games/tangent/mods/ui_holohud/src/client.rs
+++ b/guest/rust/packages/games/tangent/mods/ui_holohud/src/client.rs
@@ -24,24 +24,19 @@ pub fn main() {
 
 #[element_component]
 fn Hud(hooks: &mut Hooks) -> Element {
-    let vehicle_id = use_entity_component(hooks, player::get_local(), pc::vehicle_ref()).0;
+    let vehicle_id = use_entity_component(hooks, player::get_local(), pc::vehicle_ref());
     vehicle_id.map(VehicleHud::el).unwrap_or_default()
 }
 
 #[element_component]
 fn VehicleHud(hooks: &mut Hooks, vehicle_id: EntityId) -> Element {
-    let health = use_entity_component(hooks, vehicle_id, vc::health())
-        .0
-        .unwrap_or_default();
+    let health = use_entity_component(hooks, vehicle_id, vc::health()).unwrap_or_default();
 
     let max_health =
         use_entity_component(hooks, vehicle_id, vdc::general::components::max_health())
-            .0
             .unwrap_or_default();
 
-    let speed = use_entity_component(hooks, vehicle_id, vcc::speed_kph())
-        .0
-        .unwrap_or_default();
+    let speed = use_entity_component(hooks, vehicle_id, vcc::speed_kph()).unwrap_or_default();
 
     let health_color = vec3(0.86, 0.08, 0.24)
         .lerp(vec3(0.54, 0.72, 0.00), health / max_health)

--- a/guest/rust/packages/tools/editor/src/client.rs
+++ b/guest/rust/packages/tools/editor/src/client.rs
@@ -159,9 +159,8 @@ pub fn main() {
 
 #[element_component]
 pub fn App(hooks: &mut Hooks) -> Element {
-    let in_editor = use_entity_component(hooks, player::get_local(), in_editor())
-        .0
-        .unwrap_or_default();
+    let in_editor =
+        use_entity_component(hooks, player::get_local(), in_editor()).unwrap_or_default();
 
     use_keyboard_input(hooks, move |_, keycode, modifiers, pressed| {
         if modifiers == ModifiersState::empty() && keycode == Some(VirtualKeyCode::F5) && !pressed {
@@ -232,8 +231,8 @@ fn MenuBar(_hooks: &mut Hooks, menu_bar_items: HashSet<(EntityId, String)>) -> E
 #[element_component]
 fn MouseoverDisplay(hooks: &mut Hooks) -> Element {
     let player_id = player::get_local();
-    let (mouseover_position, _) = use_entity_component(hooks, player_id, mouseover_position());
-    let (camera_id, _) = use_entity_component(hooks, player_id, editor_camera());
+    let mouseover_position = use_entity_component(hooks, player_id, mouseover_position());
+    let camera_id = use_entity_component(hooks, player_id, editor_camera());
 
     let Some(mouseover_position) = mouseover_position else {
         return Element::new();
@@ -253,8 +252,8 @@ fn MouseoverDisplay(hooks: &mut Hooks) -> Element {
 #[element_component]
 fn SelectedDisplay(hooks: &mut Hooks) -> Element {
     let player_id = player::get_local();
-    let (selected_entity, _) = use_entity_component(hooks, player_id, selected_entity());
-    let (camera_id, _) = use_entity_component(hooks, player_id, editor_camera());
+    let selected_entity = use_entity_component(hooks, player_id, selected_entity());
+    let camera_id = use_entity_component(hooks, player_id, editor_camera());
 
     // TODO: is there a better way to force this element to re-render every frame?
     let rerender = use_rerender_signal(hooks);

--- a/guest/rust/packages/tools/package_manager/src/client/package_manager.rs
+++ b/guest/rust/packages/tools/package_manager/src/client/package_manager.rs
@@ -38,8 +38,7 @@ pub fn PackageManager(hooks: &mut Hooks) -> Element {
         hooks,
         packages::this::entity(),
         packages::this::components::mod_manager_for(),
-    )
-    .0;
+    );
 
     let title = if mod_manager_for.is_some() {
         "Mod Manager".to_string()

--- a/shared_crates/element/src/hooks.rs
+++ b/shared_crates/element/src/hooks.rs
@@ -582,10 +582,9 @@ pub fn use_query<
 }
 
 #[cfg(feature = "guest")]
-/// Use a component from an entity in the ECS, and update its state if required.
+/// Use a component from an entity in the ECS.
 ///
 /// If the entity or component does not exist, this will return `None`.
-/// The setter will add the component if it does not exist.
 pub fn use_entity_component<
     T: ambient_guest_bridge::api::ecs::SupportedValue
         + Clone
@@ -598,7 +597,7 @@ pub fn use_entity_component<
     hooks: &mut Hooks,
     id: EntityId,
     component: ambient_guest_bridge::api::ecs::Component<T>,
-) -> (Option<T>, Setter<T>) {
+) -> Option<T> {
     use ambient_guest_bridge::api::prelude::{change_query, entity};
 
     let refresh = use_rerender_signal(hooks);
@@ -612,10 +611,7 @@ pub fn use_entity_component<
         }
     });
 
-    (
-        entity::get_component(id, component),
-        cb(move |value| entity::add_component(id, component, value)),
-    )
+    entity::get_component(id, component)
 }
 
 #[cfg(feature = "guest")]
@@ -637,7 +633,10 @@ pub fn use_resource<
 ) -> (Option<T>, Setter<T>) {
     use ambient_guest_bridge::api::entity;
 
-    use_entity_component(hooks, entity::resources(), component)
+    (
+        use_entity_component(hooks, entity::resources(), component),
+        cb(move |value| entity::add_component(entity::resources(), component, value)),
+    )
 }
 
 #[cfg(feature = "guest")]

--- a/shared_crates/ui/src/text.rs
+++ b/shared_crates/ui/src/text.rs
@@ -3,13 +3,13 @@
 use crate::{UIBase, UIElement};
 use ambient_element::{element_component, Element, ElementComponentExt, Hooks};
 use ambient_guest_bridge::core::{
-    app::components::{name, ui_scene},
+    app::components::{main_scene, name, ui_scene},
     layout::components::{height, width},
     rendering::components::color,
     text::components::{font_family, font_size, text},
-    transform::components::mesh_to_local,
+    transform::components::{local_to_parent, local_to_world, mesh_to_local, mesh_to_world, scale},
 };
-use glam::{vec4, Mat4};
+use glam::{vec4, Mat4, Vec3};
 
 /// A text element. Use the [text], [font_size], [font_family] and [color] components to set its state.
 #[element_component(without_el)]
@@ -67,4 +67,26 @@ pub fn FontAwesomeIcon(
         }
         .to_string(),
     )
+}
+
+#[element_component]
+/// A text element that renders in the main scene in 3D.
+pub fn Text3D(
+    _hooks: &mut Hooks,
+    /// The text to render.
+    text: String,
+    /// The scale of the text, where 1.0 is about 0.5m tall.
+    // TODO: update this to be accurate/precise.
+    scale: f32,
+) -> Element {
+    Element::new()
+        .with(local_to_world(), Default::default())
+        .with(local_to_parent(), Default::default())
+        .with(mesh_to_local(), Default::default())
+        .with(mesh_to_world(), Default::default())
+        .with(main_scene(), ())
+        .with(font_size(), 48.0)
+        .with(self::text(), text)
+        .with(self::scale(), Vec3::ONE * (scale / 1_000.))
+        .init(width(), 1.0)
 }

--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "ambient_shared_types",
  "ambient_ui_native",
  "glam",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/web/client/src/app.rs
+++ b/web/client/src/app.rs
@@ -3,10 +3,9 @@ use ambient_cameras::UICamera;
 use ambient_client_shared::{game_view::GameView, player};
 use ambient_ecs::{Entity, SystemGroup};
 use ambient_element::{element_component, Element, ElementComponentExt, Hooks};
-use ambient_native_std::friendly_id;
 use ambient_network::{server::RpcArgs, web::client::GameClientView};
 use ambient_rpc::RpcRegistry;
-use ambient_ui_native::{cb};
+use ambient_ui_native::cb;
 use std::collections::HashMap;
 
 #[element_component]
@@ -15,7 +14,7 @@ pub fn MainApp(_hooks: &mut Hooks, server_url: String) -> Element {
 
     GameClientView {
         url: server_url,
-        user_id: friendly_id(),
+        user_id: ambient_client_shared::util::random_username(),
         systems_and_resources: cb(|| {
             let mut resources = Entity::new();
 


### PR DESCRIPTION
Have been working on Tangent in the background, but pulled these fixes/changes out from my branch as they're generally relevant.

- You can now set `general.user_id` for the native client's settings.
- `Text3D` lets you easily position text in space. I'm not sure about its interface quite yet, but it does make it much easier.
- `LayoutFreeCenter` offers a solution to the problem of centering 3D text (#112). It's not the best solution - ideally the mesh itself would be centered at the point - but it works.
- Literally no use of `use_entity_component` uses the setter. I've removed it to make it simpler and to make it clearer that you can't manipulate the server with it.
- The desktop and web clients now generate a nice AdjectiveAnimal name if you don't have one specified. After this goes in, I'll probably pass the user_id in as an argument for the web client so that your profile username becomes your ingame username.