### PR TITLE
feat(ci): release-version drive other workflows

### DIFF
--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -3,7 +3,7 @@
 name: Deploy packages
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -1,11 +1,7 @@
 name: Deploy server
 
 on:
-  workflow_dispatch:
-  push:
-    tags: [v*]
-    branches:
-      - main
+  workflow_dispatch: {}
 
 env:
   CARGO_TERM_COLOR: always
@@ -76,14 +72,12 @@ jobs:
       - name: Prepare canary
         if: github.ref == 'refs/heads/main'
         shell: bash
-        run:
-          cp "${{ env.BUILD_DIR }}/${{ env.SERVER_BINARY_NAME }}" "${{ env.BUILD_DIR }}/${{ env.CANARY_SERVER_BINARY_NAME }}"
+        run: cp "${{ env.BUILD_DIR }}/${{ env.SERVER_BINARY_NAME }}" "${{ env.BUILD_DIR }}/${{ env.CANARY_SERVER_BINARY_NAME }}"
 
       - name: Prepare versioned
         if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
-        run:
-          cp "${{ env.BUILD_DIR }}/${{ env.SERVER_BINARY_NAME }}" "${{ env.BUILD_DIR }}/ambient-${GITHUB_REF#refs/tags/v}"
+        run: cp "${{ env.BUILD_DIR }}/${{ env.SERVER_BINARY_NAME }}" "${{ env.BUILD_DIR }}/ambient-${GITHUB_REF#refs/tags/v}"
 
       - name: Upload ambient server binary
         uses: google-github-actions/upload-cloud-storage@v1

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,11 +1,7 @@
 name: Deploy web client
 
 on:
-  workflow_dispatch:
-  push:
-    tags: [v*]
-    branches:
-      - main
+  workflow_dispatch: {}
 
 env:
   PACKAGE_NAME: ambient-web-${{ github.sha }}
@@ -28,7 +24,6 @@ jobs:
           sudo apt-get install --no-install-recommends -y tree libasound2-dev libglib2.0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libcairo-dev libgtk2.0-dev libsoup2.4-dev libgtk-3-dev libwebkit2gtk-4.0-dev xorg-dev ninja-build libxcb-render0-dev
       - uses: actions/checkout@v3
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -83,8 +78,7 @@ jobs:
         # ref example: refs/tags/v0.3.0-nightly-2023-09-05
         if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
-        run:
-          echo "tagged_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+        run: echo "tagged_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
       - name: Upload tagged version to Google Cloud
         # Only upload if triggered for a tag

--- a/.github/workflows/publish-api.yml
+++ b/.github/workflows/publish-api.yml
@@ -1,5 +1,4 @@
 # This workflow is triggered on demand and publishes the API.
-# TODO: Have release-version call this instead of duplicating the logic
 
 name: Publish API
 

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -5,7 +5,7 @@
 name: Release
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
   push:
     tags: [v*]
     branches:
@@ -146,16 +146,15 @@ jobs:
           destination: "ambient-artifacts/ambient-builds/${{ needs.meta.outputs.version }}/${{ matrix.os }}"
       - name: Upload debug symbols
         run: sentry-cli upload-dif -o dims -p native-client ${{ env.EXE_DIR }}/${{ matrix.exe_name }} ${{ env.EXE_DIR }}/${{ matrix.symbol_path }}
-
-  publish-api:
-    if: needs.meta.outputs.kind == 'full'
-    needs: [meta, build-app]
-    runs-on: ubuntu-22.04
-    env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - run: rustup target add --toolchain stable wasm32-wasi
-      - name: Release all packages required for API
-        run: cargo campfire-slim release publish --execute
+      - name: Trigger build jobs
+        uses: actions/github-script@v6
+        with:
+          script: |
+            for (const workflow_id of ['deploy-server.yml', 'deploy-web.yml', 'deploy-packages.yml', 'publish-api.yml']) {
+              github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflow_id,
+                ref: '${{ steps.meta.outputs.tag }}',
+              })
+            }

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            for (const workflow_id of ['deploy-server.yml', 'deploy-web.yml', 'deploy-packages.yml', 'publish-api.yml']) {
+            for (const workflow_id of ['deploy-server.yml', 'deploy-web.yml', 'deploy-packages.yml']) {
               github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -158,3 +158,20 @@ jobs:
                 ref: '${{ steps.meta.outputs.tag }}',
               })
             }
+
+  publish-api:
+    if: needs.meta.outputs.kind == 'full'
+    needs: [meta, build-app]
+    runs-on: ubuntu-22.04
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'publish-api.yml',
+              ref: '${{ steps.meta.outputs.tag }}',
+            })

--- a/.github/workflows/tag-internal.yml
+++ b/.github/workflows/tag-internal.yml
@@ -8,9 +8,9 @@ on:
       suffix:
         description: 'Suffix to add to the version number (e.g. suffix "testing" will create a version like "0.3.0-internal-testing")'
         required: true
-        default: 'fancy-new-feature'
+        default: "fancy-new-feature"
   schedule:
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
 
 env:
   CARGO_TERM_COLOR: always
@@ -66,11 +66,9 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            for (const workflow_id of ['deploy-server.yml', 'release-version.yml', 'deploy-web.yml', 'deploy-packages.yml']) {
-              github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: workflow_id,
-                ref: '${{ steps.tag.outputs.tag }}',
-              })
-            }
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release-version.yml',
+              ref: '${{ steps.tag.outputs.tag }}',
+            })


### PR DESCRIPTION
I *think* this should work, but I'm going to get a second pair of eyes before I merge it.

The idea is that `release-version` always kicks off the other workflows, and `tag-nightly` sets up the environment for `release-version` and then calls it. This should lead to consistent behaviour when cutting a release.