### PR TITLE
Allow for Chrome app selection in `campfire web open-browser`

### DIFF
--- a/campfire/src/web/mod.rs
+++ b/campfire/src/web/mod.rs
@@ -14,7 +14,7 @@ pub enum Web {
     Check(BuildOptions),
     /// Launches chrome with the correct flags to explicitly trust
     /// the self-signed certificate
-    OpenBrowser,
+    OpenBrowser(browser::BrowserOptions),
     #[cfg(feature = "serve")]
     Serve(serve::Serve),
 }
@@ -26,7 +26,7 @@ pub async fn run(command: Web) -> anyhow::Result<()> {
             Ok(())
         }
         Web::Check(args) => args.check().await,
-        Web::OpenBrowser => browser::open().await,
+        Web::OpenBrowser(args) => browser::open(args).await,
         #[cfg(feature = "serve")]
         Web::Serve(args) => args.run().await,
     }


### PR DESCRIPTION
I just want to be able to run: `cargo cf web open-browser -a 'Google Chrome Canary'` on my mac. Not sure how much it makes sense for other OSes. Tested on:
- [x] macOS
- [x] Windows
- [ ] ~~Linux~~ - I don't have Linux installed anywhere that is useable for this.

Also fixes URL passing on macOS.