### PR TITLE
bump as-any; get rid of downcast-rs usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,13 +556,13 @@ dependencies = [
  "ambient_shared_types",
  "ambient_sys",
  "anyhow",
+ "as-any",
  "atomic_refcell",
  "bincode",
  "bit-set",
  "bit-vec",
  "byteorder",
  "data-encoding",
- "downcast-rs",
  "erased-serde",
  "glam 0.24.1",
  "itertools",
@@ -1021,6 +1021,7 @@ dependencies = [
  "ambient_ui_native",
  "ambient_world_audio",
  "anyhow",
+ "as-any",
  "async-trait",
  "bincode",
  "bytes",
@@ -1299,10 +1300,10 @@ dependencies = [
  "ambient_std",
  "ambient_sys",
  "anyhow",
+ "as-any",
  "async-trait",
  "bytemuck",
  "derive_more",
- "downcast-rs",
  "env_logger 0.10.0",
  "glam 0.24.1",
  "itertools",
@@ -1826,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "as-any"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088ccb346677e658e7ccd9627c62576fba881f4db7fab71fa9e21bf31c0aa4cb"
+checksum = "5b8a30a44e99a1c83ccb2a6298c563c888952a1c9134953db26876528f84c93a"
 
 [[package]]
 name = "ash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ log = "0.4"
 dyn-clonable = "0.9.0"
 semver = { version = "1.0", features = ["serde"] }
 paste = "1.0"
-as-any = "0.2.1"
+as-any = "0.3.1"
 closure = "0.3.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11.12"
@@ -71,7 +71,6 @@ thiserror = "1.0"
 thread-priority = "0.10.0"
 once_cell = { version = "1.18.0", features = ["parking_lot"] }
 smallvec = "1.11.1"
-downcast-rs = "1.2.0"
 yaml-rust = { version = "0.5", package = "yaml-rust-davvid" }
 maplit = "1.0.2"
 chrono = { version = "0.4", default-features = false, features = [

--- a/crates/asset_cache/src/lib.rs
+++ b/crates/asset_cache/src/lib.rs
@@ -27,11 +27,6 @@ use serde::{Deserialize, Serialize};
 trait AssetHolder: as_any::AsAny + Sync + Send {}
 impl<T: Clone + Sync + Send + Any + 'static> AssetHolder for T {}
 
-impl as_any::Downcast for dyn AssetHolder {}
-impl as_any::Downcast for dyn AssetHolder + Send {}
-impl as_any::Downcast for dyn AssetHolder + Sync {}
-impl as_any::Downcast for dyn AssetHolder + Send + Sync {}
-
 #[derive(Clone)]
 struct LoadPayload {
     asset_key: AssetKey,

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 name = "ambient_ecs"
 version = { workspace = true }
@@ -16,6 +15,7 @@ ambient_native_std = { path = "../native_std" , version = "0.3.0-dev" }
 ambient_shared_types = { path = "../../shared_crates/shared_types", features = ["native"] , version = "0.3.0-dev" }
 ambient_package_rt = { path = "../../shared_crates/package_rt" , version = "0.3.0-dev" }
 
+as-any = { workspace = true }
 itertools = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
@@ -26,7 +26,6 @@ paste = { workspace = true }
 atomic_refcell = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }
-downcast-rs = { workspace = true }
 once_cell = { workspace = true }
 anyhow = { workspace = true }
 bit-set = { workspace = true }

--- a/crates/ecs/src/component.rs
+++ b/crates/ecs/src/component.rs
@@ -6,7 +6,6 @@ use std::{
     marker::PhantomData,
 };
 
-use downcast_rs::Downcast;
 use parking_lot::MappedRwLockReadGuard;
 use serde::{
     self,
@@ -22,11 +21,7 @@ use crate::{
 
 use ambient_shared_types::ComponentIndex;
 
-pub trait ComponentValueBase: Send + Sync + Downcast + 'static {
-    fn type_name(&self) -> &'static str {
-        std::any::type_name::<Self>()
-    }
-}
+pub trait ComponentValueBase: Send + Sync + as_any::AsAny {}
 
 impl<T: Send + Sync + 'static> ComponentValueBase for T {}
 pub trait ComponentValue: ComponentValueBase + Clone {}

--- a/crates/ecs/src/component_traits.rs
+++ b/crates/ecs/src/component_traits.rs
@@ -1,6 +1,5 @@
 use std::{self, any::Any};
 
-use downcast_rs::impl_downcast;
 use serde::{de::DeserializeOwned, Deserializer, Serializer};
 
 use super::*;
@@ -15,8 +14,6 @@ impl<T: ComponentValue + Serialize + DeserializeOwned + Clone + std::fmt::Debug>
     for T
 {
 }
-
-impl_downcast!(ComponentValueBase);
 
 impl<T: ComponentValue> Serialize for Component<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -27,6 +27,7 @@ ambient_world_audio = { path = "../world_audio", version = "0.3.0-dev" }
 
 rustls-native-certs = { workspace = true, optional = true }
 
+as-any = { workspace = true }
 url = { workspace = true }
 itertools = { workspace = true }
 serde = { workspace = true }

--- a/crates/network/src/client.rs
+++ b/crates/network/src/client.rs
@@ -1,11 +1,12 @@
 use ambient_core::{gpu, window::window_scale_factor};
-use ambient_ecs::{components, ComponentValueBase, Resource, World};
+use ambient_ecs::{components, Resource, World};
 use ambient_element::{consume_context, element_component, Element, ElementComponentExt, Hooks};
 use ambient_native_std::{asset_cache::AssetCache, cb, friendly_id, to_byte_unit, Cb};
 use ambient_renderer::RenderTarget;
 use ambient_rpc::RpcRegistry;
 use ambient_sys::task::{PlatformBoxFuture, RuntimeHandle};
 use ambient_ui_native::{Image, MeasureSize};
+use as_any::AsAny;
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use glam::UVec2;

--- a/crates/renderer/Cargo.toml
+++ b/crates/renderer/Cargo.toml
@@ -21,14 +21,13 @@ ambient_settings = { path = "../settings" , version = "0.3.0-dev" }
 
 ambient_color = { path = "../../libs/color", features = ["wgpu"] , version = "0.3.0-dev" }
 
-
+as-any = { workspace = true }
 wgpu = { workspace = true }
 glam = { workspace = true }
 itertools = { workspace = true }
 ordered-float = { workspace = true }
 serde = { workspace = true }
 derive_more = { workspace = true }
-downcast-rs = { workspace = true }
 profiling = { workspace = true }
 bytemuck = { workspace = true }
 smallvec = { workspace = true }

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -25,7 +25,6 @@ use ambient_gpu_ecs::{
 };
 use ambient_native_std::{asset_cache::*, asset_url::AbsAssetUrl, cb, include_file, Cb};
 use derive_more::*;
-use downcast_rs::{impl_downcast, DowncastSync};
 use glam::{uvec4, UVec2, UVec4, Vec3};
 use serde::{Deserialize, Serialize};
 
@@ -285,7 +284,8 @@ impl SharedMaterial {
     }
 
     pub fn borrow_downcast<T: Material>(&self) -> &T {
-        self.0.downcast_ref::<T>().unwrap()
+        use as_any::Downcast;
+        (*self.0).downcast_ref::<T>().unwrap()
     }
 }
 
@@ -414,7 +414,7 @@ pub struct MaterialShader {
     pub shader: Arc<ShaderModule>,
 }
 
-pub trait Material: Debug + Sync + Send + DowncastSync {
+pub trait Material: Debug + Sync + Send + as_any::AsAny {
     fn id(&self) -> &str;
 
     fn name(&self) -> &str {
@@ -440,8 +440,6 @@ pub trait Material: Debug + Sync + Send + DowncastSync {
         None
     }
 }
-
-impl_downcast!(sync Material);
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 #[repr(u32)]

--- a/shared_crates/element/src/hooks.rs
+++ b/shared_crates/element/src/hooks.rs
@@ -92,15 +92,14 @@ pub fn use_state_with<T: Clone + Debug + Send + 'static>(
     hooks.state_index += 1;
     let value = {
         let instance = hooks.tree.instances.get_mut(&hooks.instance_id).unwrap();
-        if let Some(value) = instance.hooks_state.get(index) {
-            value
+        let value: &(dyn AnyCloneable + Send) = if let Some(value) = instance.hooks_state.get(index)
+        {
+            &**value
         } else {
             instance.hooks_state.push(Box::new(init(hooks.world)));
-            instance.hooks_state.last().unwrap()
-        }
-        .downcast_ref::<T>()
-        .unwrap()
-        .clone()
+            &**instance.hooks_state.last().unwrap()
+        };
+        value.downcast_ref::<T>().unwrap().clone()
     };
     let environment = hooks.environment.clone();
     let element = hooks.instance_id.clone();
@@ -165,7 +164,7 @@ pub fn consume_context<T: Clone + Debug + Sync + Send + 'static>(
             let instance = hooks.tree.instances.get_mut(&provider).unwrap();
             let ctx = instance.hooks_context_state.get_mut(&type_id).unwrap();
             ctx.listeners.insert(hooks.instance_id.clone());
-            ctx.value.downcast_ref::<T>().unwrap().clone()
+            (*ctx.value).downcast_ref::<T>().unwrap().clone()
         };
         {
             let instance = hooks.tree.instances.get_mut(&hooks.instance_id).unwrap();

--- a/shared_crates/element/src/lib.rs
+++ b/shared_crates/element/src/lib.rs
@@ -76,10 +76,6 @@ pub use ambient_guest_bridge::core::app::components::{element, element_unmanaged
 /// A trait for types that can be converted to `Any` and can also be cloned.
 pub trait AnyCloneable: AsAny + Clone + std::fmt::Debug {}
 impl<T: Clone + std::fmt::Debug + Any + 'static> AnyCloneable for T {}
-impl as_any::Downcast for dyn AnyCloneable {}
-impl as_any::Downcast for dyn AnyCloneable + Send {}
-impl as_any::Downcast for dyn AnyCloneable + Sync {}
-impl as_any::Downcast for dyn AnyCloneable + Send + Sync {}
 
 type InstanceId = String;
 


### PR DESCRIPTION
NOTE: as the new `as-any` version implements `Downcast` directly for everything that could support it, name resolution changes a bit and requires more explicit dereferences.

* `cargo fmt --check` passes
* `cargo test --all` passes