### PR TITLE
feat(build): bring back OptiVorbis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "once_cell",
  "version_check",
 ]
@@ -79,6 +79,12 @@ checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "allocator-api2"
@@ -194,7 +200,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "ordered-float 3.9.1",
  "serde",
  "tracing",
@@ -212,7 +218,7 @@ dependencies = [
  "data-encoding",
  "futures",
  "glam 0.24.2",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "once_cell",
  "paste",
  "rand 0.8.5",
@@ -302,7 +308,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -327,7 +333,7 @@ dependencies = [
  "flume 0.11.0",
  "glam 0.24.2",
  "hound",
- "itertools",
+ "itertools 0.10.5",
  "lewton",
  "lyon",
  "macroquad",
@@ -381,8 +387,9 @@ dependencies = [
  "glam 0.24.2",
  "glob",
  "image",
- "indexmap 2.0.2",
- "itertools",
+ "indexmap 2.1.0",
+ "itertools 0.10.5",
+ "optivorbis",
  "parking_lot",
  "rand 0.8.5",
  "relative-path",
@@ -471,7 +478,7 @@ dependencies = [
  "chrono",
  "flume 0.11.0",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "ordered-float 3.9.1",
  "profiling",
  "serde",
@@ -575,7 +582,7 @@ dependencies = [
  "data-encoding",
  "erased-serde",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "once_cell",
  "parking_lot",
  "paste",
@@ -603,7 +610,7 @@ dependencies = [
  "ambient_ui_native",
  "env_logger 0.10.0",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "tokio",
 ]
 
@@ -640,7 +647,7 @@ dependencies = [
  "futures-signals",
  "glam 0.24.2",
  "image",
- "itertools",
+ "itertools 0.10.5",
  "ordered-float 3.9.1",
  "parking_lot",
  "physxx",
@@ -678,7 +685,7 @@ dependencies = [
  "atomic_refcell",
  "derivative",
  "dyn-clonable",
- "itertools",
+ "itertools 0.10.5",
  "parking_lot",
  "profiling",
  "tokio",
@@ -689,7 +696,7 @@ dependencies = [
 name = "ambient_element_component"
 version = "0.3.2-dev"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -764,7 +771,7 @@ dependencies = [
  "futures",
  "glam 0.24.2",
  "image",
- "itertools",
+ "itertools 0.10.5",
  "ndarray",
  "ordered-float 3.9.1",
  "parking_lot",
@@ -788,7 +795,7 @@ dependencies = [
  "bytemuck",
  "derive_more",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "parking_lot",
  "paste",
@@ -845,7 +852,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "futures",
- "itertools",
+ "itertools 0.10.5",
  "parking_lot",
  "pretty_assertions",
  "tokio",
@@ -862,7 +869,7 @@ dependencies = [
  "ambient_gpu_ecs",
  "ambient_input",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "profiling",
  "tracing",
 ]
@@ -902,7 +909,7 @@ dependencies = [
  "bytemuck",
  "futures",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "serde",
  "tokio",
  "tracing",
@@ -940,8 +947,8 @@ dependencies = [
  "glam 0.24.2",
  "gltf",
  "image",
- "indexmap 2.0.2",
- "itertools",
+ "indexmap 2.1.0",
+ "itertools 0.10.5",
  "ordered-float 3.9.1",
  "physxx",
  "relative-path",
@@ -1010,7 +1017,7 @@ dependencies = [
  "async-trait",
  "bytemuck",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1050,7 +1057,7 @@ dependencies = [
  "h3-quinn",
  "h3-webtransport",
  "http",
- "itertools",
+ "itertools 0.10.5",
  "js-sys",
  "parking_lot",
  "pin-project",
@@ -1082,7 +1089,7 @@ dependencies = [
  "chrono",
  "convert_case 0.6.0",
  "data-encoding",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "once_cell",
  "paste",
  "proc-macro2",
@@ -1116,7 +1123,7 @@ name = "ambient_package_json"
 version = "0.3.2-dev"
 dependencies = [
  "ambient_primitive_component_definitions",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "pathdiff",
  "serde",
 ]
@@ -1162,7 +1169,7 @@ dependencies = [
  "async-recursion",
  "data-encoding",
  "glam 0.24.2",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "paste",
  "reqwest",
  "semver 1.0.19",
@@ -1211,7 +1218,7 @@ dependencies = [
  "async-trait",
  "futures",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "ordered-float 3.9.1",
  "parking_lot",
  "physxx",
@@ -1351,7 +1358,7 @@ dependencies = [
  "derive_more",
  "env_logger 0.10.0",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "ordered-float 3.9.1",
  "parking_lot",
  "profiling",
@@ -1380,7 +1387,7 @@ version = "0.3.2-dev"
 dependencies = [
  "anyhow",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "serde_json",
 ]
 
@@ -1442,7 +1449,7 @@ dependencies = [
 name = "ambient_std"
 version = "0.3.2-dev"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "thiserror",
 ]
 
@@ -1499,7 +1506,7 @@ dependencies = [
  "closure",
  "futures",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "ndarray",
  "physxx",
  "profiling",
@@ -1534,7 +1541,7 @@ dependencies = [
 name = "ambient_time"
 version = "0.3.2-dev"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "thiserror",
 ]
 
@@ -1553,8 +1560,8 @@ dependencies = [
  "convert_case 0.6.0",
  "futures",
  "glam 0.24.2",
- "indexmap 2.0.2",
- "itertools",
+ "indexmap 2.1.0",
+ "itertools 0.10.5",
  "parking_lot",
  "rand 0.8.5",
  "serde",
@@ -1585,7 +1592,7 @@ dependencies = [
  "env_logger 0.10.0",
  "fixed-vec-deque",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "parking_lot",
  "rand 0.8.5",
  "tokio",
@@ -1601,7 +1608,7 @@ dependencies = [
  "ambient_native_std",
  "anyhow",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "tracing",
  "yaml-rust-davvid",
 ]
@@ -1634,7 +1641,7 @@ dependencies = [
  "flume 0.11.0",
  "futures",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "once_cell",
  "parking_lot",
  "paste",
@@ -1693,7 +1700,7 @@ dependencies = [
  "derive_more",
  "flume 0.11.0",
  "glam 0.24.2",
- "itertools",
+ "itertools 0.10.5",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -1811,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "aotuv_lancer_vorbis_sys"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fccf12dee70dbae164314a8218b53744422ee37c43d2df98f402001a94556d62"
+checksum = "495ea2c3cc8dc08e9fb6ff470c9c90e44d4fbc648882a0bfaba13216daea4c3c"
 dependencies = [
  "cc",
  "ogg_next_sys",
@@ -2286,7 +2293,7 @@ dependencies = [
  "guppy",
  "home",
  "indicatif",
- "itertools",
+ "itertools 0.10.5",
  "nix 0.26.4",
  "notify",
  "num_cpus",
@@ -2952,7 +2959,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity 0.101.0 (git+https://github.com/bytecodealliance/wasmtime?rev=9f00198611537c7a9b384c9f9e3db85e0ca15123)",
  "cranelift-frontend",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "smallvec",
  "wasmparser 0.112.0",
@@ -3372,23 +3379,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3816,9 +3812,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3844,7 +3840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "stable_deref_trait",
 ]
 
@@ -4069,7 +4065,7 @@ dependencies = [
  "fixedbitset",
  "guppy-workspace-hack",
  "indexmap 1.9.3",
- "itertools",
+ "itertools 0.10.5",
  "nested",
  "once_cell",
  "pathdiff",
@@ -4518,9 +4514,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
@@ -4633,6 +4629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4684,7 +4689,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.4",
  "heck",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "wasm-encoder 0.33.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime-environ 14.0.0 (git+https://github.com/bytecodealliance/wasmtime)",
  "wit-bindgen-core 0.12.0",
@@ -4763,15 +4768,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
 dependencies = [
  "byteorder",
- "ogg",
+ "ogg 0.8.0",
  "tinyvec",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libflate"
@@ -5281,7 +5286,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -5735,7 +5740,7 @@ checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.1",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "memchr",
 ]
 
@@ -5772,10 +5777,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "ogg_next_sys"
-version = "0.1.2"
+name = "ogg"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fd1787d091b80a730629dc4234f93584c436b174560b5c95d8556551f15c9c"
+checksum = "5477016638150530ba21dec7caac835b29ef69b20865751d2973fce6be386cf1"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "ogg_next_sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4af25868786f6ab24956a8496a1eca4b010f860b449596f523d19ee9f956ae"
 dependencies = [
  "cc",
 ]
@@ -5850,6 +5864,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "optivorbis"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055727959561866acbe505db55b8919e1e6b347951a39bd1b4dc051208a0360e"
+dependencies = [
+ "bumpalo",
+ "getrandom 0.2.11",
+ "indexmap 2.1.0",
+ "log",
+ "ogg 0.9.1",
+ "ouroboros",
+ "rand_xoshiro",
+ "slice-group-by",
+ "thiserror",
+ "tinyvec",
+ "vorbis_bitpack",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5887,6 +5920,31 @@ dependencies = [
  "log",
  "serde",
  "winapi",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab3e3891cfef81d47b93c6e0aeaf4828b2dc19c0bde389f4a988fbbfe5a8f4b"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd5c45035b07108752f091edb8fcc13dcaffcdb8d9f40cc017e3c9afc1a5bd"
+dependencies = [
+ "heck",
+ "itertools 0.11.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6031,7 +6089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -6210,6 +6268,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6265,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6464,7 +6546,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "serde",
 ]
 
@@ -6493,6 +6575,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6566,7 +6657,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
@@ -7231,7 +7322,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -7851,18 +7942,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8074,7 +8165,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8096,7 +8187,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8550,7 +8641,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "serde",
 ]
 
@@ -8579,13 +8670,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "vorbis_rs"
-version = "0.3.0"
+name = "vorbis_bitpack"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7294961c8fb25a627f40bb9948d9a79fcc66fd16259a5870aec57288ee468b9f"
+checksum = "91304fb1fb7f14c888496d859d627db36efdb63cdd6755e286e3dd637cc28997"
+
+[[package]]
+name = "vorbis_rs"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513beb7a94438399e404b297592dad39e99dd5e39515ab66dfe9caa6fd18897a"
 dependencies = [
  "aotuv_lancer_vorbis_sys",
  "errno",
+ "getrandom 0.2.11",
  "ogg_next_sys",
  "thiserror",
  "tinyvec",
@@ -8773,7 +8871,7 @@ source = "git+https://github.com/AmbientRun/wasm-bridge?branch=wasmtime-git#5741
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "js-component-bindgen",
  "js-sys",
  "rand_core 0.6.4",
@@ -8864,7 +8962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51db59397fc650b5f2fc778e4a5c4456cd856bed7fc1ec15f8d3e28229dc463"
 dependencies = [
  "anyhow",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_json",
  "spdx",
@@ -8879,7 +8977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577508d8a45bc54ad97efe77c95ba57bb10e7e5c5bac9c31295ce88b8045cd7d"
 dependencies = [
  "anyhow",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_json",
  "spdx",
@@ -8903,7 +9001,7 @@ version = "0.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c956109dcb41436a39391139d9b6e2d0a5e0b158e1293ef352ec977e5e36c5"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "semver 1.0.19",
 ]
 
@@ -8913,7 +9011,7 @@ version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e986b010f47fcce49cf8ea5d5f9e5d2737832f12b53ae8ae785bbe895d0877bf"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "semver 1.0.19",
 ]
 
@@ -8923,7 +9021,7 @@ version = "0.113.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0d44fab0bd78404e352f3399324eef76516a4580b52bc9031c60f064e98f3"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "semver 1.0.19",
 ]
 
@@ -8949,7 +9047,7 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "fxprof-processed-profile",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "libc",
  "log",
  "object",
@@ -9059,7 +9157,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity 0.101.0 (git+https://github.com/bytecodealliance/wasmtime?rev=9f00198611537c7a9b384c9f9e3db85e0ca15123)",
  "gimli",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "log",
  "object",
  "serde",
@@ -9081,7 +9179,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity 0.101.0 (git+https://github.com/bytecodealliance/wasmtime)",
  "gimli",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "log",
  "object",
  "serde",
@@ -9160,7 +9258,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "encoding_rs",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "libc",
  "log",
  "mach",
@@ -9271,7 +9369,7 @@ checksum = "14770d0820f56ba86cdd9987aef97cc3bacbb0394633c37dbfbc61ef29603a71"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "wit-parser 0.9.2",
 ]
 
@@ -9282,7 +9380,7 @@ source = "git+https://github.com/bytecodealliance/wasmtime?rev=9f00198611537c7a9
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "wit-parser 0.11.3",
 ]
 
@@ -9839,6 +9937,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9869,6 +9976,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9879,6 +10001,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9905,6 +10033,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9927,6 +10061,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9953,6 +10093,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9977,6 +10123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9987,6 +10139,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10011,6 +10169,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winit"
@@ -10171,7 +10335,7 @@ checksum = "253bd426c532f1cae8c633c517c63719920535f3a7fada3589de40c5b734e393"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "log",
  "wasm-encoder 0.30.0",
  "wasm-metadata 0.9.0",
@@ -10187,7 +10351,7 @@ checksum = "ee23614740bf871dac9856e3062c7a308506eb3f0a2759939ab8d0aa8436a1c0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "log",
  "serde",
  "serde_json",
@@ -10222,7 +10386,7 @@ checksum = "541efa2046e544de53a9da1e2f6299e63079840360c9e106f1f8275a97771318"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "log",
  "pulldown-cmark 0.9.3",
  "semver 1.0.19",
@@ -10238,7 +10402,7 @@ checksum = "a39edca9abb16309def3843af73b58d47d243fe33a9ceee572446bcc57556b9a"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "log",
  "pulldown-cmark 0.9.3",
  "semver 1.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,8 @@ symphonia = { version = "0.5", default-features = false, features = [
     "pcm",
     "wav",
 ] }
-vorbis_rs = "0.3.0"
+vorbis_rs = "0.5.4"
+optivorbis = "0.2.0"
 colored = "2.0.4"
 directories = "5.0.1"
 ulid = { version = "1.1.0", features = ["serde"] }

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -56,6 +56,7 @@ async-trait = { workspace = true }
 dyn-clonable = { workspace = true }
 symphonia = { workspace = true }
 vorbis_rs = { workspace = true }
+optivorbis = { workspace = true }
 rand = { workspace = true }
 chrono = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/build/src/pipelines/audio/mod.rs
+++ b/crates/build/src/pipelines/audio/mod.rs
@@ -179,7 +179,7 @@ async fn symphonia_convert(ext: &str, input: Vec<u8>) -> anyhow::Result<Vec<u8>>
         channels,
         Vec::new(),
         0, /* OptiVorbis will randomize this serial */
-    )?
+    )
     .bitrate_management_strategy(bitrate)
     .build()?;
 

--- a/crates/build/src/pipelines/audio/mod.rs
+++ b/crates/build/src/pipelines/audio/mod.rs
@@ -232,5 +232,5 @@ async fn symphonia_convert(ext: &str, input: Vec<u8>) -> anyhow::Result<Vec<u8>>
         optimized_output.len()
     );
 
-    Ok(output)
+    Ok(optimized_output)
 }

--- a/crates/build/src/pipelines/audio/mod.rs
+++ b/crates/build/src/pipelines/audio/mod.rs
@@ -5,7 +5,6 @@ use anyhow::Context;
 use optivorbis::Remuxer;
 use std::io::Cursor;
 use tracing::{info_span, Instrument};
-use vorbis_rs::VorbisEncoderBuilder;
 
 use super::{
     context::PipelineCtx,
@@ -114,7 +113,7 @@ async fn symphonia_convert(ext: &str, input: Vec<u8>) -> anyhow::Result<Vec<u8>>
         probe::Hint,
     };
 
-    use vorbis_rs::{VorbisBitrateManagementStrategy, VorbisEncoder};
+    use vorbis_rs::{VorbisBitrateManagementStrategy, VorbisEncoderBuilder};
 
     // this symphonia decoding code is largely based on symphonia's examples:
     // https://github.com/pdeljanov/Symphonia/blob/master/symphonia/examples


### PR DESCRIPTION
Even though OptiVorbis was deemed appropriate for the sound build pipeline of Ambient in #619, its inclusion was later reverted in #751 due to a significant impact in compile times for a transitive dependency.

The good news is that, at long last, a new version of OptiVorbis is here, with refactored internals that got rid of the troublesome dependencies! Several other changes have also been made, which can be read [here](https://github.com/OptiVorbis/OptiVorbis/blob/master/CHANGELOG.md#020---2023-12-11).

While at it, I've also updated the dependency on `vorbis_rs`. This new version of `vorbis_rs` brings a new builder for instantiating encoders as I initially discussed with @marceline-cramer in https://github.com/ComunidadAylas/vorbis-rs/pull/9, and other minor fixes and QoL changes you can read about [in the changelog](https://github.com/ComunidadAylas/vorbis-rs/blob/master/CHANGELOG.md) if interested.