### PR TITLE
Add hide component for nameplates

### DIFF
--- a/guest/rust/packages/std/nameplates/ambient.toml
+++ b/guest/rust/packages/std/nameplates/ambient.toml
@@ -18,4 +18,7 @@ text_size = { type = "F32", name = "Nameplate Text Size", description = "The tex
     "Debuggable",
     "Networked",
 ] }
-hide = { type="Empty", name ="Nameplate hide for local player", description = "If true hide the nameplate for the local user", attributes = ["Networked", "Debuggable"]}
+hide = { type = "Empty", name = "Nameplate Hide", description = "If attached to a player, hide the nameplate for that player.", attributes = [
+    "Networked",
+    "Debuggable",
+] }

--- a/guest/rust/packages/std/nameplates/ambient.toml
+++ b/guest/rust/packages/std/nameplates/ambient.toml
@@ -18,3 +18,4 @@ text_size = { type = "F32", name = "Nameplate Text Size", description = "The tex
     "Debuggable",
     "Networked",
 ] }
+hide = { type="Empty", name ="Nameplate hide for local player", description = "If true hide the nameplate for the local user", attributes = ["Networked", "Debuggable"]}

--- a/guest/rust/packages/std/nameplates/src/client.rs
+++ b/guest/rust/packages/std/nameplates/src/client.rs
@@ -1,6 +1,6 @@
 use ambient_api::{
     core::{
-        player::components::{is_player, local_user_id, user_id},
+        player::components::{is_player, user_id},
         rendering::components::{double_sided, local_bounding_aabb_max},
         transform::components::local_to_world,
     },
@@ -19,15 +19,7 @@ pub fn main() {
 fn Nameplates(hooks: &mut Hooks) -> Element {
     let players = use_query(hooks, is_player());
 
-    Group::el(players.into_iter().map(|player| {
-        let should_hide = entity::has_component(player.0, hide());
-        println!("should hide?? {:?} {:?}", player.0, should_hide);
-        if should_hide {
-            Element::new()
-        } else {
-            Nameplate::el(player.0)
-        }
-    }))
+    Group::el(players.into_iter().map(|player| Nameplate::el(player.0)))
 }
 
 // Consider moving this to ambient_api if there's more demand for it
@@ -47,6 +39,10 @@ fn use_active_camera(hooks: &mut Hooks) -> Option<EntityId> {
 
 #[element_component]
 fn Nameplate(hooks: &mut Hooks, player_id: EntityId) -> Element {
+    if use_entity_component(hooks, player_id, hide()).is_some() {
+        return Element::new();
+    }
+
     let Some(camera_id) = use_active_camera(hooks) else {
         return Element::new();
     };

--- a/guest/rust/packages/std/nameplates/src/client.rs
+++ b/guest/rust/packages/std/nameplates/src/client.rs
@@ -1,6 +1,6 @@
 use ambient_api::{
     core::{
-        player::components::{is_player, user_id},
+        player::components::{is_player, local_user_id, user_id},
         rendering::components::{double_sided, local_bounding_aabb_max},
         transform::components::local_to_world,
     },
@@ -8,7 +8,7 @@ use ambient_api::{
     prelude::*,
 };
 
-use packages::this::components::{height_offset, text_size};
+use packages::this::components::{height_offset, hide, text_size};
 
 #[main]
 pub fn main() {
@@ -19,7 +19,15 @@ pub fn main() {
 fn Nameplates(hooks: &mut Hooks) -> Element {
     let players = use_query(hooks, is_player());
 
-    Group::el(players.into_iter().map(|player| Nameplate::el(player.0)))
+    Group::el(players.into_iter().map(|player| {
+        let should_hide = entity::has_component(player.0, hide());
+        println!("should hide?? {:?} {:?}", player.0, should_hide);
+        if should_hide {
+            Element::new()
+        } else {
+            Nameplate::el(player.0)
+        }
+    }))
 }
 
 // Consider moving this to ambient_api if there's more demand for it


### PR DESCRIPTION
This PR attempts to add a parameter to t he `nameplates` package that does not render the name plate for the local player. 

This doesn't currently work. I'm opening PR for discussion: 

In my game code I attempt to use with:
``` rust
    spawn_query((is_player(), user_id())).bind(move |players| {
        for (player_id, (_, uid)) in players {
            // First, we check if this player is the "local" player, and only then do we attach a camera
            if uid == entity::get_component(entity::resources(), local_user_id()).unwrap() {
                // hide the nameplate for local player
                println!("adding hide to {:?}", player_id);
                entity::add_component(player_id, packages::nameplates::components::hide(), ());
                p
                ...
```

However this doesn't work as the `nameplate` package is executed before this `hide` component gets added.

initially discussed at: https://discord.com/channels/894505972289134632/1141326292919263262/1170466566693986324