### PR TITLE
Fix misuse of overly verbose log levels and unify use of log and tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,6 @@ dependencies = [
  "glam 0.24.2",
  "image",
  "image_hasher",
- "log",
  "parking_lot",
  "rpassword",
  "rustls-pemfile",
@@ -169,7 +168,6 @@ dependencies = [
  "toml_edit",
  "tower-http",
  "tracing",
- "tracing-log",
  "tracing-stackdriver",
  "tracing-subscriber",
  "tracing-tree",
@@ -193,9 +191,9 @@ dependencies = [
  "async-trait",
  "glam 0.24.2",
  "itertools",
- "log",
  "ordered-float 3.9.1",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -330,7 +328,6 @@ dependencies = [
  "hound",
  "itertools",
  "lewton",
- "log",
  "lyon",
  "macroquad",
  "num",
@@ -382,7 +379,6 @@ dependencies = [
  "glob",
  "image",
  "itertools",
- "log",
  "parking_lot",
  "rand 0.8.5",
  "relative-path",
@@ -442,9 +438,9 @@ dependencies = [
  "ambient_native_std",
  "ambient_sys",
  "anyhow",
- "log",
  "reqwest",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -527,7 +523,7 @@ dependencies = [
  "ambient_renderer",
  "env_logger 0.10.0",
  "glam 0.24.2",
- "log",
+ "tracing",
 ]
 
 [[package]]
@@ -540,12 +536,12 @@ dependencies = [
  "ambient_sys",
  "anyhow",
  "flume 0.11.0",
- "log",
  "md-5",
  "prost",
  "tokio",
  "tokio-stream",
  "tonic",
+ "tracing",
  "walkdir",
 ]
 
@@ -576,7 +572,6 @@ dependencies = [
  "erased-serde",
  "glam 0.24.2",
  "itertools",
- "log",
  "once_cell",
  "parking_lot",
  "paste",
@@ -642,7 +637,6 @@ dependencies = [
  "glam 0.24.2",
  "image",
  "itertools",
- "log",
  "ordered-float 3.9.1",
  "parking_lot",
  "physxx",
@@ -742,10 +736,10 @@ dependencies = [
  "bytemuck",
  "dashmap",
  "glam 0.24.2",
- "log",
  "once_cell",
  "profiling",
  "serde",
+ "tracing",
  "wgpu 0.16.3",
 ]
 
@@ -767,7 +761,6 @@ dependencies = [
  "glam 0.24.2",
  "image",
  "itertools",
- "log",
  "ndarray",
  "ordered-float 3.9.1",
  "parking_lot",
@@ -866,8 +859,8 @@ dependencies = [
  "ambient_input",
  "glam 0.24.2",
  "itertools",
- "log",
  "profiling",
+ "tracing",
 ]
 
 [[package]]
@@ -945,7 +938,6 @@ dependencies = [
  "image",
  "indexmap 2.0.2",
  "itertools",
- "log",
  "ordered-float 3.9.1",
  "physxx",
  "relative-path",
@@ -953,6 +945,7 @@ dependencies = [
  "russimp",
  "serde_json",
  "tokio",
+ "tracing",
  "winit",
 ]
 
@@ -976,7 +969,6 @@ dependencies = [
  "data-encoding",
  "futures",
  "glam 0.24.2",
- "log",
  "mikktspace",
  "ordered-float 3.9.1",
  "percent-encoding",
@@ -1056,7 +1048,6 @@ dependencies = [
  "http",
  "itertools",
  "js-sys",
- "log",
  "parking_lot",
  "pin-project",
  "profiling",
@@ -1194,7 +1185,6 @@ dependencies = [
  "futures",
  "glam 0.24.2",
  "itertools",
- "log",
  "ordered-float 3.9.1",
  "parking_lot",
  "physxx",
@@ -1299,7 +1289,7 @@ dependencies = [
  "async-trait",
  "bytemuck",
  "glam 0.24.2",
- "log",
+ "tracing",
  "wgpu 0.16.3",
 ]
 
@@ -1331,7 +1321,6 @@ dependencies = [
  "env_logger 0.10.0",
  "glam 0.24.2",
  "itertools",
- "log",
  "ordered-float 3.9.1",
  "parking_lot",
  "profiling",
@@ -1504,8 +1493,8 @@ dependencies = [
  "async-trait",
  "glam 0.24.2",
  "glyph_brush",
- "log",
  "parking_lot",
+ "tracing",
  "wgpu 0.16.3",
 ]
 
@@ -1565,7 +1554,6 @@ dependencies = [
  "fixed-vec-deque",
  "glam 0.24.2",
  "itertools",
- "log",
  "parking_lot",
  "rand 0.8.5",
  "tokio",
@@ -1615,7 +1603,6 @@ dependencies = [
  "futures",
  "glam 0.24.2",
  "itertools",
- "log",
  "once_cell",
  "parking_lot",
  "paste",
@@ -1675,7 +1662,6 @@ dependencies = [
  "flume 0.11.0",
  "glam 0.24.2",
  "itertools",
- "log",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -2232,7 +2218,6 @@ dependencies = [
  "home",
  "indicatif",
  "itertools",
- "log",
  "nix 0.26.4",
  "notify",
  "num_cpus",
@@ -2241,11 +2226,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "simplelog",
  "spki",
  "tokio",
  "toml 0.7.8",
  "toml_edit",
+ "tracing",
+ "tracing-subscriber",
  "which",
  "x509-certificate",
 ]
@@ -7089,17 +7075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
-name = "simplelog"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
-dependencies = [
- "log",
- "termcolor",
- "time",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8006,12 +7981,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d6b63348fad3ae0439b8bebf8d38fb5bda0b115d7a8a7e6f165f12790c58c3"
+checksum = "2ec6adcab41b1391b08a308cc6302b79f8095d1673f6947c2dc65ffb028b0b2d"
 dependencies = [
- "is-terminal",
  "nu-ansi-term",
+ "time",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.70.0"
 aho-corasick = "1.1.1"
 profiling = { version = "1.0.11", features = ["profile-with-puffin"] }
 tracing = "0.1.37"
-tracing-tree = { version = "0.2" }
+tracing-tree = { version = "0.2", features = ["time"] }
 tracing-stackdriver = "0.6.2"
 tracing-subscriber = { version = "0.3.17", features = [
     "env-filter",
@@ -20,7 +20,6 @@ tracing-subscriber = { version = "0.3.17", features = [
     "local-time",
     "parking_lot",
 ] }
-tracing-log = { version = "0.1" }
 wgpu = { version = "0.16.3", features = ["serde", "trace", "replay"] }
 wgpu-types = { version = "0.16", features = ["serde"] }
 winit = { version = "0.28.6", features = ["serde"] }
@@ -38,7 +37,6 @@ ndarray = { version = "0.15.6", features = ["serde"] }
 rand = "0.8.5"
 rand_pcg = "0.3.1"
 glyph_brush = "0.7.7"
-log = "0.4"
 dyn-clonable = "0.9.0"
 semver = { version = "1.0", features = ["serde"] }
 paste = "1.0"
@@ -177,7 +175,7 @@ wasm-bindgen-futures = "0.4"
 #
 # Networking
 #
-time = { version = "0.3" }
+time = { version = "0.3", features = ["local-offset"] }
 quinn = { version = "0.10" }
 rustls-native-certs = "0.6.3"
 webpki-roots = "0.23.1"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -45,15 +45,13 @@ ambient_shared_types = { path = "../shared_crates/shared_types", features = [
 
 tracing-tree = { workspace = true, optional = true }
 tracing-stackdriver = { workspace = true, optional = true }
-tracing-subscriber = { workspace = true, optional = true }
-tracing-log = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true }
 time = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 convert_case = { workspace = true }
 env_logger = { workspace = true }
 glam = { workspace = true }
-log = { workspace = true }
 parking_lot = { workspace = true }
 rustls-pemfile = { workspace = true }
 serde = { workspace = true }
@@ -75,13 +73,12 @@ rusty-hook = "^0.11.2"
 
 [features]
 no_bundled_certs = []
-default = ["tls-webpki-roots"]
+default = ["tls-webpki-roots", "tracing-tree"]
 slim = ["stackdriver"]
 production = ["assimp"]
 profile = ["ambient_app/profile"]
 assimp = ["ambient_model_import/russimp"]
-stackdriver = ["tracing", "tracing-stackdriver"]
-tracing = ["tracing-tree", "tracing-subscriber", "tracing-log"]
+stackdriver = ["tracing-stackdriver"]
 tls-native-roots = ["ambient_network/tls-native-roots"]
 tls-webpki-roots = ["ambient_network/tls-webpki-roots"]
 hotload-includes = [

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -73,7 +73,7 @@ rusty-hook = "^0.11.2"
 
 [features]
 no_bundled_certs = []
-default = ["tls-webpki-roots", "tracing-tree"]
+default = ["tls-webpki-roots"]
 slim = ["stackdriver"]
 production = ["assimp"]
 profile = ["ambient_app/profile"]

--- a/app/src/cli/package/deploy.rs
+++ b/app/src/cli/package/deploy.rs
@@ -52,7 +52,7 @@ pub async fn handle(args: &Deploy, assets: &AssetCache, release_build: bool) -> 
     if !release_build {
         // Using string interpolation due to a rustfmt bug where it will break
         // if any one line is too long
-        log::warn!(
+        tracing::warn!(
             "{} {}",
             "Deploying a debug build which might involve uploading large files.",
             "Remove `--debug` to deploy a release build."
@@ -218,7 +218,7 @@ pub async fn handle(args: &Deploy, assets: &AssetCache, release_build: bool) -> 
 
         match deployment_id {
             Deployment::Skipped => {
-                log::info!(
+                tracing::info!(
                     "Package \"{main_package_name}\" was already deployed, skipping deployment"
                 );
             }
@@ -238,10 +238,10 @@ pub async fn handle(args: &Deploy, assets: &AssetCache, release_build: bool) -> 
                     Some(&deployment_id),
                 );
 
-                log::info!("Package \"{main_package_name}\" deployed successfully!");
-                log::info!("  Deployment ID: {deployment_id}");
-                log::info!("  Join: ambient join '{ensure_running_url}'");
-                log::info!("  Web URL: '{}'", web_url.bright_green());
+                tracing::info!("Package \"{main_package_name}\" deployed successfully!");
+                tracing::info!("  Deployment ID: {deployment_id}");
+                tracing::info!("  Join: ambient join '{ensure_running_url}'");
+                tracing::info!("  Web URL: '{}'", web_url.bright_green());
 
                 if first_deployment_id.is_none() {
                     first_deployment_id = Some(deployment_id);
@@ -256,7 +256,7 @@ pub async fn handle(args: &Deploy, assets: &AssetCache, release_build: bool) -> 
         let server =
             ambient_cloud_client::ensure_server_running(assets, api_server, token.into(), spec)
                 .await?;
-        log::info!("Deployed package is running at {}", server.host);
+        tracing::info!("Deployed package is running at {}", server.host);
     }
 
     Ok(())

--- a/app/src/cli/package/new.rs
+++ b/app/src/cli/package/new.rs
@@ -152,13 +152,13 @@ pub(crate) async fn handle(args: &New, assets: &AssetCache) -> anyhow::Result<()
         std::fs::write(&path, contents).with_context(|| format!("Failed to create {path:?}"))?;
     }
 
-    log::info!("Package \"{name}\" created; doing first build");
+    tracing::info!("Package \"{name}\" created; doing first build");
 
     // Build the new package to ensure that the user can use it immediately, and to have the proc-macro
     // ready for rust-analyzer to use
     build::handle_inner(&args.package, assets, false).await?;
 
-    log::info!("Package \"{name}\" built successfully - ready to go at {package_path:?}");
+    tracing::info!("Package \"{name}\" built successfully - ready to go at {package_path:?}");
 
     Ok(())
 }
@@ -187,19 +187,19 @@ fn build_cargo_toml(
             let version = ambient_version();
             (
                 if let Some(api_path) = api_path {
-                    log::info!("Ambient path: {}", api_path);
+                    tracing::info!("Ambient path: {}", api_path);
                     format!("ambient_api = {{ path = {:?} }}", api_path)
                 } else if version.is_released_version() {
-                    log::info!("Ambient version: {}", version.version);
+                    tracing::info!("Ambient version: {}", version.version);
                     format!("ambient_api = \"{}\"", version.version)
                 } else if let Some(tag) = version.tag() {
-                    log::info!("Ambient tag: {}", tag);
+                    tracing::info!("Ambient tag: {}", tag);
                     format!("ambient_api = {{ git = \"https://github.com/AmbientRun/Ambient.git\", tag = \"{}\" }}", tag)
                 } else if !version.revision.is_empty() {
-                    log::info!("Ambient revision: {}", version.revision);
+                    tracing::info!("Ambient revision: {}", version.revision);
                     format!("ambient_api = {{ git = \"https://github.com/AmbientRun/Ambient.git\", rev = \"{}\" }}", version.revision)
                 } else {
-                    log::info!("Ambient version: {}", version.version);
+                    tracing::info!("Ambient version: {}", version.version);
                     format!("ambient_api = \"{}\"", version.version)
                 },
                 false,

--- a/app/src/cli/package/serve.rs
+++ b/app/src/cli/package/serve.rs
@@ -80,7 +80,7 @@ fn get_crypto(host: &HostCli) -> anyhow::Result<ambient_network::native::server:
         }
         #[cfg(not(feature = "no_bundled_certs"))]
         {
-            tracing::info!("Using bundled certificate and key");
+            tracing::debug!("Using bundled certificate and key");
             return Ok(ambient_network::native::server::Crypto {
                 cert_chain: vec![CERT.to_vec()],
                 key: CERT_KEY.to_vec(),

--- a/app/src/client/mod.rs
+++ b/app/src/client/mod.rs
@@ -46,7 +46,7 @@ pub fn run(
         match AudioStream::new() {
             Ok(v) => Some(v),
             Err(err) => {
-                log::error!("Failed to initialize audio stream: {err}");
+                tracing::error!("Failed to initialize audio stream: {err}");
                 None
             }
         }
@@ -60,7 +60,7 @@ pub fn run(
         Some(user_id) => user_id,
         None => {
             let user_id = ambient_client_shared::util::random_username();
-            log::warn!(
+            tracing::warn!(
                 "No `user_id` found in settings, using random username: {:?}",
                 user_id
             );
@@ -212,7 +212,7 @@ fn MainApp(
                 set_loaded(true);
 
                 Ok(Box::new(|| {
-                    log::info!("Disconnecting client");
+                    tracing::info!("Disconnecting client");
                 }))
             }),
             systems_and_resources: cb(|| {

--- a/app/src/client/wasm.rs
+++ b/app/src/client/wasm.rs
@@ -22,7 +22,7 @@ pub fn initialize(
                 MessageType::Info => tracing::info!(%module_name, "{}", message),
                 MessageType::Warn => tracing::warn!(%module_name, "{}", message),
                 MessageType::Error => tracing::error!(%module_name, "{}", message),
-                MessageType::Stdout => tracing::info!(%module_name, "stdout {}", message),
+                MessageType::Stdout => tracing::info!(%module_name, "stdout: {}", message),
                 MessageType::Stderr => tracing::info!(%module_name, "stderr: {}", message),
             };
         },

--- a/app/src/client/wasm.rs
+++ b/app/src/client/wasm.rs
@@ -15,21 +15,16 @@ pub fn initialize(
     mixer: Option<AudioMixer>,
 ) -> anyhow::Result<()> {
     let messenger = Arc::new(
-        |world: &World, id: EntityId, type_: MessageType, message: &str| {
-            let name = world.get_cloned(id, module_name()).unwrap_or_default();
-            let (prefix, level) = match type_ {
-                MessageType::Info => ("info", log::Level::Info),
-                MessageType::Warn => ("warn", log::Level::Warn),
-                MessageType::Error => ("error", log::Level::Error),
-                MessageType::Stdout => ("stdout", log::Level::Info),
-                MessageType::Stderr => ("stderr", log::Level::Info),
-            };
+        |world: &World, id: EntityId, ty: MessageType, message: &str| {
+            let module_name = world.get_cloned(id, module_name()).unwrap_or_default();
 
-            log::log!(
-                level,
-                "[{name}] {prefix}: {}",
-                message.strip_suffix('\n').unwrap_or(message)
-            );
+            match ty {
+                MessageType::Info => tracing::info!(%module_name, "{}", message),
+                MessageType::Warn => tracing::warn!(%module_name, "{}", message),
+                MessageType::Error => tracing::error!(%module_name, "{}", message),
+                MessageType::Stdout => tracing::info!(%module_name, "stdout {}", message),
+                MessageType::Stderr => tracing::info!(%module_name, "stderr: {}", message),
+            };
         },
     );
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -210,7 +210,7 @@ fn setup_logging() -> anyhow::Result<()> {
     }
 
     #[cfg(all(not(feature = "stackdriver"), not(feature = "tracing-tree")))]
-    let format_layer = tracing_subscriber::fmt::Layer::new().with_timer(
+    let format_layer = tracing_subscriber::fmt::Layer::new().compact().with_timer(
         tracing_subscriber::fmt::time::LocalTime::new(
             time::format_description::parse("[hour]:[minute]:[second]")
                 .expect("format string should be valid!"),

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -145,7 +145,7 @@ impl LaunchJson {
 }
 
 fn setup_logging() -> anyhow::Result<()> {
-    // This fixes the `<unknown time>` in log formatting
+    // This fixes the `<unknown time>` in log formatting, an alternative is to use UTC time
     unsafe { time::util::local_offset::set_soundness(time::util::local_offset::Soundness::Unsound) }
 
     /// Create a layer of filtering before to remove info statements from external crates
@@ -185,14 +185,6 @@ fn setup_logging() -> anyhow::Result<()> {
             targets = targets.with_target(module, *level);
         }
     }
-
-    // BLOCKING: pending https://github.com/tokio-rs/tracing/issues/2507
-    // let modules: Vec<_> = MODULES.iter().flat_map(|&(level, modules)| modules.iter().map(move |&v| format!("{v}={level}"))).collect();
-
-    // eprintln!("{modules:#?}");
-
-    // let mut filter = std::env::var("RUST_LOG").unwrap_or_default().parse::<tracing_subscriber::filter::Targets>().unwrap_or_default();
-    // filter.extend(MODULES.iter().flat_map(|&(level, modules)| modules.iter().map(move |&v| (v, level.as_trace()))));
 
     let env_filter = EnvFilter::builder()
         .with_default_directive(Level::INFO.into())

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -197,7 +197,7 @@ pub async fn start(
         .await
         .unwrap();
 
-        log::info!("Starting server");
+        tracing::info!("Starting server");
         server
             .run(
                 server_world,

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -197,7 +197,7 @@ pub async fn start(
         .await
         .unwrap();
 
-        tracing::info!("Starting server");
+        tracing::debug!("Starting server");
         server
             .run(
                 server_world,

--- a/app/src/server/wasm.rs
+++ b/app/src/server/wasm.rs
@@ -25,7 +25,7 @@ pub async fn initialize(
                 MessageType::Info => tracing::info!(%module_name, "{}", message),
                 MessageType::Warn => tracing::warn!(%module_name, "{}", message),
                 MessageType::Error => tracing::error!(%module_name, "{}", message),
-                MessageType::Stdout => tracing::info!(%module_name, "stdout {}", message),
+                MessageType::Stdout => tracing::info!(%module_name, "stdout: {}", message),
                 MessageType::Stderr => tracing::info!(%module_name, "stderr: {}", message),
             };
         },

--- a/app/src/server/wasm.rs
+++ b/app/src/server/wasm.rs
@@ -19,21 +19,15 @@ pub async fn initialize(
     data_path: PathBuf,
 ) -> anyhow::Result<()> {
     let messenger = Arc::new(
-        |world: &World, id: EntityId, type_: MessageType, message: &str| {
-            let name = world.get_cloned(id, module_name()).unwrap_or_default();
-            let (prefix, level) = match type_ {
-                MessageType::Info => ("info", log::Level::Info),
-                MessageType::Warn => ("warn", log::Level::Warn),
-                MessageType::Error => ("error", log::Level::Error),
-                MessageType::Stdout => ("stdout", log::Level::Info),
-                MessageType::Stderr => ("stderr", log::Level::Info),
+        |world: &World, id: EntityId, ty: MessageType, message: &str| {
+            let module_name = world.get_cloned(id, module_name()).unwrap_or_default();
+            match ty {
+                MessageType::Info => tracing::info!(%module_name, "{}", message),
+                MessageType::Warn => tracing::warn!(%module_name, "{}", message),
+                MessageType::Error => tracing::error!(%module_name, "{}", message),
+                MessageType::Stdout => tracing::info!(%module_name, "stdout {}", message),
+                MessageType::Stderr => tracing::info!(%module_name, "stderr: {}", message),
             };
-
-            log::log!(
-                level,
-                "[{name}] {prefix}: {}",
-                message.strip_suffix('\n').unwrap_or(message)
-            );
         },
     );
 

--- a/campfire/Cargo.toml
+++ b/campfire/Cargo.toml
@@ -7,7 +7,8 @@ publish = false
 [dependencies]
 anyhow = { version = "1.0", features = [] }
 clap = { workspace = true, features = ["derive"] }
-log = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml_edit = { workspace = true }
@@ -16,10 +17,12 @@ toml = { workspace = true }
 sha2 = { workspace = true }
 data-encoding = { workspace = true }
 
+notify = { version = "6.1", optional = true }
+flume = { version = "0.11", optional = true }
+
 which = "4.4"
 rustdoc-json = "0.8.7"
 rustdoc-types = "0.20.0"
-simplelog = "0.12.1"
 cargo_toml = "0.15"
 guppy = "0.15"
 indicatif = "0.17.6"
@@ -29,9 +32,6 @@ num_cpus = "1.16.0"
 home = "0.5"
 x509-certificate = "0.21.0"
 spki = "0.7"
-
-notify = { version = "6.1", optional = true }
-flume = { version = "0.11", optional = true }
 
 # Hope this won't cause any issues!
 ambient_shared_types = { path = "../shared_crates/shared_types" }

--- a/campfire/src/doc/mod.rs
+++ b/campfire/src/doc/mod.rs
@@ -60,7 +60,7 @@ fn api(open: bool, args: &[String]) -> anyhow::Result<()> {
 // deleted it entirely
 #[allow(dead_code)]
 fn pipeline() -> anyhow::Result<()> {
-    log::info!("Generating pipeline.d.ts...");
+    tracing::info!("Generating pipeline.d.ts...");
 
     let ctx = context::Context::new(&[
         Path::new("crates/physics/Cargo.toml"),
@@ -68,7 +68,7 @@ fn pipeline() -> anyhow::Result<()> {
         Path::new("crates/build/Cargo.toml"),
     ])?;
 
-    log::info!("Built context from rustdoc.");
+    tracing::info!("Built context from rustdoc.");
 
     let (build_crate, pipeline) = ctx
         .get("ambient_build::pipelines::Pipeline")
@@ -81,7 +81,7 @@ fn pipeline() -> anyhow::Result<()> {
         std::path::Path::new("docs/src/reference/pipeline.d.ts"),
     )?;
 
-    log::info!("Done generating pipeline.d.ts.");
+    tracing::info!("Done generating pipeline.d.ts.");
 
     Ok(())
 }

--- a/campfire/src/golden_images/mod.rs
+++ b/campfire/src/golden_images/mod.rs
@@ -86,7 +86,7 @@ pub async fn main(gi: &GoldenImages) -> anyhow::Result<()> {
             .into_iter()
             .filter(|test| test.starts_with(prefix))
             .collect_vec();
-        log::info!(
+        tracing::info!(
             "--prefix {prefix} resulted in {} out of {total_test_count} tests",
             filtered_tests.len(),
         );
@@ -159,7 +159,7 @@ async fn parse_tests_from_manifest() -> anyhow::Result<Vec<PathBuf>> {
         .context("Failed to read test manifest")?;
 
     let manifest: Manifest = toml::from_str(&manifest)?;
-    log::info!(
+    tracing::info!(
         "Read manifest from '{}', parsed {} tests",
         manifest_path.display(),
         manifest.tests.len()
@@ -325,7 +325,7 @@ async fn run<S: AsRef<str>>(
             eprintln!("{failure}")
         }
 
-        log::error!(
+        tracing::error!(
             "Failed tests: \n    {}",
             failures.iter().map(|v| &v.test).join("\n    ")
         );

--- a/campfire/src/install.rs
+++ b/campfire/src/install.rs
@@ -78,7 +78,7 @@ fn install_version(suffix: &str, args: &[&str]) -> anyhow::Result<()> {
         install_root_bin.join(ambient_executable_name("")),
         &target_path,
     )?;
-    log::info!("Installed ambient to {}", target_path.display());
+    tracing::info!("Installed ambient to {}", target_path.display());
 
     Ok(())
 }

--- a/campfire/src/main.rs
+++ b/campfire/src/main.rs
@@ -12,13 +12,20 @@ pub mod web;
 
 use clap::Parser;
 use cli::Cli;
+use tracing_subscriber::filter::LevelFilter;
 
 async fn run() -> anyhow::Result<()> {
+    // A very minimal and short log output
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_max_level(LevelFilter::INFO)
+        .without_time()
+        .with_target(false)
+        .init();
+
     if !std::path::Path::new("schema/schema/ambient.toml").exists() {
         anyhow::bail!("ambient.toml not found. Please run this from the root of the Ambient repository (preferably using `cargo campfire`).");
     }
-
-    simplelog::SimpleLogger::init(simplelog::LevelFilter::Info, Default::default())?;
 
     let cli = Cli::parse();
 
@@ -46,7 +53,7 @@ fn main() -> ExitCode {
     match rt.block_on(run()) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            log::error!("{:?}", err);
+            tracing::error!("{:?}", err);
             ExitCode::FAILURE
         }
     }

--- a/campfire/src/package.rs
+++ b/campfire/src/package.rs
@@ -73,7 +73,7 @@ pub fn main(args: &Package) -> anyhow::Result<()> {
 }
 
 pub fn clean() -> anyhow::Result<()> {
-    log::info!("Cleaning examples...");
+    tracing::info!("Cleaning examples...");
     for path in get_all_packages(true, true, true)? {
         let build_path = path.join("build");
         if !build_path.exists() {
@@ -81,9 +81,9 @@ pub fn clean() -> anyhow::Result<()> {
         }
 
         std::fs::remove_dir_all(&build_path)?;
-        log::info!("Removed build directory for {}.", path.display());
+        tracing::info!("Removed build directory for {}.", path.display());
     }
-    log::info!("Done cleaning examples.");
+    tracing::info!("Done cleaning examples.");
     Ok(())
 }
 
@@ -91,7 +91,7 @@ pub fn run(args: &Run) -> anyhow::Result<()> {
     let Run { package, params } = args;
     let path = find_package(package)?;
 
-    log::info!("Running example {} (params: {params:?})...", path.display());
+    tracing::info!("Running example {} (params: {params:?})...", path.display());
     run_package("run", &path, params)
 }
 
@@ -99,7 +99,7 @@ pub fn serve(args: &Run) -> anyhow::Result<()> {
     let Run { package, params } = args;
     let path = find_package(package)?;
 
-    log::info!("Serving example {} (params: {params:?})...", path.display());
+    tracing::info!("Serving example {} (params: {params:?})...", path.display());
     run_package("serve", &path, params)
 }
 
@@ -120,7 +120,7 @@ fn list() -> anyhow::Result<()> {
 
 fn run_all(params: &RunParams) -> anyhow::Result<()> {
     for path in get_all_packages(true, true, false)? {
-        log::info!("Running example {} (params: {params:?})...", path.display());
+        tracing::info!("Running example {} (params: {params:?})...", path.display());
         run_package("run", &path, params)?;
     }
 
@@ -131,10 +131,10 @@ fn check_all() -> anyhow::Result<()> {
     // Rust
     {
         let root_path = Path::new("guest/rust");
-        log::info!("Checking Rust guest code...");
+        tracing::info!("Checking Rust guest code...");
 
         for features in ["", "client", "server", "client,server"] {
-            log::info!("Checking Rust guest code with features `{}`...", features);
+            tracing::info!("Checking Rust guest code with features `{}`...", features);
 
             let mut command = std::process::Command::new("cargo");
             command.current_dir(root_path);
@@ -154,7 +154,7 @@ fn check_all() -> anyhow::Result<()> {
             }
         }
 
-        log::info!("Checked Rust guest code.");
+        tracing::info!("Checked Rust guest code.");
     }
 
     Ok(())
@@ -259,7 +259,7 @@ fn get_all_examples(include_testcases: bool) -> anyhow::Result<Vec<PathBuf>> {
         let dirs = match all_directories_in(&examples_path) {
             Ok(v) => v,
             Err(e) => {
-                log::warn!("Failed to query examples directory at {examples_path:?}: {e}");
+                tracing::warn!("Failed to query examples directory at {examples_path:?}: {e}");
                 continue;
             }
         };

--- a/campfire/src/release.rs
+++ b/campfire/src/release.rs
@@ -481,7 +481,7 @@ fn edit_toml(
 }
 
 fn check_docker_build() -> anyhow::Result<()> {
-    log::info!("Building Docker image...");
+    tracing::info!("Building Docker image...");
     let success = Command::new("docker")
         .args(["build", ".", "-t", "ambient_campfire"])
         .spawn()?
@@ -490,13 +490,13 @@ fn check_docker_build() -> anyhow::Result<()> {
     if !success {
         anyhow::bail!("failed to build Docker image");
     }
-    log::info!("Built Docker image.");
+    tracing::info!("Built Docker image.");
 
     Ok(())
 }
 
 fn check_docker_run() -> anyhow::Result<()> {
-    log::info!("Running Docker instance...");
+    tracing::info!("Running Docker instance...");
     let success = Command::new("docker")
         .args([
             "run",
@@ -519,7 +519,7 @@ fn check_docker_run() -> anyhow::Result<()> {
     if !success {
         anyhow::bail!("failed to execute cargo run in Docker instance");
     }
-    log::info!("Ran Docker instance.");
+    tracing::info!("Ran Docker instance.");
 
     Ok(())
 }
@@ -568,7 +568,7 @@ fn check_crates_io_validity() -> anyhow::Result<()> {
 }
 
 fn check_msrv() -> anyhow::Result<()> {
-    log::info!("Checking MSRV...");
+    tracing::info!("Checking MSRV...");
 
     let msrv = {
         let output = Command::new("cargo")
@@ -629,12 +629,12 @@ fn check_msrv() -> anyhow::Result<()> {
 
     // TODO: check dockerfile
 
-    log::info!("MSRV OK.");
+    tracing::info!("MSRV OK.");
     Ok(())
 }
 
 fn check_builds() -> anyhow::Result<()> {
-    log::info!("Checking builds...");
+    tracing::info!("Checking builds...");
     let success = Command::new("cargo")
         .args(["build", "--release"])
         .spawn()?
@@ -654,18 +654,18 @@ fn check_builds() -> anyhow::Result<()> {
         anyhow::bail!("failed to build guest crate");
     }
 
-    log::info!("Builds OK.");
+    tracing::info!("Builds OK.");
     Ok(())
 }
 
 fn check_changelog() -> anyhow::Result<()> {
-    log::info!("Checking CHANGELOG...");
+    tracing::info!("Checking CHANGELOG...");
 
     // TODO: Currently unimplemented; the implementation needs to handle
     // commented out Markdown, so it has to have some degree of smarts about it
     let _changelog = std::fs::read_to_string(CHANGELOG)?;
 
-    log::info!("CHANGELOG skipped (unimplemented, see code).");
+    tracing::info!("CHANGELOG skipped (unimplemented, see code).");
     Ok(())
 }
 

--- a/campfire/src/web/build.rs
+++ b/campfire/src/web/build.rs
@@ -89,7 +89,7 @@ impl BuildOptions {
 
         command.arg("--out-dir").arg(output_path.clone());
 
-        eprintln!("Building web client {command:?}");
+        tracing::info!("Building web client {command:?}");
 
         let res = command.spawn()?.wait().await?;
 
@@ -99,14 +99,14 @@ impl BuildOptions {
 
         assert!(output_path.exists());
 
-        eprintln!("Built package: {:?}", output_path);
+        tracing::info!("Built package: {:?}", output_path);
 
         Ok(output_path)
     }
 }
 #[cfg(not(target_os = "linux"))]
 pub(crate) async fn install_wasm_pack() -> anyhow::Result<()> {
-    eprintln!("Installing wasm-pack from source");
+    tracing::info!("Installing wasm-pack from source");
     let status = Command::new("cargo")
         .args(["install", "wasm-pack"])
         .kill_on_drop(true)
@@ -123,7 +123,8 @@ pub(crate) async fn install_wasm_pack() -> anyhow::Result<()> {
 
 #[cfg(target_os = "linux")]
 pub(crate) async fn install_wasm_pack() -> anyhow::Result<()> {
-    eprintln!("Installing wasm-pack");
+    tracing::info!("Installing wasm-pack");
+
     let mut curl = std::process::Command::new("curl")
         .args([
             "https://rustwasm.github.io/wasm-pack/installer/init.sh",
@@ -163,7 +164,7 @@ pub async fn ensure_wasm_pack() -> anyhow::Result<()> {
             Ok(())
         }
         Ok(path) => {
-            eprintln!("Found installation of wasm-pack at {path:?}");
+            tracing::info!("Found installation of wasm-pack at {path:?}");
             Ok(())
         }
     }

--- a/campfire/src/web/serve.rs
+++ b/campfire/src/web/serve.rs
@@ -22,7 +22,7 @@ impl Serve {
             .await
             .context("Failed to query node_modules directory")?
         {
-            log::info!("Installing node modules");
+            tracing::info!("Installing node modules");
             tokio::process::Command::new("npm")
                 .args(["install", "-d"])
                 .current_dir("web/www")
@@ -92,7 +92,7 @@ impl Serve {
             return Ok(());
         }
 
-        log::info!("Enabled watching");
+        tracing::info!("Enabled watching");
 
         let (tx, rx) = flume::unbounded();
 
@@ -106,7 +106,7 @@ impl Serve {
                         .collect_vec();
 
                     if !paths.is_empty() {
-                        log::info!("Event: {:#?}", event.kind);
+                        tracing::info!("Event: {:#?}", event.kind);
                         let _ = tx.send(paths);
                     }
                 }
@@ -114,7 +114,7 @@ impl Serve {
 
         for entry in find_top_level_dirs(".") {
             let entry = entry?;
-            log::info!("Watching entry {entry:?}");
+            tracing::info!("Watching entry {entry:?}");
             watcher.watch(&entry.path(), RecursiveMode::Recursive)?;
         }
 
@@ -122,12 +122,12 @@ impl Serve {
             tokio::time::sleep(Duration::from_millis(1000)).await;
 
             paths.extend(rx.drain().flatten());
-            log::info!("Changed paths: {paths:?}");
-            log::info!("Rebuilding...");
+            tracing::info!("Changed paths: {paths:?}");
+            tracing::info!("Rebuilding...");
 
             if let Err(err) = self.build.build().await {
-                log::error!("Failed to build: {err}");
-                log::info!("Finished building the web client");
+                tracing::error!("Failed to build: {err}");
+                tracing::info!("Finished building the web client");
             }
         }
 
@@ -145,7 +145,7 @@ impl Serve {
 
 //         let path = entry.path();
 //         if watching.insert(path.to_path_buf()) {
-//             log::info!("Watching new entry: {path:?}");
+//             tracing::info!("Watching new entry: {path:?}");
 //             watcher.watch(entry.path(), RecursiveMode::NonRecursive)?;
 //         }
 //     }
@@ -160,7 +160,7 @@ fn filter_path(path: impl AsRef<Path>) -> bool {
         let seg: &Path = seg.as_ref();
         match seg.to_str() {
             None => {
-                log::error!("Path is not UTF-8: {path:?}");
+                tracing::error!("Path is not UTF-8: {path:?}");
                 false
             }
             Some(
@@ -177,7 +177,7 @@ pub fn find_top_level_dirs(
     dir: impl AsRef<Path>,
 ) -> impl Iterator<Item = Result<std::fs::DirEntry, std::io::Error>> {
     let dir = dir.as_ref();
-    log::info!("Walking directory {dir:?}");
+    tracing::info!("Walking directory {dir:?}");
 
     std::fs::read_dir(dir).unwrap().filter_map_ok(|entry| {
         let path = entry.path();

--- a/crates/animation/Cargo.toml
+++ b/crates/animation/Cargo.toml
@@ -20,4 +20,4 @@ serde = { workspace = true }
 async-trait = { workspace = true }
 itertools = { workspace = true }
 anyhow = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }

--- a/crates/animation/src/player.rs
+++ b/crates/animation/src/player.rs
@@ -256,7 +256,7 @@ pub fn animation_player_systems() -> SystemGroup {
                                     world.add_component(id, play_clip(), clip).ok();
                                 }
                                 Err(err) => {
-                                    log::warn!("Failed to load clip: {:?}", err);
+                                    tracing::warn!("Failed to load clip: {:?}", err);
                                     world.add_component(
                                         id,
                                         clip_load_error(),

--- a/crates/app/src/renderers.rs
+++ b/crates/app/src/renderers.rs
@@ -96,7 +96,7 @@ impl MainRenderer {
 
         let is_srgb = gpu.swapchain_format().is_srgb();
         let gamma_correction = if !is_srgb {
-            tracing::info!(
+            tracing::debug!(
                 "Output format is not in sRGB colorspace. Applying manual gamma correction."
             );
             Some(2.2)
@@ -396,8 +396,6 @@ impl UiRenderer {
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
         let mut post_submit = Vec::new();
-
-        tracing::info!("Drawing UI");
 
         self.ui_renderer.render(
             gpu,

--- a/crates/asset_timeline/examples/asset_timeline.rs
+++ b/crates/asset_timeline/examples/asset_timeline.rs
@@ -71,7 +71,7 @@ fn load_asset_no_keepalive(world: &mut World) -> JoinHandle<()> {
     let assets = world.resource(asset_cache()).clone();
     world.resource(runtime()).spawn(async move {
         let asset = NoKeepaliveKey.get(&assets).await;
-        tracing::info!("Finished loading asset");
+        tracing::debug!("Finished loading asset");
         tokio::time::sleep(Duration::from_secs(5)).await;
         drop(asset);
     })

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/AmbientRun/Ambient"
 ambient_sys = { path = "../sys", version = "0.3.1-dev" }
 flume = { workspace = true }
 derive_more = { workspace = true }
-log = { workspace = true }
 thiserror = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true }

--- a/crates/audio/src/sink.rs
+++ b/crates/audio/src/sink.rs
@@ -1,7 +1,10 @@
 use std::{
-    fmt::Debug, sync::{
-        atomic::{AtomicU64, Ordering}, Arc
-    }, time::Duration
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
 
 use cpal::{ChannelCount, Sample};
@@ -9,7 +12,8 @@ use flume::{Receiver, Sender, TryRecvError};
 use glam::Vec3;
 
 use crate::{
-    spatial::{AudioListener, SpatialParams}, BoxSourceInit, NanoTime, SinkId, SourceInit, StreamConfig
+    spatial::{AudioListener, SpatialParams},
+    BoxSourceInit, NanoTime, SinkId, SourceInit, StreamConfig,
 };
 
 pub const SPEED_OF_SOUND: f32 = 343.0; // m/s
@@ -427,7 +431,7 @@ impl SinkConsumer {
 
             let pos = cursor.saturating_sub(delay);
             if channel == 0 {
-                log::info!("Playing sample: d: {delay} {pos}");
+                tracing::info!("Playing sample: d: {delay} {pos}");
             }
             match current.source.at(pos, channel, config) {
                 Some(v) => {

--- a/crates/audio/src/stream.rs
+++ b/crates/audio/src/stream.rs
@@ -62,7 +62,7 @@ impl AudioStream {
         let format = config.sample_format();
         let config: cpal::StreamConfig = config.into();
 
-        tracing::info!("Audio stream config: {config:?}");
+        tracing::debug!("Audio stream config: {config:?}");
         if config.channels < 1 || config.channels > 2 {
             return Err(Error::InvalidChannelCount(config.channels));
         }

--- a/crates/audio/src/stream.rs
+++ b/crates/audio/src/stream.rs
@@ -73,7 +73,7 @@ impl AudioStream {
 
         let weak_mixer = mixer.downgrade();
 
-        let err_func = |err| log::error!("Audio error: {err}");
+        let err_func = |err| tracing::error!("Audio error: {err}");
 
         let channels = mixer_config.channels;
 

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -44,7 +44,6 @@ anyhow = { workspace = true }
 relative-path = { workspace = true }
 convert_case = { workspace = true }
 slugify = { workspace = true }
-log = { workspace = true }
 glob = { workspace = true }
 yaml-rust = { workspace = true }
 tracing = { workspace = true }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -48,6 +48,7 @@ pub async fn build_package(
     package_path: &Path,
     root_build_path: &Path,
 ) -> anyhow::Result<BuildResult> {
+    let _span = tracing::info_span!("register_semantic", ?package_path).entered();
     let mut semantic = Semantic::new(settings.deploy).await?;
 
     let package_item_id = add_to_semantic_and_register_components(
@@ -73,7 +74,11 @@ pub async fn build_package(
                 .to_owned(),
         )
     };
+
+    drop(_span);
+
     let package_name = &manifest.package.name;
+    let _span = tracing::info_span!("build_package", name = package_name).entered();
 
     // Bodge: for local builds, rewrite the dependencies to be relative to this package,
     // assuming that they are all in the same folder

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -265,7 +265,7 @@ pub async fn build_assets(
             move |path, contents| {
                 let file_write_semaphore = file_write_semaphore.clone();
                 let path = build_path.join("assets").join(path);
-                tracing::info!("Writing file: {:?}", path);
+                tracing::trace!("Writing file: {:?}", path);
 
                 if for_import_only {
                     if let Some(ext) = path.extension() {

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -193,13 +193,14 @@ pub async fn build_package(
     } else {
         vec![]
     };
-    log::info!("Assets built, building source code...");
+
+    tracing::info!("Assets built, building source code...");
 
     build_rust_if_available(&package_path, &manifest, &build_path, settings.release)
         .await
         .with_context(|| format!("Failed to build Rust in {build_path:?}"))?;
 
-    log::info!("Source built");
+    tracing::info!("Source built");
 
     tokio::fs::write(&output_manifest_path, toml::to_string(&manifest)?).await?;
 
@@ -259,7 +260,7 @@ pub async fn build_assets(
             move |path, contents| {
                 let file_write_semaphore = file_write_semaphore.clone();
                 let path = build_path.join("assets").join(path);
-                log::info!("Writing file: {:?}", path);
+                tracing::info!("Writing file: {:?}", path);
 
                 if for_import_only {
                     if let Some(ext) = path.extension() {
@@ -283,13 +284,13 @@ pub async fn build_assets(
             }
         }),
         on_status: Arc::new(|msg| {
-            log::debug!("{}", msg);
+            tracing::debug!("{}", msg);
             async {}.boxed()
         }),
         on_error: Arc::new({
             let has_errored = has_errored.clone();
             move |err| {
-                log::error!("{:?}", err);
+                tracing::error!("{:?}", err);
                 has_errored.store(true, Ordering::SeqCst);
                 async {}.boxed()
             }

--- a/crates/build/src/migrate/toml.rs
+++ b/crates/build/src/migrate/toml.rs
@@ -29,7 +29,7 @@ pub async fn process(path: PathBuf) -> anyhow::Result<()> {
 }
 
 async fn migrate_pipeline(path: &Path) -> anyhow::Result<()> {
-    tracing::info!(?path, "Processing pipeline");
+    tracing::info!("Processing pipeline {path:?}");
 
     let str = tokio::fs::read_to_string(path)
         .await

--- a/crates/build/src/pipelines/context.rs
+++ b/crates/build/src/pipelines/context.rs
@@ -112,7 +112,7 @@ impl PipelineCtx {
             .map(|p| glob::Pattern::new(p))
             .collect::<Result<Vec<_>, glob::PatternError>>()
             .unwrap();
-        log::debug!(
+        tracing::debug!(
             "[{}] Sources filter: {:?}",
             self.pipeline_path(),
             sources_filter
@@ -122,7 +122,7 @@ impl PipelineCtx {
             .input_file_filter
             .as_ref()
             .and_then(|x| glob::Pattern::new(x).ok());
-        log::debug!(
+        tracing::debug!(
             "[{}] Input file filter: {:?}",
             self.pipeline_path(),
             sources_filter
@@ -153,7 +153,7 @@ impl PipelineCtx {
             .iter()
             .filter(move |file| {
                 if !filter_by_sources(file) {
-                    log::debug!(
+                    tracing::debug!(
                         "[{}] Skipping file {} because it doesn't match sources filter",
                         self.pipeline_path(),
                         file
@@ -161,7 +161,7 @@ impl PipelineCtx {
                     return false;
                 }
                 if !filter_by_opt_filter(file) {
-                    log::debug!(
+                    tracing::debug!(
                         "[{}] Skipping file {} because it doesn't match input file filter",
                         self.pipeline_path(),
                         file
@@ -169,7 +169,7 @@ impl PipelineCtx {
                     return false;
                 }
                 if !filter(file) {
-                    log::debug!(
+                    tracing::debug!(
                         "[{}] Skipping file {} because it doesn't match pipeline filter",
                         self.pipeline_path(),
                         file

--- a/crates/build/src/pipelines/mod.rs
+++ b/crates/build/src/pipelines/mod.rs
@@ -22,7 +22,7 @@ pub mod out_asset;
 pub use importer::*;
 
 pub async fn process_pipeline(pipeline: &Pipeline, ctx: PipelineCtx) -> Vec<OutAsset> {
-    log::debug!("Processing pipeline: {:?}", ctx.pipeline_path());
+    tracing::debug!("Processing pipeline: {:?}", ctx.pipeline_path());
     let mut assets = match &pipeline.processor {
         PipelineProcessor::Models(config) => models::pipeline(&ctx, config.clone()).await,
         PipelineProcessor::Materials(config) => materials::pipeline(&ctx, config.clone()).await,
@@ -54,7 +54,7 @@ fn get_pipelines(
             )
         })
         .then(move |file| async move {
-            log::debug!("Found pipeline file at {:?}, parsing...", file.0.path());
+            tracing::debug!("Found pipeline file at {:?}, parsing...", file.0.path());
             let schema = file
                 .download_toml::<PipelinesFile>(&ctx.assets)
                 .await
@@ -69,7 +69,7 @@ pub async fn process_pipelines(ctx: &ProcessCtx) -> anyhow::Result<Vec<OutAsset>
 
     get_pipelines(ctx)
         .map_ok(|(file, pipelines)| {
-            log::debug!(
+            tracing::debug!(
                 "Found pipelines file: {:?} with {} pipelines",
                 file.0.path(),
                 pipelines.pipelines.len()

--- a/crates/build/src/pipelines/models/mod.rs
+++ b/crates/build/src/pipelines/models/mod.rs
@@ -127,7 +127,7 @@ fn create_texture_resolver(ctx: &PipelineCtx) -> TextureResolver {
                 match download_image(&ctx.process_ctx.assets, file).await {
                     Ok(img) => Some(img.into_rgba8()),
                     Err(err) => {
-                        log::error!("Failed to import image {:?}: {:?}", path, err);
+                        tracing::error!("Failed to import image {:?}: {:?}", path, err);
                         None
                     }
                 }

--- a/crates/build/src/pipelines/models/unity.rs
+++ b/crates/build/src/pipelines/models/unity.rs
@@ -86,8 +86,6 @@ pub async fn pipeline(
     .collect::<anyhow::Result<HashMap<_, _>>>()
     .unwrap();
 
-    log::debug!("guid_lookup done");
-
     let materials = Arc::new(Mutex::new(UnityMaterials {
         materials: Default::default(),
         ctx: ctx.clone(),

--- a/crates/cloud_client/Cargo.toml
+++ b/crates/cloud_client/Cargo.toml
@@ -15,6 +15,6 @@ ambient_native_std = { path = "../native_std", version = "0.3.1-dev" }
 ambient_sys = { path = "../sys", version = "0.3.1-dev" }
 
 anyhow = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/crates/cloud_client/src/lib.rs
+++ b/crates/cloud_client/src/lib.rs
@@ -106,7 +106,7 @@ where
     wasm_nonsend(move || async move {
         let client = ReqwestClientKey.get(&assets);
 
-        log::debug!("Requesting {}", url_str);
+        tracing::debug!("Requesting {}", url_str);
         let mut builder = client
             .request(method.clone(), url.clone())
             .bearer_auth(auth_token);
@@ -127,7 +127,7 @@ where
             .with_context(|| format!("Failed to send request to \"{url_str}\""))?;
 
         if !resp.status().is_success() {
-            log::warn!("Request for {} failed: {:?}", url_str, resp.status());
+            tracing::warn!("Request for {} failed: {:?}", url_str, resp.status());
             return Err(anyhow!(
                 "Requesting {url_str} failed, bad status code: {:?}",
                 resp.status()

--- a/crates/decals/Cargo.toml
+++ b/crates/decals/Cargo.toml
@@ -18,7 +18,7 @@ ambient_gpu_ecs = { path = "../gpu_ecs" , version = "0.3.1-dev" }
 ambient_native_std = { path = "../native_std" , version = "0.3.1-dev" }
 ambient_core = { path = "../core" , version = "0.3.1-dev" }
 ambient_meshes = { path = "../meshes" , version = "0.3.1-dev" }
-log = { workspace = true }
+tracing = { workspace = true }
 glam = { workspace = true }
 
 [dev-dependencies]

--- a/crates/decals/src/lib.rs
+++ b/crates/decals/src/lib.rs
@@ -93,7 +93,7 @@ pub fn client_systems() -> SystemGroup {
                     let decal = if let Some(url) = decal.abs() {
                         url
                     } else {
-                        log::error!("Decal was not an absolute url: {}", decal);
+                        tracing::error!("Decal was not an absolute url: {}", decal);
                         continue;
                     };
                     let assets = world.resource(asset_cache()).clone();
@@ -146,7 +146,7 @@ pub fn client_systems() -> SystemGroup {
                     let url = match AbsAssetUrl::from_str(&url) {
                         Ok(value) => value,
                         Err(err) => {
-                            log::warn!("Failed to parse pbr_material_from_url url: {:?}", err);
+                            tracing::warn!("Failed to parse pbr_material_from_url url: {:?}", err);
                             continue;
                         }
                     };

--- a/crates/deploy/Cargo.toml
+++ b/crates/deploy/Cargo.toml
@@ -17,7 +17,7 @@ ambient_sys = { path = "../sys" , version = "0.3.1-dev" }
 
 anyhow = { workspace = true }
 flume = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 md-5 = { workspace = true }
 prost = { workspace = true }
 tokio = { workspace = true }

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -21,7 +21,6 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 profiling = { workspace = true }
 yaml-rust = { workspace = true }
-log = { workspace = true }
 paste = { workspace = true }
 atomic_refcell = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ecs/src/component_registry.rs
+++ b/crates/ecs/src/component_registry.rs
@@ -215,7 +215,7 @@ impl ComponentRegistry {
             "Static name does not match provided name"
         );
 
-        log::debug!("Registering external component: {path}");
+        tracing::debug!("Registering external component: {path}");
 
         attributes.set(External);
         self.register(path, vtable, Some(attributes))
@@ -226,7 +226,7 @@ impl ComponentRegistry {
         path: &str,
         vtable: &'static ComponentVTable<()>,
     ) -> ComponentDesc {
-        log::debug!("Registering static component: {path}");
+        tracing::debug!("Registering static component: {path}");
         self.register(path.into(), vtable, Default::default())
     }
 

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -662,7 +662,7 @@ impl World {
     }
     fn warn_on_non_resource_component<T: ComponentValue>(component: Component<T>) {
         if !component.has_attribute::<Resource>() && !component.has_attribute::<MaybeResource>() {
-            log::warn!("Attempt to access non-resource component as a resource: {component:?}");
+            tracing::warn!("Attempt to access non-resource component as a resource: {component:?}");
         }
     }
 
@@ -768,7 +768,7 @@ impl World {
         std::fs::create_dir_all("tmp").ok();
         let mut f = std::fs::File::create("tmp/ecs.txt").expect("Unable to create file");
         self.dump(&mut f);
-        log::info!("Wrote ecs to tmp/ecs.txt");
+        tracing::info!("Wrote ecs to tmp/ecs.txt");
     }
 
     pub fn dump_entity_to_string(&self, id: EntityId) -> String {
@@ -985,7 +985,7 @@ impl Commands {
     pub fn soft_apply(&mut self, world: &mut World) {
         for command in self.0.drain(..) {
             if let Err(err) = command.apply(world) {
-                log::warn!("soft_apply error: {:?}", err);
+                tracing::warn!("soft_apply error: {:?}", err);
             }
         }
     }

--- a/crates/ecs/src/serialization.rs
+++ b/crates/ecs/src/serialization.rs
@@ -155,9 +155,9 @@ impl std::ops::Deref for ECSDeserializationWarnings {
 impl ECSDeserializationWarnings {
     pub fn log_warnings(&self) {
         if !self.warnings.is_empty() {
-            log::warn!("{} component bad format errors", self.warnings.len());
+            tracing::warn!("{} component bad format errors", self.warnings.len());
             for (id, comp, err) in self.warnings.iter().take(10) {
-                log::warn!("Bad component format {} {}: {}", id, comp, err);
+                tracing::warn!("Bad component format {} {}: {}", id, comp, err);
             }
         }
     }

--- a/crates/ecs/src/stream.rs
+++ b/crates/ecs/src/stream.rs
@@ -363,7 +363,7 @@ impl WorldChange {
                     if panic_on_error {
                         panic!("WorldChange::apply spawn_mirror entity already exists: {id:?}");
                     } else {
-                        log::error!(
+                        tracing::error!(
                             "WorldChange::apply spawn_mirror entity already exists: {id:?}"
                         );
                     }

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -40,7 +40,6 @@ ordered-float = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
-log = { workspace = true }
 profiling = { workspace = true }
 closure = { workspace = true }
 wgpu = { workspace = true }

--- a/crates/editor/src/ui/build_mode/mod.rs
+++ b/crates/editor/src/ui/build_mode/mod.rs
@@ -124,7 +124,7 @@ impl<T: ComponentValue> EditorAction<T> {
     pub fn cancel(&self) {
         let id = self.id.clone();
         if let Some(id) = id {
-            tracing::info!("Cancelling action: {id}");
+            tracing::debug!("Cancelling action: {id}");
             let client = self.client.clone();
             self.runtime.spawn(async move {
                 client.rpc(rpc_undo_head_exact, id).await.unwrap();
@@ -135,7 +135,7 @@ impl<T: ComponentValue> EditorAction<T> {
 
 impl<T: ComponentValue> Drop for EditorAction<T> {
     fn drop(&mut self) {
-        tracing::info!("Dropping editor action");
+        tracing::trace!("Dropping editor action");
         self.cancel()
     }
 }
@@ -170,7 +170,7 @@ impl ElementComponent for EditorBuildMode {
                     .collect_vec();
 
                 if Some(&res) != prev.as_ref() {
-                    tracing::info!("Resolving targets: {selection:?} => {res:?}");
+                    tracing::debug!("Resolving targets: {selection:?} => {res:?}");
                     prev = Some(res.clone());
                     *targets.lock() = res.into();
                     rerender();
@@ -234,7 +234,7 @@ impl ElementComponent for EditorBuildMode {
                             let client_state = client_state.clone();
                             let async_run = world.resource(async_run()).clone();
                             select_asset(world.resource(asset_cache()), AssetType::Prefab, move |object_url| {
-                                tracing::info!("got object_url: {object_url:?}");
+                                tracing::debug!("got object_url: {object_url:?}");
                                 if let Some(object_url) = object_url.random().cloned() {
                                     async_run.run(move |world| {
                                         let set_srt_mode = set_srt_mode.clone();
@@ -297,10 +297,10 @@ impl ElementComponent for EditorBuildMode {
                                 let set_srt_mode = set_srt_mode.clone();
                                 let client_state = client_state.clone();
 
-                                tracing::info!("Duplicating {targets:?}");
+                                tracing::debug!("Duplicating {targets:?}");
                                 world.resource(runtime()).spawn(
                                     client_push_intent(client_state, intent_duplicate(), IntentDuplicate { new_uids: targets.iter().map(|_| EntityId::new()).collect(), entities: targets.to_vec(), select: true }, None, Some(Box::new(move || {
-                                        tracing::info!("Entering translate move");
+                                        tracing::debug!("Entering translate move");
 
 
                                         set_srt_mode(Some(TransformMode::Translate));

--- a/crates/editor/src/ui/build_mode/select_area.rs
+++ b/crates/editor/src/ui/build_mode/select_area.rs
@@ -152,7 +152,7 @@ impl ElementComponent for SelectArea {
                     let area_offset = get_world_position(world, id).unwrap().xy();
                     set_dragging(Some(*world.resource(cursor_position())));
                     set_area_offset(area_offset);
-                    tracing::info!("Set is_clicking to true");
+                    tracing::debug!("Set is_clicking to true");
                     *is_clicking.lock() = true;
                 }),
             )

--- a/crates/editor/src/ui/build_mode/transform.rs
+++ b/crates/editor/src/ui/build_mode/transform.rs
@@ -107,7 +107,7 @@ fn initial_transforms(
         let transforms = match get_world_transforms(&state.world, targets) {
             Ok(v) => v,
             Err(err) => {
-                log::error!("{err:?}");
+                tracing::error!("{err:?}");
                 return Default::default();
             }
         };

--- a/crates/gizmos/Cargo.toml
+++ b/crates/gizmos/Cargo.toml
@@ -20,7 +20,7 @@ dashmap = { workspace = true }
 glam = { workspace = true }
 bytemuck = { workspace = true }
 wgpu = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 serde = { workspace = true }
 once_cell = "1.18.0"
 profiling = { workspace = true }

--- a/crates/gizmos/src/render.rs
+++ b/crates/gizmos/src/render.rs
@@ -152,7 +152,7 @@ impl SubRenderer for GizmoRenderer {
         });
 
         self.buffer.fill(gpu, primitives, |_| {
-            log::debug!("Resizing bind group for gizmos");
+            tracing::debug!("Resizing bind group for gizmos");
         });
 
         let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {

--- a/crates/gpu/Cargo.toml
+++ b/crates/gpu/Cargo.toml
@@ -22,7 +22,6 @@ bytemuck = { workspace = true }
 winit = { workspace = true }
 wgpu = { workspace = true }
 glam = { workspace = true }
-log = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 byteorder = { workspace = true }

--- a/crates/gpu/src/blit.rs
+++ b/crates/gpu/src/blit.rs
@@ -30,7 +30,7 @@ pub struct Blitter {
 }
 impl Blitter {
     pub fn new(gpu: &Gpu, assets: &AssetCache, conf: &BlitterKey) -> Self {
-        log::debug!("Creating blitter: {conf:#?}");
+        tracing::debug!("Creating blitter: {conf:#?}");
         let colorspace = if let Some(gamma) = conf.gamma_correction {
             let inv_gamma = 1.0 / gamma;
             format!("vec4<f32>(pow(color.xyz, vec3<f32>({inv_gamma})), color.w)")
@@ -79,7 +79,7 @@ impl Blitter {
                 push_constant_ranges: &[],
             });
 
-        log::debug!("Setting up blitter");
+        tracing::debug!("Setting up blitter");
         let pipeline = gpu
             .device
             .create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/crates/gpu/src/gpu.rs
+++ b/crates/gpu/src/gpu.rs
@@ -33,12 +33,12 @@ impl Gpu {
     pub async fn new(window: Option<&Window>) -> anyhow::Result<Self> {
         Self::with_config(window, false, &RenderSettings::default()).await
     }
-    #[tracing::instrument(level = "info")]
     pub async fn with_config(
         window: Option<&Window>,
         will_be_polled: bool,
         settings: &RenderSettings,
     ) -> anyhow::Result<Self> {
+        let _span = tracing::info_span!("create_gpu").entered();
         // From: https://github.com/KhronosGroup/Vulkan-Loader/issues/552
         #[cfg(not(target_os = "unknown"))]
         {
@@ -121,7 +121,7 @@ impl Gpu {
             }
         };
 
-        tracing::info!("Using features: {features:#?}");
+        tracing::info!("Using device features: {features:?}");
 
         let (device, queue) = adapter
             .request_device(
@@ -191,7 +191,6 @@ impl Gpu {
     pub fn resize(&self, size: winit::dpi::PhysicalSize<u32>) {
         if let Some(surface) = &self.surface {
             if size.width > 0 && size.height > 0 {
-                tracing::info!("Resizing to {size:?}");
                 surface.configure(&self.device, &self.sc_desc(uvec2(size.width, size.height)));
             }
         }

--- a/crates/gpu/src/shader_module.rs
+++ b/crates/gpu/src/shader_module.rs
@@ -243,7 +243,7 @@ impl Shader {
         let label = label.into();
         let gpu = GpuKey.get(assets);
 
-        let _span = tracing::info_span!("Shader::from_modules", ?label).entered();
+        let _span = tracing::debug_span!("Shader::from_modules", ?label).entered();
 
         // The complete dependency graph, in the correct order
         let modules = resolve_module_graph(&[module]);

--- a/crates/intent/src/registry.rs
+++ b/crates/intent/src/registry.rs
@@ -9,7 +9,6 @@ use ambient_network::{
 };
 use futures::Future;
 use parking_lot::MutexGuard;
-use tracing::info_span;
 
 use crate::{
     common_intent_systems, intent, intent_applied, intent_failed, intent_id, intent_id_index,
@@ -291,7 +290,7 @@ where
     }
 
     fn merge(&self, ctx: &mut IntentContext<'_>, a: EntityId, b: EntityId) {
-        let _span = info_span!("merge_intent", self.name).entered();
+        let _span = tracing::debug_span!("merge_intent", self.name).entered();
         let world = &mut ctx.world;
         let old_arg = world.get_ref(a, self.intent).expect("Missing old intent");
         let old_state = world

--- a/crates/layout/Cargo.toml
+++ b/crates/layout/Cargo.toml
@@ -17,5 +17,5 @@ ambient_core = { path = "../core" , version = "0.3.1-dev" }
 ambient_input = { path = "../input" , version = "0.3.1-dev" }
 glam = { workspace = true }
 itertools = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 profiling = { workspace = true }

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -201,7 +201,7 @@ pub fn layout_systems() -> SystemGroup {
                         return;
                     }
                 }
-                log::warn!("Layout ran the full 100 iterations");
+                tracing::warn!("Layout ran the full 100 iterations");
             }),
             query_mut((mesh_to_local(),), (width().changed(), height().changed()))
                 .incl(mesh_to_local_from_size())

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -171,7 +171,7 @@ async fn internal_spawn_models_from_defs(
 
             match model {
                 Ok(model) => {
-                    tracing::info!("Spawning model: {:?} for {ids:?}", model.name());
+                    tracing::debug!("Spawning model: {:?} for {ids:?}", model.name());
                     let gpu = world.resource(gpu()).clone();
                     model.batch_spawn(
                         &gpu,

--- a/crates/model/src/model.rs
+++ b/crates/model/src/model.rs
@@ -179,7 +179,7 @@ impl Model {
                             root_components.remove_self(name());
                         }
 
-                        tracing::info!(
+                        tracing::debug!(
                             "Attaching to {:?} to {entity}",
                             root_components.get(local_bounding_aabb())
                         );

--- a/crates/model_import/Cargo.toml
+++ b/crates/model_import/Cargo.toml
@@ -38,7 +38,7 @@ async-recursion = { workspace = true }
 fbxcel = { workspace = true }
 ordered-float = { workspace = true }
 indexmap = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 relative-path = { workspace = true }
 russimp = { workspace = true, optional = true }
 convert_case = { workspace = true }

--- a/crates/model_import/src/model_crate.rs
+++ b/crates/model_import/src/model_crate.rs
@@ -165,7 +165,7 @@ impl ModelCrate {
                     async move {
                         let path: PathBuf = path.into();
                         let filename = path.file_name().unwrap().to_str().unwrap().to_string();
-                        log::info!("XXX {filename:?}");
+                        tracing::info!("XXX {filename:?}");
                         None
                     }
                     .boxed()
@@ -623,7 +623,7 @@ impl ModelCrate {
                 let stream = PxDefaultMemoryOutputStream::new();
                 let mut res = physxx::PxTriangleMeshCookingResult::Success;
                 if !physics.cooking.cook_triangle_mesh(&desc, &stream, &mut res) {
-                    log::error!("Failed to cook triangle mesh: {:?}", res);
+                    tracing::error!("Failed to cook triangle mesh: {:?}", res);
                     return false;
                 }
                 asset_crate
@@ -667,7 +667,7 @@ impl ModelCrate {
             let stream = PxDefaultMemoryOutputStream::new();
             let mut res = physxx::PxConvexMeshCookingResult::Success;
             if !physics.cooking.cook_convex_mesh(&desc, &stream, &mut res) {
-                log::error!("Failed to cook convex mesh: {:?}", res);
+                tracing::error!("Failed to cook convex mesh: {:?}", res);
                 return None;
             }
             Some(

--- a/crates/model_import/src/model_crate.rs
+++ b/crates/model_import/src/model_crate.rs
@@ -165,7 +165,7 @@ impl ModelCrate {
                     async move {
                         let path: PathBuf = path.into();
                         let filename = path.file_name().unwrap().to_str().unwrap().to_string();
-                        tracing::info!("XXX {filename:?}");
+                        tracing::debug!("XXX {filename:?}");
                         None
                     }
                     .boxed()

--- a/crates/native_std/Cargo.toml
+++ b/crates/native_std/Cargo.toml
@@ -37,7 +37,6 @@ tokio = { workspace = true, optional = true, features = ["sync"] }
 async-trait = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 bytemuck = { workspace = true, optional = true }
-log = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 sentry-anyhow = { workspace = true, optional = true }
@@ -69,7 +68,6 @@ uncategorized = [
     "dep:async-trait",
     "dep:futures",
     "dep:bytemuck",
-    "dep:log",
     "dep:reqwest",
     "dep:thiserror",
     "dep:sentry-anyhow",

--- a/crates/native_std/src/lib.rs
+++ b/crates/native_std/src/lib.rs
@@ -97,7 +97,7 @@ macro_rules! log_result {
 macro_rules! log_warning {
     ( $x:expr ) => {
         if let Err(err) = $x {
-            log::warn!("{:?}", err);
+            tracing::warn!("{:?}", err);
         }
     };
 }
@@ -121,7 +121,7 @@ macro_rules! unwrap_log_warn {
         match $x {
             Ok(val) => val,
             Err(err) => {
-                log::warn!("{:?}", err);
+                tracing::warn!("{:?}", err);
                 return Default::default();
             }
         }

--- a/crates/native_std/src/uncategorized/disk_cache.rs
+++ b/crates/native_std/src/uncategorized/disk_cache.rs
@@ -36,7 +36,7 @@ impl<
             match serde_json::from_slice(&data) {
                 Ok(value) => return Ok(value),
                 Err(err) => {
-                    log::warn!("Failed to parse cached json asset: {:?}", err);
+                    tracing::warn!("Failed to parse cached json asset: {:?}", err);
                 }
             }
         }

--- a/crates/native_std/src/uncategorized/download_asset.rs
+++ b/crates/native_std/src/uncategorized/download_asset.rs
@@ -99,9 +99,9 @@ pub(crate) async fn download<T: 'static + Send, F: Future<Output = anyhow::Resul
         let max_retries = 12;
         for i in 0..max_retries {
             let semaphore = DownloadSemaphore.get(&assets);
-            tracing::info!("Download [pending ] {}", url_short);
+            tracing::debug!("Download [pending ] {}", url_short);
             let _permit = semaphore.acquire().await.unwrap();
-            tracing::info!("Download [download] {}", url_short);
+            tracing::debug!("Download [download] {}", url_short);
             let resp = client
                 .get(url.clone())
                 .send()
@@ -116,7 +116,7 @@ pub(crate) async fn download<T: 'static + Send, F: Future<Output = anyhow::Resul
             }
             match map(resp).await {
                 Ok(res) => {
-                    tracing::info!("Download [complete] {}", url_short);
+                    tracing::debug!("Download [complete] {}", url_short);
                     return Ok(res);
                 }
                 Err(err) => {
@@ -275,7 +275,7 @@ impl AsyncAssetKey<AssetResult<Arc<PathBuf>>> for BytesFromUrlCachedPath {
             std::fs::rename(&tmp_path, &path).context(format!(
                 "Failed to rename tmp file, from: {tmp_path:?}, to: {path:?}"
             ))?;
-            tracing::info!("Cached asset at {:?}", path);
+            tracing::debug!("Cached asset at {:?}", path);
         }
 
         return Ok(Arc::new(path));

--- a/crates/native_std/src/uncategorized/download_asset.rs
+++ b/crates/native_std/src/uncategorized/download_asset.rs
@@ -99,16 +99,16 @@ pub(crate) async fn download<T: 'static + Send, F: Future<Output = anyhow::Resul
         let max_retries = 12;
         for i in 0..max_retries {
             let semaphore = DownloadSemaphore.get(&assets);
-            log::info!("Download [pending ] {}", url_short);
+            tracing::info!("Download [pending ] {}", url_short);
             let _permit = semaphore.acquire().await.unwrap();
-            log::info!("Download [download] {}", url_short);
+            tracing::info!("Download [download] {}", url_short);
             let resp = client
                 .get(url.clone())
                 .send()
                 .await
                 .with_context(|| format!("Failed to download {url_str}"))?;
             if !resp.status().is_success() {
-                log::warn!("Request for {} failed: {:?}", url_str, resp.status());
+                tracing::warn!("Request for {} failed: {:?}", url_str, resp.status());
                 return Err(anyhow!(
                     "Downloading {url_str} failed, bad status code: {:?}",
                     resp.status()
@@ -116,11 +116,11 @@ pub(crate) async fn download<T: 'static + Send, F: Future<Output = anyhow::Resul
             }
             match map(resp).await {
                 Ok(res) => {
-                    log::info!("Download [complete] {}", url_short);
+                    tracing::info!("Download [complete] {}", url_short);
                     return Ok(res);
                 }
                 Err(err) => {
-                    log::warn!(
+                    tracing::warn!(
                         "Failed to read body of {url_str}, retrying ({i}/{max_retries}): {:?}",
                         err
                     );
@@ -275,7 +275,7 @@ impl AsyncAssetKey<AssetResult<Arc<PathBuf>>> for BytesFromUrlCachedPath {
             std::fs::rename(&tmp_path, &path).context(format!(
                 "Failed to rename tmp file, from: {tmp_path:?}, to: {path:?}"
             ))?;
-            log::info!("Cached asset at {:?}", path);
+            tracing::info!("Cached asset at {:?}", path);
         }
 
         return Ok(Arc::new(path));

--- a/crates/native_std/src/uncategorized/mesh.rs
+++ b/crates/native_std/src/uncategorized/mesh.rs
@@ -118,7 +118,7 @@ pub fn generate_tangents(
     };
     let result = mikktspace::generate_tangents(&mut geometry);
     if !result {
-        log::warn!("mikktspace::generate_tangents failed");
+        tracing::warn!("mikktspace::generate_tangents failed");
     }
     tangents
 }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -37,13 +37,12 @@ thiserror = { workspace = true }
 bincode = { workspace = true }
 glam = { workspace = true }
 profiling = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 bytes = { workspace = true }
 parking_lot = { workspace = true }
 wgpu = { workspace = true }
 flume = { workspace = true }
 anyhow = { workspace = true }
-tracing = { workspace = true }
 colored = { workspace = true }
 pin-project = { workspace = true }
 uuid = { workspace = true }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -224,11 +224,11 @@ pub async fn log_task_result(task: impl Future<Output = anyhow::Result<()>>) {
 #[cfg(not(target_os = "unknown"))]
 pub fn log_network_error(err: &anyhow::Error) {
     if let Some(quinn::WriteError::ConnectionLost(err)) = err.downcast_ref::<quinn::WriteError>() {
-        log::info!("Connection lost: {:#}", err);
+        tracing::info!("Connection lost: {:#}", err);
     } else if let Some(err) = err.downcast_ref::<quinn::ConnectionError>() {
-        log::info!("Connection error: {:#}", err);
+        tracing::info!("Connection error: {:#}", err);
     } else if let Some(err) = err.downcast_ref::<quinn::WriteError>() {
-        log::info!("Write error: {:#}", err);
+        tracing::info!("Write error: {:#}", err);
     } else {
         log_error(err);
     }

--- a/crates/network/src/native/client.rs
+++ b/crates/network/src/native/client.rs
@@ -197,7 +197,6 @@ impl ElementComponent for ClientView {
                         );
 
                         let game_state = &client_state.game_state;
-                        tracing::info!("Setting game state");
                         let cleanup = {
                             // Lock before setting
                             let game_state = &mut game_state.lock();
@@ -342,8 +341,6 @@ async fn handle_connection(
 
     let mut control_rx = control_rx.into_stream();
 
-    tracing::info!("Client connected");
-
     while let ClientProtoState::Connected(connected) = &mut client {
         tokio::select! {
             Some(frame) = push_recv.next() => {
@@ -366,7 +363,7 @@ async fn handle_connection(
            Some(control) = control_rx.next() => {
                 match control {
                     Control::Disconnect => {
-                        tracing::info!("Disconnecting manually");
+                        tracing::debug!("Disconnecting manually");
                         // Tell the server that we want to gracefully disconnect
                         request_send.send(ClientRequest::Disconnect).await?;
                     }
@@ -388,7 +385,6 @@ async fn handle_connection(
         }
     }
 
-    tracing::info!("Client entered disconnected state");
     Ok(())
 }
 

--- a/crates/network/src/native/client.rs
+++ b/crates/network/src/native/client.rs
@@ -398,17 +398,17 @@ async fn open_connection(
     server_addr: ResolvedAddr,
     cert: Option<Certificate>,
 ) -> anyhow::Result<Connection> {
-    log::debug!("Connecting to world instance: {server_addr:?}");
+    tracing::debug!("Connecting to world instance: {server_addr:?}");
 
     let endpoint =
         create_client_endpoint_random_port(cert).context("Failed to create client endpoint")?;
 
-    log::debug!("Got endpoint");
+    tracing::debug!("Got endpoint");
     let conn = endpoint
         .connect(server_addr.addr, &server_addr.host_name)?
         .await?;
 
-    log::debug!("Got connection");
+    tracing::debug!("Got connection");
     Ok(conn)
 }
 

--- a/crates/network/src/native/mod.rs
+++ b/crates/network/src/native/mod.rs
@@ -50,7 +50,6 @@ fn load_root_certs() -> rustls::RootCertStore {
     }
     #[cfg(not(any(feature = "tls-native-roots", feature = "tls-webpki-roots")))]
     {
-        tracing::info!("Creating empty root certificates store");
         rustls::RootCertStore::empty()
     }
 }

--- a/crates/network/src/native/server.rs
+++ b/crates/network/src/native/server.rs
@@ -386,7 +386,7 @@ async fn start_proxy_connection(
                       ..
                   }: AllocatedEndpoint| {
                 tracing::debug!("Allocated proxy endpoint. Allocation id: {}", id);
-                tracing::info!("Proxy sees this server as {}", external_endpoint);
+                tracing::debug!("Proxy sees this server as {}", external_endpoint);
                 tracing::info!(
                     "Proxy allocated an endpoint, use `{}` to join",
                     format!("ambient join {}", allocated_endpoint).bright_green()

--- a/crates/network/src/proto/client.rs
+++ b/crates/network/src/proto/client.rs
@@ -44,7 +44,7 @@ pub type SharedClientGameState = Arc<Mutex<ClientGameState>>;
 
 impl ClientProtoState {
     pub fn process_disconnect(&mut self) {
-        tracing::info!("Disconnecting client: {self:#?}");
+        tracing::debug!("Disconnecting client: {self:#?}");
 
         *self = Self::Disconnected;
     }

--- a/crates/network/src/proto/server.rs
+++ b/crates/network/src/proto/server.rs
@@ -112,12 +112,12 @@ impl ServerProtoState {
     ) -> anyhow::Result<()> {
         match (frame, &self) {
             (_, Self::Disconnected) => {
-                tracing::info!("Client is disconnected, ignoring control frame");
+                tracing::debug!("Client is disconnected, ignoring control frame");
                 Ok(())
             }
             (ClientRequest::Connect(user_id), Self::PendingConnection) => {
                 // Connect the user
-                tracing::info!("User connected");
+                tracing::debug!("User connected");
                 self.process_connect(data, user_id);
                 Ok(())
             }
@@ -173,10 +173,10 @@ impl ServerProtoState {
 
             instance.world.add_components(id, entity_data).unwrap();
 
-            tracing::info!(user_id, ?id, "Player reconnected");
+            tracing::debug!(user_id, ?id, "Player reconnected");
         } else {
             let id = instance.spawn_player(entity_data);
-            tracing::info!(user_id, ?id, "Player connected");
+            tracing::debug!(user_id, ?id, "Player connected");
         }
 
         *self = Self::Connected(ConnectedClient {
@@ -188,7 +188,7 @@ impl ServerProtoState {
     #[tracing::instrument(level = "debug")]
     pub fn process_disconnect(&mut self, data: &ConnectionData) {
         if let Self::Connected(ConnectedClient { user_id, .. }) = self {
-            tracing::info!(?user_id, "User disconnected");
+            tracing::debug!(?user_id, "User disconnected");
             let mut state = data.state.lock();
 
             let Some(player) = state.players.get(&**user_id) else {

--- a/crates/network/src/server.rs
+++ b/crates/network/src/server.rs
@@ -143,7 +143,7 @@ impl WorldInstance {
 
         for (_, (entity_stream,)) in query((player_entity_stream(),)).iter(&self.world, None) {
             if let Err(err) = entity_stream.send(diff.clone()) {
-                log::warn!("Failed to broadcast diff to player: {err:?}");
+                tracing::warn!("Failed to broadcast diff to player: {err:?}");
             }
         }
     }
@@ -248,7 +248,7 @@ impl ServerState {
         self.get_player_world_instance(user_id).map(|i| &i.world)
     }
     pub fn remove_instance(&mut self, instance_id: &str) {
-        log::debug!("Removing server instance id={}", instance_id);
+        tracing::debug!("Removing server instance id={}", instance_id);
         let mut sys = (self.create_shutdown_systems)();
         let old_instance = self.instances.get_mut(instance_id).unwrap();
         sys.run(&mut old_instance.world, &ShutdownEvent);

--- a/crates/network/src/web/client.rs
+++ b/crates/network/src/web/client.rs
@@ -118,7 +118,7 @@ impl ElementComponent for GameClientView {
                     format!("Failed to establish a WebTransport session for \"{url}\"")
                 })?;
 
-                tracing::info!("Established WebTransport session");
+                tracing::debug!("Established WebTransport session");
 
                 let (proxy_tx, proxy_rx) = flume::bounded(32);
 
@@ -155,7 +155,6 @@ impl ElementComponent for GameClientView {
                         );
 
                         let game_state = &client_state.game_state;
-                        tracing::info!("Setting game state");
                         let cleanup = {
                             // Lock before setting
                             let game_state = &mut game_state.lock();
@@ -181,8 +180,6 @@ impl ElementComponent for GameClientView {
                     proxy_rx,
                 )
                 .await?;
-
-                tracing::info!("Finished handling connection");
 
                 Ok(()) as anyhow::Result<()>
             };
@@ -380,20 +377,15 @@ async fn handle_connection(
     control_rx: flume::Receiver<Control>,
     proxy_rx: flume::Receiver<ProxyMessage>,
 ) -> anyhow::Result<()> {
-    tracing::info!("Handling client connection");
-    tracing::info!("Opening control stream");
-
     let runtime = RuntimeKey.get(&assets);
 
     let mut request_send = FramedSendStream::new(conn.open_uni().await?);
-
-    tracing::info!("Opened control stream");
 
     // Accept the diff and stat stream
     // Nothing is read from them until the connection has been accepted
 
     // Send a connection request
-    tracing::info!("Attempting to connect using {user_id:?}");
+    tracing::debug!("Attempting to connect using {user_id:?}");
 
     request_send
         .send(ClientRequest::Connect(user_id.clone()))
@@ -401,14 +393,12 @@ async fn handle_connection(
 
     let mut client = ClientProtoState::Pending(user_id.clone());
 
-    tracing::info!("Accepting control stream from server");
     let mut push_recv = FramedRecvStream::new(
         conn.accept_uni()
             .await
             .ok_or(NetworkError::ConnectionClosed)??,
     );
 
-    tracing::info!("Entering client loop");
     while client.is_pending() {
         tracing::info!("Waiting for server to accept connection and send server info");
         if let Some(frame) = push_recv.next().await {
@@ -421,7 +411,6 @@ async fn handle_connection(
         return Ok(());
     }
 
-    tracing::info!("Accepting diff stream");
     let mut diff_stream = RawFramedRecvStream::new(
         conn.accept_uni()
             .await
@@ -429,10 +418,7 @@ async fn handle_connection(
     );
 
     let (shared_client_state, cleanup) = on_loaded(&assets, &user_id)?;
-    let on_disconnect = move || {
-        tracing::info!("Running connection cleanup");
-        cleanup()
-    };
+    let on_disconnect = move || cleanup();
 
     scopeguard::defer!(on_disconnect());
 
@@ -479,7 +465,7 @@ async fn handle_connection(
         }
     }
 
-    tracing::info!("Client entered disconnected state");
+    tracing::debug!("Client entered disconnected state");
     Ok(())
 }
 
@@ -491,7 +477,6 @@ async fn handle_request(
 ) -> Result<(), NetworkError> {
     match message {
         ProxyMessage::RequestBi { id, mut data, resp } => {
-            tracing::info!("Sending bi request");
             let (mut send, mut recv) = conn.open_bi().await?;
 
             runtime.spawn_local(async move {

--- a/crates/network/src/webtransport/connection.rs
+++ b/crates/network/src/webtransport/connection.rs
@@ -50,8 +50,6 @@ impl Connection {
             .map_err(|e| anyhow!("{e:?}"))
             .context("While waiting for ready handshake")?;
 
-        tracing::info!("Connection ready");
-
         let datagrams = transport.datagrams();
         let datagrams = datagrams.writable().get_writer().unwrap();
         let incoming_datagrams = transport.datagrams().readable();

--- a/crates/network/src/webtransport/recv_stream.rs
+++ b/crates/network/src/webtransport/recv_stream.rs
@@ -79,7 +79,6 @@ impl<'a> Future for ReadChunk<'a> {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let data = ready!(self.stream.poll_read_chunk(cx)?);
-        tracing::info!("Data: {data:?}");
 
         if let Some(data) = data {
             Poll::Ready(Some(Ok(std::mem::take(data))))

--- a/crates/physics/Cargo.toml
+++ b/crates/physics/Cargo.toml
@@ -33,7 +33,6 @@ anyhow = { workspace = true }
 profiling = { workspace = true }
 ordered-float = { workspace = true }
 tokio = { workspace = true }
-log = { workspace = true }
 
 [dev-dependencies]
 ambient_app = { path = "../app" , version = "0.3.1-dev" }

--- a/crates/physics/src/collider.rs
+++ b/crates/physics/src/collider.rs
@@ -639,7 +639,7 @@ impl Collider {
         if convex { &self.convex } else { &self.concave }
             .iter()
             .map(|(transform, mesh)| {
-                tracing::info!(transform = ?transform.to_scale_rotation_translation(), "Spawning convex mesh with transform");
+                tracing::debug!(transform = ?transform.to_scale_rotation_translation(), "Spawning convex mesh with transform");
                 // Read the scale that was applied with the model local transform
                 let (scale, rotation, translation) = (Mat4::from_scale(scale) * *transform).to_scale_rotation_translation();
 

--- a/crates/physics/src/collider.rs
+++ b/crates/physics/src/collider.rs
@@ -161,7 +161,9 @@ pub fn server_systems() -> SystemGroup {
                                 },
                             )
                             .unwrap(),
-                        Err(err) => log::warn!("Failed to load collider from {}: {:?}", url, err),
+                        Err(err) => {
+                            tracing::warn!("Failed to load collider from {}: {:?}", url, err)
+                        }
                     }
                 }
             }),
@@ -367,7 +369,7 @@ pub fn server_systems() -> SystemGroup {
                         let roff = world.get(id, rest_offset()).ok();
                         for shape in shapes.iter_mut() {
                             if !actor.attach_shape(shape) {
-                                log::error!("Failed to attach shape to entity {}", id);
+                                tracing::error!("Failed to attach shape to entity {}", id);
                                 actor.as_actor().remove_user_data::<PxActorUserData>();
                                 actor.release();
                                 return;

--- a/crates/physics/src/visualization.rs
+++ b/crates/physics/src/visualization.rs
@@ -101,7 +101,7 @@ pub(crate) fn server_systems() -> SystemGroup {
                     }
 
                     for id in ids {
-                        tracing::info!("Removing visualize_collider from {id:?}");
+                        tracing::debug!("Removing visualize_collider from {id:?}");
                         w.remove_component(id, local_gizmos()).ok();
                     }
                 },

--- a/crates/rect/Cargo.toml
+++ b/crates/rect/Cargo.toml
@@ -21,4 +21,4 @@ glam = { workspace = true }
 wgpu = { workspace = true }
 bytemuck = { workspace = true }
 async-trait = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }

--- a/crates/rect/src/lib.rs
+++ b/crates/rect/src/lib.rs
@@ -234,7 +234,7 @@ pub fn systems() -> SystemGroup {
                                     });
                                 }
                                 Err(err) => {
-                                    log::error!(
+                                    tracing::error!(
                                         "Failed to load material for entity {}: {:?}",
                                         id,
                                         err
@@ -328,13 +328,13 @@ impl AsyncAssetKey<AssetResult<Arc<RectMaterial>>> for RectMaterialKey {
                     match tex.get(&assets).await {
                         Ok(texture) => texture,
                         Err(err) => {
-                            log::warn!("Failed to load image at url {}: {:?}", url, err);
+                            tracing::warn!("Failed to load image at url {}: {:?}", url, err);
                             error_color.get(&assets)
                         }
                     }
                 }
                 Err(err) => {
-                    log::warn!("Failed to load image at url {}: {:?}", url, err);
+                    tracing::warn!("Failed to load image at url {}: {:?}", url, err);
                     error_color.get(&assets)
                 }
             },

--- a/crates/renderer/Cargo.toml
+++ b/crates/renderer/Cargo.toml
@@ -31,7 +31,6 @@ derive_more = { workspace = true }
 profiling = { workspace = true }
 bytemuck = { workspace = true }
 smallvec = { workspace = true }
-log = { workspace = true }
 parking_lot = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/renderer/examples/lod.rs
+++ b/crates/renderer/examples/lod.rs
@@ -63,7 +63,7 @@ async fn init(app: &mut App) {
         })
         .unzip();
 
-    log::info!("Lod levels: {lods:?}");
+    tracing::info!("Lod levels: {lods:?}");
 
     let aabb = AABB {
         min: -Vec3::ONE,

--- a/crates/renderer/src/collect.rs
+++ b/crates/renderer/src/collect.rs
@@ -91,7 +91,7 @@ pub(crate) struct RendererCollectState {
 
 impl RendererCollectState {
     pub fn new(gpu: &Gpu) -> Self {
-        log::debug!("Setting up renderer collect state");
+        tracing::debug!("Setting up renderer collect state");
         Self {
             params: TypedBuffer::new_init(
                 gpu,

--- a/crates/renderer/src/culling.rs
+++ b/crates/renderer/src/culling.rs
@@ -100,7 +100,7 @@ fn get_culling_layout() -> BindGroupDesc<'static> {
 
 impl Culling {
     pub fn new(gpu: &Gpu, assets: &AssetCache, config: RendererConfig) -> Self {
-        log::debug!("Setting up culling");
+        tracing::debug!("Setting up culling");
         let module = ShaderModule::new("CullingParams", include_file!("culling.wgsl"))
             .with_ident(ShaderIdent::constant(
                 "SHADOW_CASCADES",

--- a/crates/renderer/src/globals.rs
+++ b/crates/renderer/src/globals.rs
@@ -179,7 +179,7 @@ impl ForwardGlobals {
         shadow_cascades: u32,
         scene: Component<()>,
     ) -> Self {
-        log::debug!("Setting up forward globals");
+        tracing::debug!("Setting up forward globals");
         let buffer = gpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("ForwardGlobals.buffer"),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -113,7 +113,7 @@ pub fn systems() -> SystemGroup {
                     let url = match AbsAssetUrl::from_str(&url) {
                         Ok(value) => value,
                         Err(err) => {
-                            log::warn!("Failed to parse pbr_material_from_url url: {:?}", err);
+                            tracing::warn!("Failed to parse pbr_material_from_url url: {:?}", err);
                             continue;
                         }
                     };
@@ -122,7 +122,7 @@ pub fn systems() -> SystemGroup {
                     world.resource(runtime()).spawn(async move {
                         match PbrMaterialFromUrl(url).get(&assets).await {
                             Err(err) => {
-                                log::warn!("Failed to load pbr material from url: {:?}", err);
+                                tracing::warn!("Failed to load pbr material from url: {:?}", err);
                             }
                             Ok(mat) => {
                                 async_run.run(move |world| {
@@ -168,7 +168,7 @@ pub fn systems() -> SystemGroup {
             .to_system(|q, world, qs, _| {
                 for (id, (p_mesh, p_lod), (primitives,)) in q.iter(world, qs) {
                     if primitives.len() > MAX_PRIMITIVE_COUNT {
-                        log::warn!(
+                        tracing::warn!(
                             "Entity {} has more than {MAX_PRIMITIVE_COUNT} primitives",
                             id
                         );

--- a/crates/renderer/src/renderer.rs
+++ b/crates/renderer/src/renderer.rs
@@ -578,7 +578,7 @@ impl Renderer {
         std::fs::create_dir_all("tmp").expect("Failed to create tmp dir");
         let mut f = std::fs::File::create("tmp/renderer.txt").expect("Unable to create file");
         self.dump(&mut f);
-        log::info!("Wrote renderer to tmp/renderer.txt");
+        tracing::info!("Wrote renderer to tmp/renderer.txt");
     }
 
     pub fn is_rendered(&self) -> bool {

--- a/crates/renderer/src/tree_renderer.rs
+++ b/crates/renderer/src/tree_renderer.rs
@@ -352,10 +352,6 @@ impl TreeRenderer {
                 .commands
                 .set_len(gpu, draw_commands.len() as _);
 
-            tracing::info!(
-                ?total_primitives,
-                "Writing draw commands {draw_commands:#?}"
-            );
             collect_state.commands.write(gpu, 0, &draw_commands);
 
             {

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -113,7 +113,7 @@ impl SyncAssetKey<Settings> for SettingsKey {
             let ua = Reflect::get(&nav, &"userAgentData".into()).unwrap();
             let platform = Reflect::get(&ua, &"platform".into()).unwrap().as_string();
 
-            tracing::info!(?platform, "Detected platform");
+            tracing::debug!(?platform, "Detected user agent platform");
             if platform.as_deref() == Some("Windows") {
                 Settings {
                     render: RenderSettings {

--- a/crates/sys/src/native/task.rs
+++ b/crates/sys/src/native/task.rs
@@ -35,10 +35,10 @@ static LOCAL_WORKER: Lazy<flume::Sender<NonSendCons>> = Lazy::new(|| {
             loop {
                 tokio::select! {
                     Some(()) = set.next() => {
-                        tracing::info!("Local future completed");
+                        tracing::trace!("Local future completed");
                     },
                     Some(task) = rx.next() => {
-                        tracing::info!("Received new future");
+                        tracing::trace!("Received new future");
                         set.push(task());
                     },
                 }

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -20,6 +20,6 @@ glyph_brush = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 glam = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 parking_lot = { workspace = true }
 wgpu = { workspace = true }

--- a/crates/text/src/lib.rs
+++ b/crates/text/src/lib.rs
@@ -29,7 +29,6 @@ use glyph_brush::{
     ab_glyph::{Font, FontArc, PxScale, Rect},
     BrushAction, BrushError, GlyphBrush, GlyphBrushBuilder, GlyphCruncher, Section,
 };
-use log::info;
 use parking_lot::Mutex;
 
 use crate::text_material::{get_text_shader, TextMaterial};
@@ -185,7 +184,7 @@ impl AsyncAssetKey<Arc<FontArc>> for FontDef {
             FontFamily::Custom(url) => match FontFromUrl(url.clone()).get(&assets).await {
                 Ok(font) => font,
                 Err(err) => {
-                    log::error!("Failed to fetch font at {url}: {err}; using fallback font");
+                    tracing::error!("Failed to fetch font at {url}: {err}; using fallback font");
                     FontDef(FontFamily::Default, self.1).get(&assets).await
                 }
             },
@@ -537,7 +536,7 @@ impl AsyncAssetKey<AssetResult<Arc<FontArc>>> for FontFromUrl {
         self,
         assets: ambient_native_std::asset_cache::AssetCache,
     ) -> AssetResult<Arc<FontArc>> {
-        info!("Downloading font: {}", self.0);
+        tracing::info!("Downloading font: {}", self.0);
         let data = BytesFromUrl::new(self.0, true).get(&assets).await?;
         let brush = FontArc::try_from_vec(data.deref().clone()).context("Failed to parse font")?;
         Ok(Arc::new(brush))

--- a/crates/ui_native/Cargo.toml
+++ b/crates/ui_native/Cargo.toml
@@ -27,7 +27,6 @@ ambient_shared_types = { path = "../../shared_crates/shared_types", features = [
 glam = { workspace = true }
 winit = { workspace = true }
 itertools = { workspace = true }
-log = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true }
 bytemuck = { workspace = true }

--- a/crates/ui_native/examples/bg_failing.rs
+++ b/crates/ui_native/examples/bg_failing.rs
@@ -20,7 +20,7 @@ impl ElementComponent for Example {
         let runtime = hooks.world.resource(runtime()).clone();
         use_memo_with(hooks, (), move |_, _| {
             runtime.spawn(async move {
-                log::info!("Spawning task");
+                tracing::info!("Spawning task");
                 use ambient_native_std::IntoDuration;
                 tokio::time::sleep(5.secs()).await;
                 set_k(5.0)

--- a/crates/ui_native/examples/bg_failing.rs
+++ b/crates/ui_native/examples/bg_failing.rs
@@ -20,7 +20,7 @@ impl ElementComponent for Example {
         let runtime = hooks.world.resource(runtime()).clone();
         use_memo_with(hooks, (), move |_, _| {
             runtime.spawn(async move {
-                tracing::info!("Spawning task");
+                tracing::trace!("Spawning task");
                 use ambient_native_std::IntoDuration;
                 tokio::time::sleep(5.secs()).await;
                 set_k(5.0)

--- a/crates/ui_native/examples/graph.rs
+++ b/crates/ui_native/examples/graph.rs
@@ -47,7 +47,7 @@ impl ElementComponent for Example {
             let mut history = history.clone();
             use_memo_with(hooks, (), move |_, _| {
                 runtime.spawn(async move {
-                    log::info!("Spawning task");
+                    tracing::info!("Spawning task");
                     let mut interval = tokio::time::interval(50.ms());
 
                     let mut upd = tokio::time::interval(250.ms());

--- a/crates/ui_native/examples/graph.rs
+++ b/crates/ui_native/examples/graph.rs
@@ -47,7 +47,7 @@ impl ElementComponent for Example {
             let mut history = history.clone();
             use_memo_with(hooks, (), move |_, _| {
                 runtime.spawn(async move {
-                    tracing::info!("Spawning task");
+                    tracing::debug!("Spawning task");
                     let mut interval = tokio::time::interval(50.ms());
 
                     let mut upd = tokio::time::interval(250.ms());

--- a/crates/ui_native/examples/state.rs
+++ b/crates/ui_native/examples/state.rs
@@ -36,7 +36,7 @@ struct Shared(Arc<String>);
 
 impl Clone for Shared {
     fn clone(&self) -> Self {
-        tracing::info!(
+        tracing::trace!(
             "Cloning {}. Strong: {}",
             &self.0,
             Arc::strong_count(&self.0)
@@ -58,7 +58,7 @@ impl Drop for Shared {
 pub struct DroppedClosure;
 impl Drop for DroppedClosure {
     fn drop(&mut self) {
-        tracing::info!("Dropping closure");
+        tracing::debug!("Dropping closure");
     }
 }
 
@@ -82,7 +82,7 @@ impl ElementComponent for B {
 
 impl Drop for B {
     fn drop(&mut self) {
-        tracing::info!("Dropping B");
+        tracing::debug!("Dropping B");
     }
 }
 

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -22,7 +22,6 @@ ambient_shared_types = { path = "../../shared_crates/shared_types", features = [
     "native",
 ] }
 
-tracing = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 byteorder = { workspace = true }
@@ -31,7 +30,7 @@ data-encoding = { workspace = true }
 flume = { workspace = true }
 glam = { workspace = true }
 itertools = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 paste = { workspace = true }

--- a/crates/wasm/src/server/network.rs
+++ b/crates/wasm/src/server/network.rs
@@ -36,7 +36,7 @@ pub fn initialize(world: &mut World) {
 fn on_datagram(state: SharedServerState, _asset_cache: AssetCache, user_id: &str, bytes: Bytes) {
     let mut state = state.lock();
     let Some(world) = state.get_player_world_mut(user_id) else {
-        log::warn!("Failed to find player world for {user_id} when processing datagram");
+        tracing::warn!("Failed to find player world for {user_id} when processing datagram");
         return;
     };
 
@@ -63,7 +63,7 @@ fn on_unistream(
 ) {
     let mut state = state.lock();
     let Some(world) = state.get_player_world_mut(user_id) else {
-        log::warn!("Failed to find player world for {user_id} when processing unistream");
+        tracing::warn!("Failed to find player world for {user_id} when processing unistream");
         return;
     };
 

--- a/crates/wasm/src/shared/mod.rs
+++ b/crates/wasm/src/shared/mod.rs
@@ -153,7 +153,7 @@ pub fn systems() -> SystemGroup {
                     let url = match AbsAssetUrl::from_str(&url) {
                         Ok(value) => value,
                         Err(err) => {
-                            log::warn!("Failed to parse bytecode_from_url URL: {:?}", err);
+                            tracing::warn!("Failed to parse bytecode_from_url URL: {:?}", err);
                             continue;
                         }
                     };
@@ -165,7 +165,7 @@ pub fn systems() -> SystemGroup {
                         // hot-reloading working.
                         match download_uncached_bytes(&assets, url.clone()).await {
                             Err(err) => {
-                                log::warn!("Failed to load bytecode from URL: {:?}", err);
+                                tracing::warn!("Failed to load bytecode from URL: {:?}", err);
                             }
                             Ok(bytecode) => {
                                 async_run.run(move |world| {
@@ -312,7 +312,7 @@ fn load(world: &mut World, id: EntityId, component_bytecode: &[u8]) {
     // TODO: offload to thread
     let task = async move {
         // let result = run_and_catch_panics(|| {
-        log::info!("Loading module {}", name);
+        tracing::info!("Loading module {}", name);
         let res = module_state_maker(module::ModuleStateArgs {
             component_bytecode: &component_bytecode,
             stdout_output: Box::new({
@@ -329,7 +329,7 @@ fn load(world: &mut World, id: EntityId, component_bytecode: &[u8]) {
             preopened_dir,
         })
         .await;
-        log::info!("Done loading module {}", name);
+        tracing::info!("Done loading module {}", name);
 
         async_run.run(move |world| {
             match res {
@@ -343,10 +343,10 @@ fn load(world: &mut World, id: EntityId, component_bytecode: &[u8]) {
 
                     world.add_component(id, module_state(), sms).unwrap();
 
-                    log::info!("Running startup event for module {name}");
+                    tracing::info!("Running startup event for module {name}");
                     messages::ModuleLoad::new().run(world, Some(id)).unwrap();
 
-                    log::info!("Finished loading module {name}");
+                    tracing::info!("Finished loading module {name}");
                 }
                 Err(err) => update_errors(world, &[(id, format!("{err:?}"))]),
             }

--- a/crates/wasm/src/shared/mod.rs
+++ b/crates/wasm/src/shared/mod.rs
@@ -312,7 +312,7 @@ fn load(world: &mut World, id: EntityId, component_bytecode: &[u8]) {
     // TODO: offload to thread
     let task = async move {
         // let result = run_and_catch_panics(|| {
-        tracing::info!("Loading module {}", name);
+        tracing::info!("Loading module {name}");
         let res = module_state_maker(module::ModuleStateArgs {
             component_bytecode: &component_bytecode,
             stdout_output: Box::new({
@@ -329,7 +329,7 @@ fn load(world: &mut World, id: EntityId, component_bytecode: &[u8]) {
             preopened_dir,
         })
         .await;
-        tracing::info!("Done loading module {}", name);
+        tracing::info!("Finished loading module {name}");
 
         async_run.run(move |world| {
             match res {

--- a/crates/world_audio/Cargo.toml
+++ b/crates/world_audio/Cargo.toml
@@ -22,7 +22,6 @@ ambient_audio = { path = "../audio" , version = "0.3.1-dev" }
 # ambient_network = { path = "../network" , version = "0.2.1" }
 parking_lot = { workspace = true }
 anyhow = { workspace = true }
-log = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/world_audio/src/systems.rs
+++ b/crates/world_audio/src/systems.rs
@@ -88,7 +88,9 @@ pub fn audio_systems() -> SystemGroup {
 
                     let mixer = world.resource(crate::audio_mixer());
                     let Ok(id) = world.get(playing_entity, crate::sound_id()) else {
-                        log::error!("No sound id component on playing entity; cannot stop audio.");
+                        tracing::error!(
+                            "No sound id component on playing entity; cannot stop audio."
+                        );
                         continue;
                     };
                     mixer.stop(id);
@@ -182,7 +184,7 @@ pub fn audio_systems() -> SystemGroup {
                                 .and_then(|c| c.last())
                                 .copied()
                             else {
-                                log::error!(
+                                tracing::error!(
                                     "No children component on parent entity; cannot play audio."
                                 );
                                 return;

--- a/docs/src/runtime_internals/guidelines.md
+++ b/docs/src/runtime_internals/guidelines.md
@@ -30,9 +30,10 @@ When composing text that is shown to the user (including error messages and log 
   - **Example**: `Error while processing single pipeline in "lol.toml": No such file or directory (os error 2)` is preferable to `In pipeline "lol.toml": No such file or directory (os error 2)`.
 - In general, try to optimize for easy copy-ability / clicking. If it's a link, you should be able to click it in your terminal without having to manually select it.
   - **Example**: `` Visit `https://example.com/` for more information. `` is preferable to `Visit https://example.com/ for more information.`, as the former is more likely to be clickable in a terminal.
-- Use logging instead of `println`. This is because many events within Ambient have a time component to them, and the output should convey that to ensure the user is aware of the time that the event occurred.
-  - **Example**: `log::info!("Server running")` is preferable to `println!("Server running")` as the latter does not convey the time that the event occurred.
-
+- Use tracing instead of `println`. This is because many events within Ambient have a time component to them, and the output should convey that to ensure the user is aware of the time that the event occurred.
+  - **Example**: `tracing::info!("Server running")` is preferable to `println!("Server running")` as the latter does not convey the time that the event occurred. 
+  - Prefer `tracing::info!` for user facing events, and `tracing::debug!` or `tracing::trace!` for verbose information as the default log filter is `info`.
+  
 ## Performance
 
 ### Error handling

--- a/recipes.json
+++ b/recipes.json
@@ -14,13 +14,13 @@
     "cmd": "cargo run -p ambient"
   },
   "third-person-camera-release": {
-    "cmd": "cargo run --features profile --release -- run ./guest/rust/examples/controllers/third_person_camera"
+    "cmd": "cargo run --release -- run ./guest/rust/examples/controllers/third_person_camera"
   },
   "third-person-camera": {
-    "cmd": "cargo run --features tracing -- run ./guest/rust/examples/controllers/third_person_camera --debugger"
+    "cmd": "cargo run -- run ./guest/rust/examples/controllers/third_person_camera --debugger"
   },
   "primitives": {
-    "cmd": "cargo run --features hotload-includes -- run ./guest/rust/examples/basics/primitives/"
+    "cmd": "cargo run -- run ./guest/rust/examples/basics/primitives/"
   },
   "gi-samplers": {
     "cmd": "cargo run --release -- run --release guest/rust/examples/basics/samplers --headless --no-proxy --quic-interface-port 9009 --http-interface-port 10009 golden-image-check --timeout-seconds 30.0",
@@ -81,13 +81,13 @@
     }
   },
   "serve-primitives": {
-    "cmd": "cargo run --features tracing -- serve ./guest/rust/examples/basics/primitives/",
+    "cmd": "cargo run -- serve ./guest/rust/examples/basics/primitives/",
     "env": {
       "RUST_LOG": "ambient_network=debug,info"
     }
   },
   "serve-procedural": {
-    "cmd": "cargo run --features tracing -- serve ./guest/rust/examples/basics/procedural_generation/",
+    "cmd": "cargo run -- serve ./guest/rust/examples/basics/procedural_generation/",
     "env": {
       "RUST_LOG": "ambient_network=debug,info"
     }

--- a/recipes.json
+++ b/recipes.json
@@ -17,7 +17,7 @@
     "cmd": "cargo run --release -- run ./guest/rust/examples/controllers/third_person_camera"
   },
   "third-person-camera": {
-    "cmd": "cargo run -- run ./guest/rust/examples/controllers/third_person_camera --debugger"
+    "cmd": "cargo run --features tracing-tree -- run ./guest/rust/examples/controllers/third_person_camera --debugger"
   },
   "primitives": {
     "cmd": "cargo run -- run ./guest/rust/examples/basics/primitives/"

--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
  "async-trait",
  "glam",
  "itertools",
- "log",
  "ordered-float 3.9.1",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -183,7 +183,6 @@ dependencies = [
  "hound",
  "itertools",
  "lewton",
- "log",
  "num",
  "ordered-float 3.9.1",
  "parking_lot",
@@ -299,7 +298,7 @@ dependencies = [
  "ambient_native_std",
  "ambient_renderer",
  "glam",
- "log",
+ "tracing",
 ]
 
 [[package]]
@@ -328,7 +327,6 @@ dependencies = [
  "erased-serde",
  "glam",
  "itertools",
- "log",
  "once_cell",
  "parking_lot",
  "paste",
@@ -441,10 +439,10 @@ dependencies = [
  "bytemuck",
  "dashmap",
  "glam",
- "log",
  "once_cell",
  "profiling",
  "serde",
+ "tracing",
  "wgpu",
 ]
 
@@ -466,7 +464,6 @@ dependencies = [
  "glam",
  "image",
  "itertools",
- "log",
  "ndarray",
  "ordered-float 3.9.1",
  "parking_lot",
@@ -540,8 +537,8 @@ dependencies = [
  "ambient_input",
  "glam",
  "itertools",
- "log",
  "profiling",
+ "tracing",
 ]
 
 [[package]]
@@ -606,7 +603,6 @@ dependencies = [
  "data-encoding",
  "futures",
  "glam",
- "log",
  "mikktspace",
  "ordered-float 3.9.1",
  "percent-encoding",
@@ -660,7 +656,6 @@ dependencies = [
  "http",
  "itertools",
  "js-sys",
- "log",
  "parking_lot",
  "pin-project",
  "profiling",
@@ -788,7 +783,6 @@ dependencies = [
  "futures",
  "glam",
  "itertools",
- "log",
  "ordered-float 3.9.1",
  "parking_lot",
  "physxx",
@@ -883,7 +877,7 @@ dependencies = [
  "async-trait",
  "bytemuck",
  "glam",
- "log",
+ "tracing",
  "wgpu",
 ]
 
@@ -907,7 +901,6 @@ dependencies = [
  "derive_more",
  "glam",
  "itertools",
- "log",
  "ordered-float 3.9.1",
  "parking_lot",
  "profiling",
@@ -1027,8 +1020,8 @@ dependencies = [
  "async-trait",
  "glam",
  "glyph_brush",
- "log",
  "parking_lot",
+ "tracing",
  "wgpu",
 ]
 
@@ -1084,7 +1077,6 @@ dependencies = [
  "bytemuck",
  "glam",
  "itertools",
- "log",
  "parking_lot",
  "tokio",
  "tracing",
@@ -1120,7 +1112,6 @@ dependencies = [
  "futures",
  "glam",
  "itertools",
- "log",
  "once_cell",
  "parking_lot",
  "paste",
@@ -1226,7 +1217,6 @@ dependencies = [
  "flume 0.11.0",
  "glam",
  "itertools",
- "log",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/web/client/src/app.rs
+++ b/web/client/src/app.rs
@@ -46,7 +46,7 @@ pub fn MainApp(_hooks: &mut Hooks, server_url: String, settings: Settings) -> El
             UICamera.el().spawn_static(world);
 
             Ok(Box::new(|| {
-                tracing::info!("Disconnecting client");
+                tracing::debug!("Disconnecting client");
             }))
         }),
         create_rpc_registry: cb(create_server_rpc_registry),

--- a/web/client/src/wasm.rs
+++ b/web/client/src/wasm.rs
@@ -22,7 +22,7 @@ pub fn initialize(world: &mut World) -> anyhow::Result<()> {
                 MessageType::Info => tracing::info!(%module_name, "{}", message),
                 MessageType::Warn => tracing::warn!(%module_name, "{}", message),
                 MessageType::Error => tracing::error!(%module_name, "{}", message),
-                MessageType::Stdout => tracing::info!(%module_name, "stdout {}", message),
+                MessageType::Stdout => tracing::info!(%module_name, "stdout: {}", message),
                 MessageType::Stderr => tracing::info!(%module_name, "stderr: {}", message),
             };
         },


### PR DESCRIPTION
This uses the appropriate log levels for our logging. 

The recommendation is:
`info` is surfaced to, and used as a means to communicate with the users, `debug` is intended for lower priority and implementation oriented messages, and trace is for very verbose and detailed information, most commonly includes debugged structs, or very implementation specific information that is almost entirely useful for internal devs and never users.

Additionally, this means the prefixed log filtering that were a common source of surprising behavior has been almost entirely removed. The only remaining targets are external crates that don't use logging appropriately.

The split usage of log, and its superset replacement *tracing* has been fixed, and tracing is used throughout. Tracing has lot of more useful features, and is especially good at capturing spatially temporal information through the use of spans. 

Tracing also has support for further detailed and structured logging, async, and much more, and is what is the new standard in the wider rust ecosystem.

Fixes: #584 
Fixes: #459 