### PR TITLE
fix #894 - web cursor locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "ambient_ecs",
  "ambient_native_std",
  "ambient_shared_types",
+ "flume 0.11.0",
  "glam 0.24.1",
  "serde",
  "tracing",

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -350,6 +350,12 @@ impl AppBuilder {
             (Some(window), Some(event_loop))
         };
 
+        let (cursor_lock_tx, cursor_lock_rx) = flume::unbounded::<bool>();
+
+        // This isn't necessary on native
+        #[cfg(not(target_os = "unknown"))]
+        let _ = cursor_lock_tx;
+
         #[cfg(target_os = "unknown")]
         let mut drop_handles: Vec<Box<dyn std::fmt::Debug>> = Vec::new();
 
@@ -359,12 +365,11 @@ impl AppBuilder {
             use winit::platform::web::WindowExtWebSys;
 
             let canvas = window.canvas();
+            let document = web_sys::window().unwrap().document().unwrap();
 
-            let target = self.parent_element.unwrap_or_else(|| {
-                let window = web_sys::window().unwrap();
-                let document = window.document().unwrap();
-                document.body().unwrap()
-            });
+            let target = self
+                .parent_element
+                .unwrap_or_else(|| document.body().unwrap());
 
             use wasm_bindgen::prelude::*;
 
@@ -373,8 +378,33 @@ impl AppBuilder {
             });
 
             canvas.set_oncontextmenu(Some(on_context_menu.as_ref().unchecked_ref()));
-
             drop_handles.push(Box::new(on_context_menu));
+
+            // HACK: Listen for pointer lock change here to ensure that the guest
+            // is notified that the pointer is no longer locked, so that they can
+            // update their state accordingly.
+            //
+            // It would be nice to move this into the input systems, but I don't
+            // want to leak too much information about the running environment
+            // into other code.
+            let on_pointer_lock_change = Closure::<dyn Fn()>::new({
+                let canvas = canvas.clone();
+                let document = document.clone();
+                move || {
+                    let is_locked =
+                        document.pointer_lock_element().as_ref() == Some(canvas.as_ref());
+
+                    let _ = cursor_lock_tx.send(is_locked);
+                }
+            });
+            document
+                .add_event_listener_with_callback_and_bool(
+                    "pointerlockchange",
+                    on_pointer_lock_change.as_ref().unchecked_ref(),
+                    false,
+                )
+                .unwrap();
+            drop_handles.push(Box::new(on_pointer_lock_change));
 
             // Get the screen's available width and height
             let window = web_sys::window().unwrap();
@@ -502,6 +532,7 @@ impl AppBuilder {
                 vec![
                     Box::new(MeshBufferUpdate),
                     Box::new(world_instance_systems(true)),
+                    ambient_input::cursor_lock_system(cursor_lock_rx),
                 ],
             ),
             world,

--- a/crates/ecs/src/generated.rs
+++ b/crates/ecs/src/generated.rs
@@ -1410,6 +1410,35 @@ mod raw {
             }
             impl RuntimeMessage for WindowMouseMotion {}
             #[derive(Clone, Debug)]
+            #[doc = "**WindowCursorLockChange**: Sent when the window's cursor lock changes."]
+            pub struct WindowCursorLockChange {
+                pub locked: bool,
+            }
+            impl WindowCursorLockChange {
+                #[allow(clippy::too_many_arguments)]
+                pub fn new(locked: impl Into<bool>) -> Self {
+                    Self {
+                        locked: locked.into(),
+                    }
+                }
+            }
+            impl Message for WindowCursorLockChange {
+                fn id() -> &'static str {
+                    "ambient_core::WindowCursorLockChange"
+                }
+                fn serialize_message(&self) -> Result<Vec<u8>, MessageSerdeError> {
+                    let mut output = vec![];
+                    self.locked.serialize_message_part(&mut output)?;
+                    Ok(output)
+                }
+                fn deserialize_message(mut input: &[u8]) -> Result<Self, MessageSerdeError> {
+                    Ok(Self {
+                        locked: bool::deserialize_message_part(&mut input)?,
+                    })
+                }
+            }
+            impl RuntimeMessage for WindowCursorLockChange {}
+            #[derive(Clone, Debug)]
             #[doc = "**HttpResponse**: Sent when an HTTP response is received."]
             pub struct HttpResponse {
                 pub url: String,

--- a/crates/input/Cargo.toml
+++ b/crates/input/Cargo.toml
@@ -18,3 +18,4 @@ winit = { workspace = true }
 glam = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
+flume = { workspace = true }

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use ambient_ecs::{
-    components, generated::messages, world_events, Debuggable, Entity, Resource, System,
+    components, generated::messages, world_events, Debuggable, Entity, FnSystem, Resource, System,
     SystemGroup, WorldEventsExt,
 };
 use glam::{vec2, Vec2};
@@ -47,6 +47,16 @@ pub fn init_all_components() {
 
 pub fn event_systems() -> SystemGroup<Event<'static, ()>> {
     SystemGroup::new("inputs", vec![Box::new(InputSystem::new())])
+}
+
+pub fn cursor_lock_system(cursor_lock_rx: flume::Receiver<bool>) -> Box<dyn System + Send + Sync> {
+    Box::new(FnSystem::new(move |world, _event| {
+        for state in cursor_lock_rx.drain() {
+            world
+                .resource_mut(world_events())
+                .add_message(messages::WindowCursorLockChange::new(state));
+        }
+    }))
 }
 
 pub fn resources() -> Entity {

--- a/crates/wasm/src/client/implementation/specific.rs
+++ b/crates/wasm/src/client/implementation/specific.rs
@@ -137,7 +137,7 @@ impl wit::client_input::Host for Bindings {
 
             #[cfg(target_os = "unknown")]
             {
-                CursorGrabMode::Confined
+                CursorGrabMode::Locked
             }
         } else {
             CursorGrabMode::None

--- a/guest/rust/api_core/src/internal/generated.rs
+++ b/guest/rust/api_core/src/internal/generated.rs
@@ -5325,6 +5325,35 @@ mod raw {
             }
             impl RuntimeMessage for WindowMouseMotion {}
             #[derive(Clone, Debug)]
+            #[doc = "**WindowCursorLockChange**: Sent when the window's cursor lock changes."]
+            pub struct WindowCursorLockChange {
+                pub locked: bool,
+            }
+            impl WindowCursorLockChange {
+                #[allow(clippy::too_many_arguments)]
+                pub fn new(locked: impl Into<bool>) -> Self {
+                    Self {
+                        locked: locked.into(),
+                    }
+                }
+            }
+            impl Message for WindowCursorLockChange {
+                fn id() -> &'static str {
+                    "ambient_core::WindowCursorLockChange"
+                }
+                fn serialize_message(&self) -> Result<Vec<u8>, MessageSerdeError> {
+                    let mut output = vec![];
+                    self.locked.serialize_message_part(&mut output)?;
+                    Ok(output)
+                }
+                fn deserialize_message(mut input: &[u8]) -> Result<Self, MessageSerdeError> {
+                    Ok(Self {
+                        locked: bool::deserialize_message_part(&mut input)?,
+                    })
+                }
+            }
+            impl RuntimeMessage for WindowCursorLockChange {}
+            #[derive(Clone, Debug)]
             #[doc = "**HttpResponse**: Sent when an HTTP response is received."]
             pub struct HttpResponse {
                 pub url: String,

--- a/guest/rust/packages/std/hide_cursor/src/client.rs
+++ b/guest/rust/packages/std/hide_cursor/src/client.rs
@@ -1,6 +1,6 @@
 use ambient_api::{
     core::{
-        messages::Frame,
+        messages::{Frame, WindowCursorLockChange},
         transform::components::translation,
         ui::{components::focusable, messages::FocusChanged},
     },
@@ -26,6 +26,7 @@ pub fn main() {
         .el()
         .with(focusable(), GAME_FOCUS_ID.to_string())
         .spawn_interactive();
+
     Frame::subscribe(move |_| {
         if is_game_focused() {
             let input = input::get();
@@ -34,8 +35,14 @@ pub fn main() {
             }
         }
     });
+    WindowCursorLockChange::subscribe(|msg| {
+        if is_game_focused() && !msg.locked {
+            input::set_focus("Nothing");
+        }
+    });
     FocusChanged::subscribe(|_, _| {
         update();
     });
+
     update();
 }

--- a/schema/schema/ambient.toml
+++ b/schema/schema/ambient.toml
@@ -95,6 +95,11 @@ name = "Window Mouse Motion"
 description = "Sent when the window receives a mouse motion input."
 fields = { delta = "Vec2" }
 
+[messages.WindowCursorLockChange]
+name = "Window Cursor Lock Change"
+description = "Sent when the window's cursor lock changes."
+fields = { locked = "Bool" }
+
 [messages.HttpResponse]
 name = "HTTP Response"
 description = "Sent when an HTTP response is received."

--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "ambient_ecs",
  "ambient_native_std",
  "ambient_shared_types",
+ "flume 0.11.0",
  "glam",
  "serde",
  "tracing",


### PR DESCRIPTION
`Confined` isn't supported on the web, but `Locked` is. Fixing that made cursor locking work, but then there were issues where you'd release the lock in the browser but the game still thought you were locked. Fixed this by propagating the window-lock state to the guest.

@ten3roberts at some point you may want to check my use of `add_event_listener` here, I have no idea if it gets cleaned up