### PR TITLE
Make it easier to self host Ambient servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "ambient_world_audio",
  "anyhow",
  "axum",
+ "axum-server",
  "clap 4.4.6",
  "colored",
  "convert_case 0.6.0",
@@ -157,6 +158,7 @@ dependencies = [
  "image_hasher",
  "parking_lot",
  "rpassword",
+ "rustls",
  "rustls-pemfile",
  "rusty-hook",
  "sentry",
@@ -1822,6 +1824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +1972,26 @@ dependencies = [
  "mime",
  "rustversion",
  "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447f28c85900215cc1bea282f32d4a2f22d55c5a300afdfbc661c8d6a632e063"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls",
  "tower-service",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ atomic_refcell = "0.1.11"
 flume = { version = "0.11", features = ["async"] }
 im = "15.1.0"
 axum = "0.6.20"
+axum-server = { version = "0.5", features = ["rustls", "tls-rustls"] }
 tower-http = { version = "0.3.5", features = ["cors", "fs"] }
 tower = "0.4.13"
 indexmap = { version = "2.0", features = ["serde"] }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -88,4 +88,6 @@ debug-local-datagram-latency = ["ambient_wasm/debug-local-datagram-latency"]
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 axum = { workspace = true }
+axum-server = { workspace = true }
+rustls = { workspace = true }
 ambient_wasm = { path = "../crates/wasm" , version = "0.3.2-dev" }

--- a/app/src/cli/package/mod.rs
+++ b/app/src/cli/package/mod.rs
@@ -84,6 +84,7 @@ impl PackageArgs {
 pub struct HostCli {
     #[arg(long, default_value = "0.0.0.0")]
     pub bind_address: IpAddr,
+
     /// Provide a public address or IP to the instance, which will allow users to connect to this instance over the internet
     ///
     /// Defaults to localhost
@@ -93,6 +94,12 @@ pub struct HostCli {
     /// Defaults to 8999
     #[arg(long)]
     pub http_interface_port: Option<u16>,
+
+    /// Use HTTPS for http interface (content serving, ping, ...)
+    ///
+    /// Defaults to not using HTTPS
+    #[arg(long, requires("cert"))]
+    pub use_https: bool,
 
     /// Defaults to 9000
     #[arg(long)]

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -367,9 +367,9 @@ fn start_http_interface(
             "/",
             get(move |Host(hostname): Host| async move {
                 let version = ambient_version();
-                let html = if version.is_released_version() {
+                let html = if version.tag().is_some() {
                     INDEX_TEMPLATE
-                        .replace("$VERSION$", &version.to_string())
+                        .replace("$VERSION$", &version.version.to_string())
                         .replace("$ENDPOINT$", &format!("{hostname}:{quic_interface_port}"))
                 } else {
                     "<h1>Unreleased versions do not support the self-hosted web client</h1>"

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -35,7 +35,9 @@ use axum::{
     routing::{get, get_service},
     Router,
 };
+use axum_server::tls_rustls::RustlsConfig;
 use parking_lot::Mutex;
+use rustls::{Certificate, PrivateKey, ServerConfig};
 use tower_http::{cors::CorsLayer, services::ServeDir};
 
 use crate::{cli::package::HostCli, shared};
@@ -115,6 +117,7 @@ pub async fn start(
 
     tracing::info!("Created server, running at {addr}");
     let http_interface_port = host_cli.http_interface_port.unwrap_or(HTTP_INTERFACE_PORT);
+    let use_https = host_cli.use_https.then(|| crypto.clone());
 
     let public_host = match (&host_cli.public_host, addr.ip()) {
         // use public_host if specified in cli
@@ -131,7 +134,8 @@ pub async fn start(
     // here the key is inserted into the asset cache
     let server_state_holder = Arc::new(Mutex::new(None));
     if let Ok(Some(build_path_fs)) = build_root_path.to_file_path() {
-        let key = format!("http://{public_host}:{http_interface_port}/content/");
+        let proto = if host_cli.use_https { "https" } else { "http" };
+        let key = format!("{proto}://{public_host}:{http_interface_port}/content/");
         let base_url = AbsAssetUrl::from_str(&key).unwrap();
         ServerBaseUrlKey.insert(&assets, base_url.clone());
         ContentBaseUrlKey.insert(&assets, base_url);
@@ -140,6 +144,7 @@ pub async fn start(
             Some(&build_path_fs),
             http_interface_port,
             server_state_holder.clone(),
+            use_https,
         );
     } else {
         let base_url = build_root_path.clone();
@@ -147,7 +152,12 @@ pub async fn start(
         ServerBaseUrlKey.insert(&assets, base_url.clone());
         ContentBaseUrlKey.insert(&assets, base_url);
 
-        start_http_interface(None, http_interface_port, server_state_holder.clone());
+        start_http_interface(
+            None,
+            http_interface_port,
+            server_state_holder.clone(),
+            use_https,
+        );
     }
 
     let join_handle = tokio::task::spawn(async move {
@@ -306,6 +316,7 @@ fn start_http_interface(
     build_path: Option<&Path>,
     http_interface_port: u16,
     server_state_holder: Arc<Mutex<Option<SharedServerState>>>,
+    use_https: Option<Crypto>,
 ) {
     let mut router = Router::new()
         .route("/ping", get(|| async move { "ok" }))
@@ -341,9 +352,16 @@ fn start_http_interface(
     );
 
     let serve = |addr| async move {
-        axum::Server::try_bind(&addr)?
-            .serve(router.into_make_service())
-            .await?;
+        if let Some(tls_config) = use_https.map(make_http_tls_config) {
+            let tls_config = tls_config?;
+            axum_server::bind_rustls(addr, tls_config)
+                .serve(router.into_make_service())
+                .await?;
+        } else {
+            axum::Server::try_bind(&addr)?
+                .serve(router.into_make_service())
+                .await?;
+        }
 
         Ok::<_, anyhow::Error>(())
     };
@@ -366,4 +384,17 @@ fn start_http_interface(
 
 async fn handle_error(_err: std::io::Error) -> impl IntoResponse {
     (StatusCode::INTERNAL_SERVER_ERROR, "Something went wrong...")
+}
+
+fn make_http_tls_config(Crypto { cert_chain, key }: Crypto) -> anyhow::Result<RustlsConfig> {
+    let certs: Vec<_> = cert_chain.into_iter().map(Certificate).collect();
+    let cert_key = PrivateKey(key);
+
+    let mut server_conf = ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_single_cert(certs, cert_key)
+        .map_err(anyhow::Error::from)?;
+    server_conf.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec(), b"http/1.0".to_vec()];
+    Ok(RustlsConfig::from_config(Arc::new(server_conf)))
 }

--- a/crates/native_std/src/lib.rs
+++ b/crates/native_std/src/lib.rs
@@ -149,13 +149,15 @@ pub struct AmbientVersion {
 }
 
 impl AmbientVersion {
-    /// Returns git tag for this version, if any. Currently only available for releases and nightly builds.
+    /// Returns git tag for this version, if any. Currently only available for releases, nightly and internal builds.
     pub fn tag(&self) -> Option<String> {
         if !self.version.build.is_empty() {
             return None;
         }
-        (self.version.pre.is_empty() || self.version.pre.starts_with("nightly-"))
-            .then(|| format!("v{}", self.version))
+        (self.version.pre.is_empty()
+            || self.version.pre.starts_with("nightly-")
+            || self.version.pre.starts_with("internal-"))
+        .then(|| format!("v{}", self.version))
     }
 
     /// True if this is a full released version (that is there's a tag, uploaded build and api is released to crates.io).


### PR DESCRIPTION
- `--use-https` options to serve http content with TLS so that it conforms to Secure context restrictions (https://github.com/AmbientRun/Ambient/issues/1143)
- simple embedded web client page hosting when running a released version (https://github.com/AmbientRun/Ambient/issues/1133)