### PR TITLE
Fix package deployment failure

### DIFF
--- a/campfire/src/util.rs
+++ b/campfire/src/util.rs
@@ -10,9 +10,18 @@ pub fn run_ambient(args: &[&str], release: bool, production: bool) -> anyhow::Re
     if production {
         command.args(["--features", "production"]);
     }
-    command.args(["-p", "ambient"]).args(args).spawn()?.wait()?;
 
-    Ok(())
+    if command
+        .args(["-p", "ambient"])
+        .args(args)
+        .spawn()?
+        .wait()?
+        .success()
+    {
+        Ok(())
+    } else {
+        anyhow::bail!("Failed to run Ambient with args {:?}", args);
+    }
 }
 
 pub fn all_directories_in(path: &Path) -> anyhow::Result<impl Iterator<Item = DirEntry>> {

--- a/guest/rust/examples/assets/unity/download.sh
+++ b/guest/rust/examples/assets/unity/download.sh
@@ -3,40 +3,44 @@ if [ -z "${EXAMPLES_ASSETS_HOST}" ]; then
     exit 1
 fi
 
+# Strip off the trailing slash if it exists to ensure the URLs are well-formed
+EXAMPLES_ASSETS_HOST=${EXAMPLES_ASSETS_HOST%/}
+
 export BASE="${EXAMPLES_ASSETS_HOST}/unity/Dynamic%20Nature%20-%20Mountain%20Tree%20Pack"
 for value in \
-    /Prefabs/Standard/Fir_01_Plant.prefab \
-    /Models/Fir_01_Plant.FBX \
-    /Models/Fir_01_Plant.FBX.meta \
-    /Models/Fir_01_Plant_cross.asset \
-    /Models/Fir_01_Plant_cross.asset.meta \
-    /Models/Fir_01_Plant_cross_s.asset \
-    /Models/Fir_01_Plant_cross_s.asset.meta \
-    /Models/Materials/M_Fir_01_Cross.mat \
-    /Models/Materials/M_Fir_01_Cross.mat.meta \
-    /Models/Materials/M_Fir_Bark_01.mat \
-    /Models/Materials/M_Fir_Bark_01.mat.meta \
-    /Models/Materials/M_Fir_Bark_01_06.mat \
-    /Models/Materials/M_Fir_Bark_01_06.mat.meta \
-    /Models/Materials/M_Fir_Leaves.mat \
-    /Models/Materials/M_Fir_Leaves.mat.meta \
-    /Models/Textures/T_Fir_01_Atlas.png \
-    /Models/Textures/T_Fir_01_Atlas.png.meta \
-    /Models/Textures/T_Fir_01_Atlas_T.png \
-    /Models/Textures/T_Fir_01_Atlas_T.png.meta \
-    /Models/Textures/T_Fir_01_Atlas_n.png \
-    /Models/Textures/T_Fir_01_Atlas_n.png.meta \
-    /Models/Textures/T_Fir_bark_01_BC.tga \
-    /Models/Textures/T_Fir_bark_01_BC.tga.meta \
-    /Models/Textures/T_Fir_bark_01_MT_AO_G.tga \
-    /Models/Textures/T_Fir_bark_01_MT_AO_G.tga.meta \
-    /Models/Textures/T_Fir_leaves_BC_T.TGA \
-    /Models/Textures/T_Fir_leaves_BC_T.TGA.meta \
-    /Models/Textures/T_Fir_leaves_MT_AO_G.tga \
-    /Models/Textures/T_Fir_leaves_MT_AO_G.tga.meta \
-    /Models/Textures/T_Fir_leaves_N.TGA \
-    /Models/Textures/T_Fir_leaves_N.TGA.meta 
+    Prefabs/Standard/Fir_01_Plant.prefab \
+    Models/Fir_01_Plant.FBX \
+    Models/Fir_01_Plant.FBX.meta \
+    Models/Fir_01_Plant_cross.asset \
+    Models/Fir_01_Plant_cross.asset.meta \
+    Models/Fir_01_Plant_cross_s.asset \
+    Models/Fir_01_Plant_cross_s.asset.meta \
+    Models/Materials/M_Fir_01_Cross.mat \
+    Models/Materials/M_Fir_01_Cross.mat.meta \
+    Models/Materials/M_Fir_Bark_01.mat \
+    Models/Materials/M_Fir_Bark_01.mat.meta \
+    Models/Materials/M_Fir_Bark_01_06.mat \
+    Models/Materials/M_Fir_Bark_01_06.mat.meta \
+    Models/Materials/M_Fir_Leaves.mat \
+    Models/Materials/M_Fir_Leaves.mat.meta \
+    Models/Textures/T_Fir_01_Atlas.png \
+    Models/Textures/T_Fir_01_Atlas.png.meta \
+    Models/Textures/T_Fir_01_Atlas_T.png \
+    Models/Textures/T_Fir_01_Atlas_T.png.meta \
+    Models/Textures/T_Fir_01_Atlas_n.png \
+    Models/Textures/T_Fir_01_Atlas_n.png.meta \
+    Models/Textures/T_Fir_bark_01_BC.tga \
+    Models/Textures/T_Fir_bark_01_BC.tga.meta \
+    Models/Textures/T_Fir_bark_01_MT_AO_G.tga \
+    Models/Textures/T_Fir_bark_01_MT_AO_G.tga.meta \
+    Models/Textures/T_Fir_leaves_BC_T.TGA \
+    Models/Textures/T_Fir_leaves_BC_T.TGA.meta \
+    Models/Textures/T_Fir_leaves_MT_AO_G.tga \
+    Models/Textures/T_Fir_leaves_MT_AO_G.tga.meta \
+    Models/Textures/T_Fir_leaves_N.TGA \
+    Models/Textures/T_Fir_leaves_N.TGA.meta
 do
    echo Downloading ${value}
    curl ${BASE}/${value} --create-dirs -o assets/TreePack/${value}
 done
+


### PR DESCRIPTION
Since the ~11th, package nightlies have not been deployed, and nobody was aware of them. This is a combination of two issues:

1) Failures in Campfire-spawned Ambient commands did not cause Campfire to exit with a non-zero status code, resulting in a silent failure
2) Our download script for the Unity assets was constructing URLs with double slashes (i.e. `BASE//path` instead of `BASE/path`), resulting in invalid assets being downloaded. My guess is that DO stopped accepting double-slashed URLs?

This PR fixes both of these issues, and should hopefully allow for package deployment to go out as per normal.