### PR TITLE
Reduce string usage in the renderer to improve performance

### DIFF
--- a/crates/gizmos/src/render.rs
+++ b/crates/gizmos/src/render.rs
@@ -72,7 +72,7 @@ impl GizmoRenderer {
     pub fn new(gpu: &Gpu, assets: &AssetCache) -> Self {
         let buffer = TypedBuffer::new(
             gpu,
-            "Gizmo Buffer",
+            Some("Gizmo Buffer"),
             128,
             BufferUsages::STORAGE | BufferUsages::COPY_DST | BufferUsages::COPY_SRC,
         );

--- a/crates/gpu/src/gpu_run.rs
+++ b/crates/gpu/src/gpu_run.rs
@@ -108,14 +108,14 @@ impl GpuRun {
 
         let in_buffer = TypedBuffer::new_init(
             gpu,
-            "GpuRun.in",
+            Some("GpuRun.in"),
             BufferUsages::COPY_DST | BufferUsages::STORAGE,
             &[input],
         );
 
         let out_buffer = TypedBuffer::new_init(
             gpu,
-            "GpuRun.out",
+            Some("GpuRun.out"),
             BufferUsages::STORAGE | BufferUsages::COPY_SRC,
             &[Out::zeroed()],
         );

--- a/crates/gpu/src/mesh_buffer.rs
+++ b/crates/gpu/src/mesh_buffer.rs
@@ -141,7 +141,7 @@ impl MeshBuffer {
         Self {
             metadata_buffer: TypedBuffer::new(
                 gpu,
-                "MeshBuffer.metadata_buffer",
+                Some("MeshBuffer.metadata_buffer"),
                 4,
                 wgpu::BufferUsages::STORAGE
                     | wgpu::BufferUsages::COPY_DST
@@ -497,10 +497,10 @@ pub struct AttributeBuffer<T: bytemuck::Pod> {
 }
 
 impl<T: bytemuck::Pod> AttributeBuffer<T> {
-    pub fn new(gpu: &Gpu, label: &str, capacity: usize, usage: wgpu::BufferUsages) -> Self {
+    pub fn new(gpu: &Gpu, label: &'static str, capacity: usize, usage: wgpu::BufferUsages) -> Self {
         Self {
-            front: TypedBuffer::new(gpu, label, capacity, usage),
-            tmp: TypedBuffer::new(gpu, label, capacity, usage),
+            front: TypedBuffer::new(gpu, Some(label), capacity, usage),
+            tmp: TypedBuffer::new(gpu, Some(label), capacity, usage),
         }
     }
 

--- a/crates/gpu_ecs/src/lib.rs
+++ b/crates/gpu_ecs/src/lib.rs
@@ -84,7 +84,7 @@ impl GpuWorld {
         Self {
             layout_buffer: TypedBuffer::new_init(
                 gpu,
-                "GpuWorld.layout_buffer",
+                Some("GpuWorld.layout_buffer"),
                 wgpu::BufferUsages::STORAGE
                     | wgpu::BufferUsages::COPY_DST
                     | wgpu::BufferUsages::COPY_SRC,
@@ -164,7 +164,7 @@ impl GpuComponentsBuffer {
         Self {
             buffer: TypedBuffer::new(
                 gpu,
-                format!("EntityBuffers.{}.data", config.format),
+                Some("EntityBuffers.data"), // TODO: add config.format to label
                 size,
                 wgpu::BufferUsages::STORAGE
                     | wgpu::BufferUsages::COPY_DST

--- a/crates/gpu_ecs/src/update.rs
+++ b/crates/gpu_ecs/src/update.rs
@@ -84,7 +84,7 @@ impl GpuWorldUpdater {
             filter,
             chunks: TypedBuffer::new(
                 gpu,
-                "GpuWorldUpdate.chunks",
+                Some("GpuWorldUpdate.chunks"),
                 1,
                 wgpu::BufferUsages::COPY_DST
                     | wgpu::BufferUsages::COPY_SRC

--- a/crates/naturals/src/compute.rs
+++ b/crates/naturals/src/compute.rs
@@ -241,13 +241,13 @@ impl NaturalsPipeline {
     ) -> Vec<NaturalEntity> {
         let out_count_staging = TypedBuffer::<u32>::new_init(
             gpu,
-            "Naturals.out_count_staging",
+            Some("Naturals.out_count_staging"),
             wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
             &[0],
         );
         let out_entities_staging = TypedBuffer::<NaturalEntity>::new(
             gpu,
-            "Naturals.out_entities_staging",
+            Some("Naturals.out_entities_staging"),
             NATURALS_MAX_ENTITIES as usize,
             wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
         );
@@ -255,7 +255,7 @@ impl NaturalsPipeline {
         {
             let natural_elements = TypedBuffer::<NaturalElementWGSL>::new_init(
                 gpu,
-                "Naturals.elements",
+                Some("Naturals.elements"),
                 wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
                 &elements
                     .iter()
@@ -265,7 +265,7 @@ impl NaturalsPipeline {
 
             let out_count_buffer = TypedBuffer::<u32>::new_init(
                 gpu,
-                "Naturals.out_count",
+                Some("Naturals.out_count"),
                 wgpu::BufferUsages::STORAGE
                     | wgpu::BufferUsages::COPY_SRC
                     | wgpu::BufferUsages::COPY_DST,
@@ -273,7 +273,7 @@ impl NaturalsPipeline {
             );
             let out_entities_buffer = TypedBuffer::<NaturalEntity>::new(
                 gpu,
-                "Naturals.out_entities",
+                Some("Naturals.out_entities"),
                 NATURALS_MAX_ENTITIES as usize,
                 wgpu::BufferUsages::STORAGE
                     | wgpu::BufferUsages::COPY_SRC

--- a/crates/rect/src/lib.rs
+++ b/crates/rect/src/lib.rs
@@ -379,7 +379,7 @@ impl RectMaterial {
 
         let buffer = TypedBuffer::new_init(
             gpu,
-            "RectMaterial.buffer",
+            Some("RectMaterial.buffer"),
             wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             &[params],
         );

--- a/crates/renderer/src/collect.rs
+++ b/crates/renderer/src/collect.rs
@@ -95,13 +95,13 @@ impl RendererCollectState {
         Self {
             params: TypedBuffer::new_init(
                 gpu,
-                "RendererCollectState.params",
+                Some("RendererCollectState.params"),
                 wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
                 &[RendererCollectParams::default()],
             ),
             commands: TypedBuffer::new(
                 gpu,
-                "RendererCollectState.commands",
+                Some("RendererCollectState.commands"),
                 1,
                 wgpu::BufferUsages::STORAGE
                     | wgpu::BufferUsages::COPY_DST
@@ -110,7 +110,7 @@ impl RendererCollectState {
             ),
             counts: TypedBuffer::new(
                 gpu,
-                "RendererCollectState.counts",
+                Some("RendererCollectState.counts"),
                 1,
                 wgpu::BufferUsages::STORAGE
                     | wgpu::BufferUsages::COPY_DST
@@ -120,7 +120,7 @@ impl RendererCollectState {
             counts_cpu: Arc::new(Default::default()),
             material_layouts: TypedBuffer::new(
                 gpu,
-                "RendererCollectState.materials",
+                Some("RendererCollectState.materials"),
                 1,
                 wgpu::BufferUsages::STORAGE
                     | wgpu::BufferUsages::COPY_DST
@@ -405,7 +405,7 @@ impl CollectCountStagingBuffers {
             }
             None => TypedBuffer::<u32>::new(
                 gpu,
-                "RendererCollectState.counts_staging",
+                Some("RendererCollectState.counts_staging"),
                 size,
                 wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
             ),

--- a/crates/renderer/src/culling.rs
+++ b/crates/renderer/src/culling.rs
@@ -126,7 +126,7 @@ impl Culling {
             ),
             params: TypedBuffer::new(
                 gpu,
-                "Culling.params",
+                Some("Culling.params"),
                 1,
                 wgpu::BufferUsages::COPY_DST
                     | wgpu::BufferUsages::COPY_SRC

--- a/crates/renderer/src/shadow_renderer.rs
+++ b/crates/renderer/src/shadow_renderer.rs
@@ -188,7 +188,7 @@ impl ShadowsRenderer {
         bind_groups: &BindGroups<'a>,
         post_submit: &mut Vec<PostSubmitFunc>,
     ) {
-        for (i, cascade) in self.cascades.iter_mut().enumerate() {
+        for cascade in self.cascades.iter_mut() {
             profiling::scope!("Shadow dynamic render");
             self.renderer.run_collect(
                 gpu,
@@ -201,9 +201,8 @@ impl ShadowsRenderer {
                 &mut cascade.collect_state,
                 mesh_buffer,
             );
-            let label = format!("Shadow cascade {i}");
             let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some(&label),
+                label: Some("Shadow cascade"),
                 color_attachments: &[],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
                     view: &cascade.dynamic_target,

--- a/crates/renderer/src/skinning.rs
+++ b/crates/renderer/src/skinning.rs
@@ -65,7 +65,7 @@ impl SkinsBuffer {
         Self {
             buffer: TypedBuffer::new(
                 gpu,
-                "SkinsBuffer.buffer",
+                Some("SkinsBuffer.buffer"),
                 1,
                 wgpu::BufferUsages::STORAGE
                     | wgpu::BufferUsages::COPY_SRC

--- a/crates/renderer/src/transparent_renderer.rs
+++ b/crates/renderer/src/transparent_renderer.rs
@@ -49,7 +49,7 @@ impl TransparentRenderer {
     pub fn new(gpu: &Gpu, config: TransparentRendererConfig) -> Self {
         let gpu_primitives = TypedBuffer::new(
             gpu,
-            "TransparentRenderer.primitives",
+            Some("TransparentRenderer.primitives"),
             1,
             wgpu::BufferUsages::STORAGE
                 | wgpu::BufferUsages::COPY_DST

--- a/crates/sky/src/lib.rs
+++ b/crates/sky/src/lib.rs
@@ -148,7 +148,7 @@ impl CloudMaterial {
     pub fn new(gpu: &Gpu, assets: &AssetCache, state: &CloudState) -> Self {
         let cloud_buffer = TypedBuffer::new(
             gpu,
-            "Cloud Buffer",
+            Some("Cloud Buffer"),
             state.tree.len().max(64) as usize,
             BufferUsages::STORAGE | BufferUsages::COPY_DST | BufferUsages::COPY_SRC,
         );


### PR DESCRIPTION
Just addressing the biggest offenders in time for 0.3.
String labels cross the js boundary and make calls to wgpu more expensive.
Ideally we would wrap the wgpu calls so that labels would be elided in non dev builds.

The downside is we lose some debug information until we find a more general solution.