### PR TITLE
Add support for collision contact points and normals

### DIFF
--- a/crates/ecs/src/generated.rs
+++ b/crates/ecs/src/generated.rs
@@ -1058,11 +1058,21 @@ mod raw {
             #[doc = "**Collision**: Sent when a collision occurs."]
             pub struct Collision {
                 pub ids: Vec<EntityId>,
+                pub points: Vec<Vec3>,
+                pub normals: Vec<Vec3>,
             }
             impl Collision {
                 #[allow(clippy::too_many_arguments)]
-                pub fn new(ids: impl Into<Vec<EntityId>>) -> Self {
-                    Self { ids: ids.into() }
+                pub fn new(
+                    ids: impl Into<Vec<EntityId>>,
+                    points: impl Into<Vec<Vec3>>,
+                    normals: impl Into<Vec<Vec3>>,
+                ) -> Self {
+                    Self {
+                        ids: ids.into(),
+                        points: points.into(),
+                        normals: normals.into(),
+                    }
                 }
             }
             impl Message for Collision {
@@ -1072,11 +1082,15 @@ mod raw {
                 fn serialize_message(&self) -> Result<Vec<u8>, MessageSerdeError> {
                     let mut output = vec![];
                     self.ids.serialize_message_part(&mut output)?;
+                    self.points.serialize_message_part(&mut output)?;
+                    self.normals.serialize_message_part(&mut output)?;
                     Ok(output)
                 }
                 fn deserialize_message(mut input: &[u8]) -> Result<Self, MessageSerdeError> {
                     Ok(Self {
                         ids: Vec::<EntityId>::deserialize_message_part(&mut input)?,
+                        points: Vec::<Vec3>::deserialize_message_part(&mut input)?,
+                        normals: Vec::<Vec3>::deserialize_message_part(&mut input)?,
                     })
                 }
             }

--- a/crates/wasm/src/server/mod.rs
+++ b/crates/wasm/src/server/mod.rs
@@ -41,8 +41,8 @@ pub fn systems() -> SystemGroup {
                     Some(collisions) => collisions.lock().clone(),
                     None => return,
                 };
-                for (a, b) in collisions.into_iter() {
-                    messages::Collision::new(vec![a, b])
+                for (a, b, positions, normals) in collisions.into_iter() {
+                    messages::Collision::new(vec![a, b], positions, normals)
                         .run(world, None)
                         .unwrap();
                 }

--- a/guest/rust/api_core/src/internal/generated.rs
+++ b/guest/rust/api_core/src/internal/generated.rs
@@ -4980,11 +4980,21 @@ mod raw {
             #[doc = "**Collision**: Sent when a collision occurs."]
             pub struct Collision {
                 pub ids: Vec<EntityId>,
+                pub points: Vec<Vec3>,
+                pub normals: Vec<Vec3>,
             }
             impl Collision {
                 #[allow(clippy::too_many_arguments)]
-                pub fn new(ids: impl Into<Vec<EntityId>>) -> Self {
-                    Self { ids: ids.into() }
+                pub fn new(
+                    ids: impl Into<Vec<EntityId>>,
+                    points: impl Into<Vec<Vec3>>,
+                    normals: impl Into<Vec<Vec3>>,
+                ) -> Self {
+                    Self {
+                        ids: ids.into(),
+                        points: points.into(),
+                        normals: normals.into(),
+                    }
                 }
             }
             impl Message for Collision {
@@ -4994,11 +5004,15 @@ mod raw {
                 fn serialize_message(&self) -> Result<Vec<u8>, MessageSerdeError> {
                     let mut output = vec![];
                     self.ids.serialize_message_part(&mut output)?;
+                    self.points.serialize_message_part(&mut output)?;
+                    self.normals.serialize_message_part(&mut output)?;
                     Ok(output)
                 }
                 fn deserialize_message(mut input: &[u8]) -> Result<Self, MessageSerdeError> {
                     Ok(Self {
                         ids: Vec::<EntityId>::deserialize_message_part(&mut input)?,
+                        points: Vec::<Vec3>::deserialize_message_part(&mut input)?,
+                        normals: Vec::<Vec3>::deserialize_message_part(&mut input)?,
                     })
                 }
             }

--- a/schema/schema/ambient.toml
+++ b/schema/schema/ambient.toml
@@ -38,7 +38,7 @@ fields = {}
 [messages.Collision]
 name = "Collision"
 description = "Sent when a collision occurs."
-fields = { ids = { container_type = "Vec", element_type = "EntityId" } }
+fields = { ids = { container_type = "Vec", element_type = "EntityId" }, points = { container_type = "Vec", element_type = "Vec3" }, normals = { container_type = "Vec", element_type = "Vec3" }}
 
 [messages.ColliderLoads]
 name = "Collider Loads"


### PR DESCRIPTION
This Pr updates the physics pipeline to expose collision contact points and normals. Still testing this but opening it up for review and discussion.