### PR TITLE
fix(web): water using the same trick as the atmosphere

### DIFF
--- a/crates/water/src/water.wgsl
+++ b/crates/water/src/water.wgsl
@@ -32,9 +32,9 @@ fn screen_space_reflections(world_position: vec3<f32>, screen_ray_dir: vec3<f32>
         if screen_tc.x < 0. || screen_tc.x >= 1. || screen_tc.y < 0. || screen_tc.y >= 1. {
             continue;
         }
-        let screen_depth = textureSampleLevel(solids_screen_depth, default_sampler, screen_tc, 0.);
-        if pos_ndc.z >= screen_depth && pos_ndc.z < screen_depth * 1.001 && screen_depth < 0.9999 {
-            return textureSampleLevel(solids_screen_color, default_sampler, screen_tc, 0.).rgb;
+        let screen_depth = textureSample(solids_screen_depth, default_sampler, screen_tc);
+        if pos_ndc.z >= screen_depth && pos_ndc.z < screen_depth * 1.001 && screen_depth < 0.999 {
+            return textureSample(solids_screen_color, default_sampler, screen_tc).rgb;
         }
         step = step * 2.;
         pos = pos + step;

--- a/web/client/src/app.rs
+++ b/web/client/src/app.rs
@@ -67,7 +67,7 @@ fn systems() -> SystemGroup {
             // Box::new(ambient_decals::client_systems()),
             Box::new(ambient_primitives::systems()),
             Box::new(ambient_sky::systems()),
-            // Box::new(ambient_water::systems()),
+            Box::new(ambient_water::systems()),
             // Box::new(ambient_physics::client_systems()),
             // Box::new(ambient_gizmos::client_systems()),
             Box::new(wasm::systems()),


### PR DESCRIPTION
The textureSampleLevel is buggy on wgpu and does not accept a int for depth comparison.

Is there a specific reason the compare*Level* was used, rather than a normal texture sample. Did it fix a specific bug in the past? The git log goes back to the `Init` squash.