### PR TITLE
Fix `ambient_api` dep version in new project

### DIFF
--- a/app/src/cli/package/new.rs
+++ b/app/src/cli/package/new.rs
@@ -189,6 +189,9 @@ fn build_cargo_toml(
                 if let Some(api_path) = api_path {
                     log::info!("Ambient path: {}", api_path);
                     format!("ambient_api = {{ path = {:?} }}", api_path)
+                } else if version.is_released_version() {
+                    log::info!("Ambient version: {}", version.version);
+                    format!("ambient_api = \"{}\"", version.version)
                 } else if let Some(tag) = version.tag() {
                     log::info!("Ambient tag: {}", tag);
                     format!("ambient_api = {{ git = \"https://github.com/AmbientRun/Ambient.git\", tag = \"{}\" }}", tag)

--- a/crates/native_std/src/lib.rs
+++ b/crates/native_std/src/lib.rs
@@ -157,6 +157,11 @@ impl AmbientVersion {
         (self.version.pre.is_empty() || self.version.pre.starts_with("nightly-"))
             .then(|| format!("v{}", self.version))
     }
+
+    /// True if this is a full released version (that is there's a tag, uploaded build and api is released to crates.io).
+    pub fn is_released_version(&self) -> bool {
+        self.version.pre.is_empty() && self.version.build.is_empty()
+    }
 }
 
 impl Default for AmbientVersion {


### PR DESCRIPTION
https://github.com/AmbientRun/Ambient/issues/1033

Not sure if we should include release candidates in this too - waiting for opinions.

Tested with `cargo cf release update-version 0.3.1` followed by `cargo run -- new ...`.