### PR TITLE
Export MaterialsImporter and PipelinePbrMaterial from pipeline_types

### DIFF
--- a/crates/pipeline_types/src/lib.rs
+++ b/crates/pipeline_types/src/lib.rs
@@ -2,7 +2,7 @@ pub mod audio;
 pub mod materials;
 pub mod models;
 pub use audio::AudioPipeline;
-pub use materials::MaterialsPipeline;
+pub use materials::{MaterialsImporter, MaterialsPipeline, PipelinePbrMaterial};
 pub use models::{Collider, ModelImporter, ModelsPipeline};
 use serde::{Deserialize, Serialize};
 use std::path::Path;


### PR DESCRIPTION
I needed to expose these values to use them in a custom build.rs example:

``` rust
use ambient_pipeline_types::{
    MaterialsImporter, MaterialsPipeline, ModelImporter, ModelsPipeline, Pipeline,
    PipelinePbrMaterial, PipelineProcessor, PipelinesFile,
};

fn main() {
    PipelinesFile {
        pipelines: vec![
            Pipeline {
                processor: PipelineProcessor::Models(ModelsPipeline {
                    importer: ModelImporter::Regular,
                    ..Default::default()
                }),
                sources: vec!["ships/*.glb".to_string()],
                tags: vec![],
                categories: vec![],
            },
            Pipeline {
                processor: PipelineProcessor::Models(ModelsPipeline {
                    importer: ModelImporter::Regular,
                    ..Default::default()
                }),
                sources: vec!["maps/*.glb".to_string()],
                tags: vec![],
                categories: vec![],
            },
            Pipeline {
                processor: PipelineProcessor::Materials(MaterialsPipeline {
                    importer: Box::new(MaterialsImporter::Single(PipelinePbrMaterial {
                        name: Some("wreticle".to_string()),
                        base_color: Some("hud/wreticle.png".to_string()),
                        ..Default::default()
                    })),
                    output_decals: false,
                }),
                sources: vec!["hud/wreticle.png".to_string()],
                tags: vec![],
                categories: vec![],
            },
        ],
    }
    .save_to_file("assets/pipeline.toml")
    .unwrap();
}
```