### PR TITLE
Remove temporary sleep for server startup

### DIFF
--- a/crates/network/src/web/client.rs
+++ b/crates/network/src/web/client.rs
@@ -12,10 +12,7 @@ use ambient_native_std::{
 };
 use ambient_renderer::RenderTarget;
 use ambient_rpc::RpcRegistry;
-use ambient_sys::{
-    task::RuntimeHandle,
-    time::{sleep_label, Instant},
-};
+use ambient_sys::{task::RuntimeHandle, time::Instant};
 use ambient_ui_native::{Centered, Dock, FlowColumn, FlowRow, StylesExt, Text, Throbber};
 use anyhow::Context;
 use bytes::{BufMut, BytesMut};
@@ -111,8 +108,6 @@ impl ElementComponent for GameClientView {
                 if url.path() == "/servers/ensure-running" {
                     url = resolve_hosted_server(&assets, url).await?;
                 }
-
-                sleep_label(Duration::from_millis(1000), "wait for server").await;
 
                 let conn = Connection::connect(&url.as_str()).await.with_context(|| {
                     format!("Failed to establish a WebTransport session for \"{url}\"")


### PR DESCRIPTION
@pierd do we still need this soft server start, or is probing and initialization order working correctly now?