### PR TITLE
fix cli http_interface_port consistency

### DIFF
--- a/app/src/cli/package/mod.rs
+++ b/app/src/cli/package/mod.rs
@@ -90,7 +90,7 @@ pub struct HostCli {
     #[arg(long)]
     pub public_host: Option<String>,
 
-    /// Defaults to 8889
+    /// Defaults to 8999
     #[arg(long)]
     pub http_interface_port: Option<u16>,
 


### PR DESCRIPTION
Seems this cli help text is incorrect and code actually defaults to `8999` at:

https://github.com/AmbientRun/Ambient/blob/256172a79d203f0669dce6bf5c9a7fab0cbab5d1/app/src/server/mod.rs#L303