### PR TITLE
Use --feature production on cf deploy-all

### DIFF
--- a/campfire/src/join.rs
+++ b/campfire/src/join.rs
@@ -58,5 +58,5 @@ pub fn main(join: &Join) -> anyhow::Result<()> {
         args.extend(join.params.args.iter().map(|s| s.as_str()));
     }
 
-    run_ambient(&args, join.params.release)
+    run_ambient(&args, join.params.release, false)
 }

--- a/campfire/src/package.rs
+++ b/campfire/src/package.rs
@@ -164,7 +164,11 @@ pub fn build_all() -> anyhow::Result<()> {
     let package_paths = get_all_packages(true, true, true)?;
 
     for path in &package_paths {
-        run_ambient(&["build", &path.to_string_lossy(), "--clean-build"], true)?;
+        run_ambient(
+            &["build", &path.to_string_lossy(), "--clean-build"],
+            true,
+            false,
+        )?;
     }
 
     Ok(())
@@ -185,7 +189,7 @@ pub fn deploy_all(token: &str, include_examples: bool) -> anyhow::Result<()> {
     args.push(token);
     args.push("--clean-build");
 
-    run_ambient(&args, true)
+    run_ambient(&args, true, true)
 }
 
 fn run_package(run_cmd: &str, path: &Path, params: &RunParams) -> anyhow::Result<()> {
@@ -195,7 +199,7 @@ fn run_package(run_cmd: &str, path: &Path, params: &RunParams) -> anyhow::Result
     if !params.args.is_empty() {
         args.extend(params.args.iter().map(|s| s.as_str()));
     }
-    run_ambient(&args, params.release)
+    run_ambient(&args, params.release, false)
 }
 
 pub fn get_all_packages(
@@ -284,7 +288,11 @@ fn get_all_examples(include_testcases: bool) -> anyhow::Result<Vec<PathBuf>> {
 fn regenerate_ids() -> anyhow::Result<()> {
     for path in get_all_packages(true, true, true)? {
         println!("Regenerating ID for {path:?}");
-        run_ambient(&["package", "regenerate-id", &path.to_string_lossy()], true)?;
+        run_ambient(
+            &["package", "regenerate-id", &path.to_string_lossy()],
+            true,
+            false,
+        )?;
     }
 
     Ok(())

--- a/campfire/src/util.rs
+++ b/campfire/src/util.rs
@@ -1,11 +1,14 @@
 use std::{fs::DirEntry, path::Path};
 
-pub fn run_ambient(args: &[&str], release: bool) -> anyhow::Result<()> {
+pub fn run_ambient(args: &[&str], release: bool, production: bool) -> anyhow::Result<()> {
     // TODO: consider running other versions of Ambient
     let mut command = std::process::Command::new("cargo");
     command.arg("run");
     if release {
         command.arg("--release");
+    }
+    if production {
+        command.args(["--features", "production"]);
     }
     command.args(["-p", "ambient"]).args(args).spawn()?.wait()?;
 


### PR DESCRIPTION
The `production` feature flag is needed to enable `assimp`, which is needed for to deploy the assimp example. It's only adding that feature flag for deploy-all now though.

It feels like deploy-all should be moved to `ambient` runtime instead though, that that the ci job should just use the latest ambient runtime? (Instead of building at again)