### PR TITLE
fix(ci): remove deploy-packages empty commits

### DIFF
--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -48,20 +48,6 @@ jobs:
       - name: Deploy all packages
         run: cargo campfire-slim package deploy-all --token ${{ secrets.AMBIENT_CLOUD_DEPLOY_TOKEN }} --include-examples
 
-      - name: Commit and push changed files (for branches)
-        # only commit and push if this is running in a branch
-        if: startsWith(github.ref, 'refs/heads/')
-        run: |
-          base_branch=${GITHUB_REF#refs/heads/}
-          branch=${base_branch}-deployed-${{ github.sha }}
-          git config --global user.name "${{ env.BOT_NAME }}"
-          git config --global user.email "${{ env.BOT_EMAIL }}"
-          git checkout -b ${branch}
-          git commit -a -m "Update deployed packages for ${{ github.sha }}"
-          git push --set-upstream origin ${branch}
-          pr_url=$(gh pr create --title "Update deployed packages for ${{ github.sha }}" --body "Deployed packages for ${{ github.sha }}" --base ${base_branch} --head ${branch})
-          gh pr merge --auto --squash --delete-branch ${pr_url}
-
       - name: Commit and push changed files (for nightly builds)
         # only commit and push if this is running in a nightly build tag
         if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-nightly-')
@@ -72,7 +58,6 @@ jobs:
           git config --global user.name "${{ env.BOT_NAME }}"
           git config --global user.email "${{ env.BOT_EMAIL }}"
           git checkout -b ${branch}
-          git commit -a -m "Update deployed packages for ${{ github.sha }}"
 
           # switch back to the main branch version
           version_majminpat=$(echo ${tag} | sed -E -e 's/^v([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
@@ -83,5 +68,5 @@ jobs:
           git commit -a -m "Revert version back to ${version}"
 
           git push --set-upstream origin ${branch}
-          pr_url=$(gh pr create --title "Update deployed packages for ${{ github.sha }}" --body "Deployed packages for ${{ github.sha }}" --base ${base_branch} --head ${branch})
+          pr_url=$(gh pr create --title "Update version for ${{ github.sha }}" --body "Deployed packages for ${{ github.sha }} and updated version" --base ${base_branch} --head ${branch})
           gh pr merge --auto --squash --delete-branch ${pr_url}


### PR DESCRIPTION
Before #1225, nightly builds would create a PR that consisted of three commits:

- Update the version of Ambient to the desired version
- Deploy all packages, making a commit with the new deployment IDs
- Revert the version back to `-dev`, except for the deployed packages

However, after that PR, deployment IDs are no longer used; instead, package versions are used, which are set by the first commit (`update-version`). This means that the second commit was empty, causing failures.

To fix this, I've removed the second commit (as it's implied by the first commit), as well as the corresponding step for tagged builds (actually not sure about this one, following up with Kuba)